### PR TITLE
Bump the LLVM version

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: write
@@ -11,15 +12,15 @@ permissions:
 
 jobs:
   format:
+    name: Lint Codebase
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Check code formatting
-        run: cargo fmt --all --check
+      - name: Check Formatting
+        run: make format
 
   unused_deps:
-    name: check for unused dependencies
+    name: Check for Unused Dependencies
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,15 +28,18 @@ jobs:
         uses: bnjbvr/cargo-machete@main
 
   test:
+    name: Run Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: cachix/install-nix-action@v27
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
         with:
-          nix_path: nixpkgs=channel:nixos-24.05
+          nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
 
@@ -49,10 +53,10 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Build test-runner
-        run: nix develop --command cargo build --release --bin test-runner
+        run: make build-test-runner
 
       - name: Run tests
-        run: nix develop --command cargo run --release --bin test-runner -- --output STATUS.md
+        run: make func-test
 
       - name: Commit STATUS.md
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,23 +1849,22 @@ dependencies = [
 
 [[package]]
 name = "inkwell"
-version = "0.5.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fb405537710d51f6bdbc8471365ddd4cd6d3a3c3ad6e0c8291691031ba94b2"
+checksum = "7decbc9dfa45a4a827a6ff7b822c113b1285678a937e84213417d4ca8a095782"
 dependencies = [
- "either",
+ "bitflags 2.11.0",
  "inkwell_internals",
  "libc",
  "llvm-sys",
- "once_cell",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "inkwell_internals"
-version = "0.10.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd28cfd4cfba665d47d31c08a6ba637eed16770abca2eccbbc3ca831fef1e44"
+checksum = "6cfe97ee860815a90ed17e09639513269e39420a7440f3f4c996f238c514cf8d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2102,9 +2101,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llvm-sys"
-version = "180.0.0"
+version = "221.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778fa5fa02e32728e718f11eec147e6f134137399ab02fd2c13d32476337affa"
+checksum = "2abcc34a3b190f03c2a61b555f218f529589ff13657bdd2ff8ac3e85f2abe6bb"
 dependencies = [
  "anyhow",
  "cc",
@@ -2596,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "pathfinder_simd"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
+checksum = "4500030c302e4af1d423f36f3b958d1aecb6c04184356ed5a833bf6b60435777"
 dependencies = [
  "rustc_version",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ ark-bn254 = { version = "0.5.0" }
 ark-ff = { version = "0.5.0" }
 bincode = "1.3"
 
-inkwell = { version = "0.5", features = ["llvm18-0"] }
+inkwell = { version = "0.9.0", features = ["llvm22-1"] }
 plotters = { version = "0.3.5" }
 wasmtime = { version = "31" }
 
@@ -55,3 +55,5 @@ path = "src/bin/test_runner.rs"
 
 [profile.release]
 debug = true
+opt-level = "z"
+lto = true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,72 @@
+.DEFAULT_GOAL := help
+
+# This is set if inside the devshell, so any command that MUST run in the devshell should have
+# $(SHELL_WRAPPER) prefixed.
+ifeq ($(IN_NIX_SHELL),)
+		SHELL_WRAPPER := nix develop --command
+else
+		SHELL_WRAPPER :=
+endif
+
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+# -- Building -------------------------------------------------------------------------------------
+
+.PHONY: build
+build: ## Build Mavros for testing
+	$(SHELL_WRAPPER) cargo build --all-features
+
+.PHONY: build-test-runner
+build-test-runner: ## Builds the test runner in release mode
+	$(SHELL_WRAPPER) cargo build --release --bin test-runner
+
+.PHONY: release
+release: ## Build Mavros in release mode
+	$(SHELL_WRAPPER) cargo build --release --all-features
+
+# -- Testing --------------------------------------------------------------------------------------
+
+.PHONY: unit-test
+unit-test: ## Run the unit tests
+	$(SHELL_WRAPPER) cargo test --all-targets --all-features
+
+.PHONY: func-test
+func-test: ## Run the functional test harness
+	$(SHELL_WRAPPER) cargo run --release --bin test-runner -- --output STATUS.md
+
+.PHONY: test
+test: unit-test func-test ## Run all the tests
+
+# -- Linting --------------------------------------------------------------------------------------
+
+.PHONY: clippy
+clippy: ## Lint the codebase with clippy
+	$(SHELL_WRAPPER) cargo clippy --all-targets --all-features
+
+.PHONY: format-check
+format-check: ## Check the codebase formatting without changing files
+	cargo fmt --all --check
+
+.PHONY: lint
+lint: format-check clippy ## Run all the linting tasks
+
+# -- Utility --------------------------------------------------------------------------------------
+
+.PHONY: format
+format: ## Format the codebase with rustfmt
+	cargo fmt --all
+
+.PHONY: clean
+clean: ## Clean all build artifacts in the project.
+	cargo clean
+
+.PHONY: shell
+shell: ## Launch the user's $SHELL inside the devshell
+	nix develop --command $(shell echo $$SHELL)
+
+.PHONY: editor
+editor: ## Launch the user's $EDITOR inside the devshell
+	nix develop --command $(EDITOR)
+

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+This document provides a brief introduction to how you can contribute to the Mavros project. We
+welcome all kinds of contributions, whether they be code or otherwise. This repository is written in
+[Rust](https://rust-lang.org), though there are components written in [Noir](https://noir-lang.org)
+as well.
+
+## Building
+
+As Mavros relies on LLVM as a dependency, we use [Nix](https://lix.systems) to encapsulate the build
+environment. You can build Mavros as follows:
+
+1. Install Nix by following the [instructions](https://lix.systems/install/) for your system. Once
+   done, check you have the `nix` command in your path.
+2. Run `nix develop` to drop into a development shell for the project (devshell). This will download
+   all of the dependencies onto your system without polluting your normal development environment
+   and then drop you into a basic bash shell that has the necessary tools on the path.
+3. Inside the devshell you can run your usual commands such as `cargo build` and so on.
+4. You can also run commands directly using `nix develop --command <...>` and passing your command.
+   This can also be used to launch the devshell using your shell of choice.
+
+By default the environment in the devshell inherits from your system environment, appending it after
+the environment-specific paths. To control what is available in the devshell, you can pass the
+following flags to the invocation. `--ignore-environment` / `-i` clears the entire parent
+environment and retains only the entries specified with `--keep` / `-k`. You can also use `--unset`
+/ `-u` to unset specific environment variables in the environment inherited by the devshell.
+
+### The Makefile
+
+This repo includes a makefile with some useful shorthand commands. In particular, it can cope with
+running its embedded commands that involve builds whether it is inside or outside of the nix
+devshell (e.g. you can run `make build` in your normal shell and it will spawn a devshell to run the
+build, or if you are already in the devshell it will not).
+
+- Run `make` to see a list of the available commands with help.
+- Run `make shell` to launch your user `$SHELL` inside the nix environment devshell.
+
+### Common Issues
+
+Below is a list of common issues that may be encountered when trying to build Mavros.
+
+- On macOS, if you have Apple's SDK `clang` and `cc` in your path ahead of the one provided by the
+  flake, you may get a linker error about not being able to find `libtinfo`. Hide these from your
+  path (commonly located in `/usr/bin`) inside the devshell to fix it (e.g. by using `-u` as
+  described above), or checking `$IN_NIX_SHELL` in your shell configuration.
+
+## Testing
+
+All of the tests in the repository can be run using `make test`. There are two main types of test
+for Mavros:
+
+- The **functional tests** are encapsulated in a special test driver included in the repository.
+  They are most easily run using `make func-test`.
+- The **unit tests** in the codebase can be run simply using `make unit-test`.
+

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735563628,
-        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1767840362,
-        "narHash": "sha256-ZtsFqUhilubohNZ1TgpQIFsi4biZTwRH9rjZsDRDik8=",
+        "lastModified": 1776914043,
+        "narHash": "sha256-qug5r56yW1qOsjSI99l3Jm15JNT9CvS2otkXNRNtrPI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d159ea1fc321c60f88a616ac28bab660092a227d",
+        "rev": "2d35c4358d7de3a0e606a6e8b27925d981c01cc3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay.url = "github:oxalica/rust-overlay";
   };
@@ -10,21 +10,18 @@
       let
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
-        llvmPackages = pkgs.llvmPackages_18;
-
-        darwinDeps = pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
-          CoreText
-          CoreGraphics
-          CoreFoundation
-          Security
-          SystemConfiguration
-        ]);
+        llvmPackages = pkgs.llvmPackages_22;
       in
       {
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             (rust-bin.nightly.latest.default.override {
-              extensions = [ "rust-src" "rust-analyzer" ];
+              extensions = [ 
+                "clippy" 
+                "rust-analyzer" 
+                "rust-src" 
+                "rustfmt" 
+              ];
               targets = [ "wasm32-unknown-unknown" ];
             })
             llvmPackages.llvm
@@ -32,7 +29,7 @@
             llvmPackages.lld
             pkg-config
             openssl
-            nodejs_20
+            nodejs_25
             libffi
             libxml2
             ncurses
@@ -40,10 +37,11 @@
             git
             fontconfig
             libiconv
-          ] ++ darwinDeps;
+            graphviz
+          ];
 
-          LLVM_SYS_180_PREFIX = "${llvmPackages.llvm.dev}";
-          LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+          LLVM_SYS_221_PREFIX = "${pkgs.lib.getDev llvmPackages.libllvm}";
+          LIBCLANG_PATH = "${pkgs.lib.getLib llvmPackages.libclang}";
           LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.fontconfig.lib ];
         };
       }

--- a/src/compiler/llssa_llvm_codegen.rs
+++ b/src/compiler/llssa_llvm_codegen.rs
@@ -4,6 +4,7 @@
 //! Operates on LLSSA + LLType — types are explicit in the LLSSA ops, no TypeInfo needed.
 
 use std::collections::HashMap;
+use std::num::NonZeroU32;
 use std::path::Path;
 
 use inkwell::AddressSpace;
@@ -112,7 +113,13 @@ impl<'ctx> LLVMCodeGen<'ctx> {
     /// Convert an LLType to the corresponding LLVM type.
     fn convert_type(&self, ty: &LLType) -> BasicTypeEnum<'ctx> {
         match ty {
-            LLType::Int(bits) => self.context.custom_width_int_type(*bits).into(),
+            LLType::Int(bits) => self
+                .context
+                .custom_width_int_type(
+                    NonZeroU32::new(*bits).expect("Cannot have zero-width integer"),
+                )
+                .expect("A basic integer type can be created")
+                .into(),
             LLType::Ptr => self.context.ptr_type(AddressSpace::default()).into(),
             LLType::Struct(s) => self.convert_struct_type(s),
         }
@@ -131,7 +138,13 @@ impl<'ctx> LLVMCodeGen<'ctx> {
     /// Convert an LLFieldType to the corresponding LLVM type.
     fn convert_field_type(&self, ft: &LLFieldType) -> BasicTypeEnum<'ctx> {
         match ft {
-            LLFieldType::Int(bits) => self.context.custom_width_int_type(*bits).into(),
+            LLFieldType::Int(bits) => self
+                .context
+                .custom_width_int_type(
+                    NonZeroU32::new(*bits).expect("Cannot have zero-width integer"),
+                )
+                .expect("A basic integer type can be created")
+                .into(),
             LLFieldType::Ptr => self.context.ptr_type(AddressSpace::default()).into(),
             LLFieldType::Inline(s) => self.convert_struct_type(s),
             LLFieldType::InlineArray(s, n) => {
@@ -443,8 +456,7 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                 )
                 .unwrap();
             call.try_as_basic_value()
-                .left()
-                .expect("__field_mul should return a value")
+                .expect_basic("__field_mul should return a value")
         };
 
         let old = builder
@@ -456,8 +468,7 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                 .build_call(add_fn, &[old.into(), product.into()], "accum_new")
                 .unwrap();
             call.try_as_basic_value()
-                .left()
-                .expect("__field_add should return a value")
+                .expect_basic("__field_add should return a value")
         };
         builder.build_store(out_d_ptr, new_val).unwrap();
         builder.build_return(None).unwrap();
@@ -518,8 +529,7 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                 .build_call(add_fn, &[old.into(), sensitivity.into()], "accum_new")
                 .unwrap();
             call.try_as_basic_value()
-                .left()
-                .expect("__field_add should return a value")
+                .expect_basic("__field_add should return a value")
         };
         builder.build_store(target_ptr, new_val).unwrap();
         builder.build_return(None).unwrap();
@@ -704,7 +714,12 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                 bits,
                 value,
             } => {
-                let int_type = self.context.custom_width_int_type(*bits);
+                let int_type = self
+                    .context
+                    .custom_width_int_type(
+                        NonZeroU32::new(*bits).expect("Cannot have zero-width integer"),
+                    )
+                    .expect("A basic integer type can be created");
                 let val = int_type.const_int(*value, false);
                 self.value_map.insert(*result, val.into());
             }
@@ -774,8 +789,7 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                             .unwrap();
                         call_site
                             .try_as_basic_value()
-                            .left()
-                            .expect("field_mul should return a value")
+                            .expect_basic("field_mul should return a value")
                     }
                     FieldArithOp::Add => {
                         let add_fn = self.field_add_fn.expect("__field_add not declared");
@@ -785,8 +799,7 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                             .unwrap();
                         call_site
                             .try_as_basic_value()
-                            .left()
-                            .expect("field_add should return a value")
+                            .expect_basic("field_add should return a value")
                     }
                     FieldArithOp::Sub => {
                         let sub_fn = self.field_sub_fn.expect("__field_sub not declared");
@@ -796,8 +809,7 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                             .unwrap();
                         call_site
                             .try_as_basic_value()
-                            .left()
-                            .expect("field_sub should return a value")
+                            .expect_basic("field_sub should return a value")
                     }
                     FieldArithOp::Div => {
                         let div_fn = self.field_div_fn.expect("__field_div not declared");
@@ -807,8 +819,7 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                             .unwrap();
                         call_site
                             .try_as_basic_value()
-                            .left()
-                            .expect("field_div should return a value")
+                            .expect_basic("field_div should return a value")
                     }
                     _ => panic!("Unsupported FieldArithOp in LLSSA codegen: {:?}", kind),
                 };
@@ -886,7 +897,12 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                 to_bits,
             } => {
                 let val = self.value_map[value].into_int_value();
-                let target_type = self.context.custom_width_int_type(*to_bits);
+                let target_type = self
+                    .context
+                    .custom_width_int_type(
+                        NonZeroU32::new(*to_bits).expect("Cannot have zero-width integer"),
+                    )
+                    .expect("The target type for truncation is valid");
                 let truncated = self
                     .builder
                     .build_int_truncate(val, target_type, &format!("v{}", result.0))
@@ -900,7 +916,12 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                 to_bits,
             } => {
                 let val = self.value_map[value].into_int_value();
-                let target_type = self.context.custom_width_int_type(*to_bits);
+                let target_type = self
+                    .context
+                    .custom_width_int_type(
+                        NonZeroU32::new(*to_bits).expect("Cannot have zero-width integer"),
+                    )
+                    .expect("The target type for zero-extension is valid");
                 let extended = self
                     .builder
                     .build_int_z_extend(val, target_type, &format!("v{}", result.0))
@@ -945,8 +966,7 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                     .unwrap();
                 let field = call
                     .try_as_basic_value()
-                    .left()
-                    .expect("__field_from_limbs should return a value");
+                    .expect_basic("__field_from_limbs should return a value");
                 self.value_map.insert(*result, field);
             }
 
@@ -962,8 +982,7 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                     .unwrap();
                 let limb_vals = call
                     .try_as_basic_value()
-                    .left()
-                    .expect("__field_to_limbs should return a value");
+                    .expect_basic("__field_to_limbs should return a value");
                 self.value_map.insert(*result, limb_vals);
             }
 
@@ -993,8 +1012,7 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                     .unwrap();
                 let ptr_val = call_site
                     .try_as_basic_value()
-                    .left()
-                    .expect("malloc should return a value");
+                    .expect_basic("malloc should return a value");
                 self.value_map.insert(*result, ptr_val);
             }
 
@@ -1115,14 +1133,13 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                     .unwrap();
 
                 if results.len() == 1 {
-                    if let Some(val) = call_result.try_as_basic_value().left() {
+                    if let Some(val) = call_result.try_as_basic_value().basic() {
                         self.value_map.insert(results[0], val);
                     }
                 } else if results.len() > 1 {
                     let ret_struct = call_result
                         .try_as_basic_value()
-                        .left()
-                        .expect("Expected return value from multi-return call");
+                        .expect_basic("Expected return value from multi-return call");
                     for (i, result_id) in results.iter().enumerate() {
                         let val = self
                             .builder
@@ -1149,8 +1166,7 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                     .unwrap();
                 let val = call_result
                     .try_as_basic_value()
-                    .left()
-                    .expect("__ad_next_d_coeff should return a value");
+                    .expect_basic("__ad_next_d_coeff should return a value");
                 self.value_map.insert(*result, val);
             }
 
@@ -1165,8 +1181,7 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                     .unwrap();
                 let val = call_result
                     .try_as_basic_value()
-                    .left()
-                    .expect("__ad_fresh_witness_index should return a value");
+                    .expect_basic("__ad_fresh_witness_index should return a value");
                 self.value_map.insert(*result, val);
             }
 

--- a/wasm-runtime/Cargo.toml
+++ b/wasm-runtime/Cargo.toml
@@ -9,7 +9,3 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 ark-bn254 = "0.5.0"
 ark-ff = "0.5.0"
-
-[profile.release]
-opt-level = "z"
-lto = true


### PR DESCRIPTION
Previously Mavros was relying on LLVM 18, which is quite out of date now. Given there is support in inkwell and nixpkgs for LLVM 22, this PR bumps it to use 22.

It also includes:

- A new `CONTRIBUTING.md` with some hints and guidance for how to build and test the project.
- A new makefile, which provides a number of utility commands to ease working with the nix devshell.
- A bump to and cleanup of the nix dev environment.
- Updates to the CI configuration to use the makefile for clarity.