### PR TITLE
Fix warnings on `main`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help:
 
 .PHONY: build
 build: ## Build Mavros for testing
-	$(SHELL_WRAPPER) cargo build --all-features
+	$(SHELL_WRAPPER) cargo build --all-targets --all-features
 
 .PHONY: build-test-runner
 build-test-runner: ## Builds the test runner in release mode
@@ -24,7 +24,7 @@ build-test-runner: ## Builds the test runner in release mode
 
 .PHONY: release
 release: ## Build Mavros in release mode
-	$(SHELL_WRAPPER) cargo build --release --all-features
+	$(SHELL_WRAPPER) cargo build --release --all-targets --all-features
 
 # -- Testing --------------------------------------------------------------------------------------
 
@@ -41,7 +41,7 @@ test: unit-test func-test ## Run all the tests
 
 .PHONY: install
 install: ## Builds the Mavros CLI and installs it to your cargo binary path
-	cargo install --locked --bin mavros --path .
+	$(SHELL_WRAPPER) cargo install --locked --bin mavros --path .
 
 # -- Linting --------------------------------------------------------------------------------------
 
@@ -58,7 +58,7 @@ format-check-docs: ## Check docs and config formatting without changing files (r
 	$(SHELL_WRAPPER) dprint check
 
 .PHONY: format-check
-format-check: format-check-rust format-check-docs ## Check code, docs, and config formatting without changing files (reformat with `make format`)
+format-check: format-check-docs format-check-rust ## Check code, docs, and config formatting without changing files (reformat with `make format`)
 
 .PHONY: lint
 lint: format-check clippy ## Run all the linting tasks
@@ -87,4 +87,3 @@ shell: ## Launch the user's `$SHELL` inside the devshell
 .PHONY: editor
 editor: ## Launch the user's `$EDITOR` inside the devshell
 	nix develop --command $(EDITOR)
-

--- a/src/api.rs
+++ b/src/api.rs
@@ -11,7 +11,7 @@ use crate::{
     vm::interpreter,
 };
 use mavros_artifacts::InputValueOrdered;
-use noirc_abi::input_parser::{Format, InputValue};
+use noirc_abi::input_parser::Format;
 
 type Error = Box<dyn std::error::Error>;
 

--- a/src/bin/test_runner.rs
+++ b/src/bin/test_runner.rs
@@ -249,7 +249,7 @@ fn run_single(root: PathBuf) {
     let wasm_path = r1cs.as_ref().and_then(|r1cs| {
         emit("START:WITGEN_WASM_COMPILE");
         let tmpdir = tempfile::tempdir().ok()?;
-        let wasm_path = tmpdir.into_path().join("witgen.wasm");
+        let wasm_path = tmpdir.keep().join("witgen.wasm");
         match driver.compile_llvm_targets(false, r1cs, Some(wasm_path.clone())) {
             Ok(_) if wasm_path.exists() => {
                 emit("END:WITGEN_WASM_COMPILE:ok");
@@ -321,7 +321,7 @@ fn run_single(root: PathBuf) {
     let ad_wasm_path: Option<std::path::PathBuf> = r1cs.as_ref().and_then(|r1cs| {
         emit("START:AD_WASM_COMPILE");
         let tmpdir = tempfile::tempdir().ok()?;
-        let wasm_path = tmpdir.into_path().join("ad.wasm");
+        let wasm_path = tmpdir.keep().join("ad.wasm");
         match driver.compile_ad_llvm_targets(wasm_path.clone(), r1cs) {
             Ok(_) if wasm_path.exists() => {
                 emit("END:AD_WASM_COMPILE:ok");

--- a/src/compiler/analysis/instrumenter.rs
+++ b/src/compiler/analysis/instrumenter.rs
@@ -1709,7 +1709,7 @@ impl symbolic_executor::Context<SpecSplitValue> for CostAnalysis {
         None
     }
 
-    fn on_return(&mut self, returns: &mut [SpecSplitValue], return_types: &[Type]) {
+    fn on_return(&mut self, returns: &mut [SpecSplitValue], _return_types: &[Type]) {
         for rval in returns.iter_mut() {
             rval.blind();
         }
@@ -1729,7 +1729,7 @@ impl symbolic_executor::Context<SpecSplitValue> for CostAnalysis {
         &mut self,
         _target: crate::compiler::ssa::BlockId,
         params: &mut [SpecSplitValue],
-        param_types: &[&Type],
+        _param_types: &[&Type],
     ) {
         for pval in params.iter_mut() {
             pval.blind_unspecialized();

--- a/src/compiler/flow_analysis.rs
+++ b/src/compiler/flow_analysis.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use crate::compiler::ir::r#type::SSAType;
-use crate::compiler::ssa::{BlockId, CallTarget, FunctionId, Instruction, OpCode, SSA, Terminator};
+use crate::compiler::ssa::{BlockId, FunctionId, Instruction, SSA, Terminator};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JumpType {

--- a/src/compiler/hlssa_to_llssa.rs
+++ b/src/compiler/hlssa_to_llssa.rs
@@ -514,7 +514,6 @@ fn lower_instruction(
                         BinaryArithOpKind::Shr => IntArithOp::UShr,
                         BinaryArithOpKind::Div => IntArithOp::UDiv,
                         BinaryArithOpKind::Mod => IntArithOp::URem,
-                        _ => panic!("Unsupported int arith op: {:?}", kind),
                     };
                     e.int_arith(op, ll_lhs, ll_rhs)
                 }
@@ -530,7 +529,6 @@ fn lower_instruction(
                         BinaryArithOpKind::Shr => IntArithOp::UShr,
                         BinaryArithOpKind::Div => panic!("Signed div not yet implemented in LLSSA"),
                         BinaryArithOpKind::Mod => panic!("Signed mod not yet implemented in LLSSA"),
-                        _ => panic!("Unsupported signed int arith op: {:?}", kind),
                     };
                     e.int_arith(op, ll_lhs, ll_rhs)
                 }
@@ -868,12 +866,7 @@ fn lower_instruction(
             val_map.insert(*result, ll_result);
         }
 
-        OpCode::Spread { result, value, .. }
-        | OpCode::Unspread {
-            result_odd: result,
-            value,
-            ..
-        } => {
+        OpCode::Spread { .. } | OpCode::Unspread { .. } => {
             todo!(
                 "Spread/Unspread opcodes are not handled yet in HLSSA->LLSSA lowering: {:?}",
                 instruction
@@ -1519,7 +1512,6 @@ fn lower_ad_fresh_witness(
 /// Allocate an ADSumNode for two AD values.
 fn lower_ad_sum(e: &mut LLBlockEmitter<'_>, ll_a: ValueId, ll_b: ValueId) -> ValueId {
     let node_struct = LLStruct::ad_sum_node();
-    let field_elem = LLStruct::field_elem();
     let node = e.heap_alloc(node_struct.clone(), None);
 
     // RC = 1
@@ -2348,17 +2340,6 @@ fn generate_rngchk_8_function(table_idx_global: usize) -> LLFunction {
     }
 
     func
-}
-
-/// Read `ad_coeffs_base[offset]` via random access (does not advance the
-/// AdCoeffs cursor). Used by AD helpers that need to peek at a coefficient at
-/// a layout-determined absolute index.
-fn ad_read_coeff_at(e: &mut LLBlockEmitter<'_>, offset: usize) -> ValueId {
-    let base_slot = e.ad_vm_field_ptr(LLStruct::AD_VM_COEFFS_BASE);
-    let base = e.ll_load(base_slot, LLType::Ptr);
-    let idx = e.int_const(32, offset as u64);
-    let slot = e.array_elem_ptr(base, LLStruct::field_elem(), idx);
-    e.ll_load(slot, LLType::Struct(LLStruct::field_elem()))
 }
 
 /// Post-increment `AdCurrentLookupWitOff` by one, returning the old i32 value.

--- a/src/compiler/llssa_llvm_codegen.rs
+++ b/src/compiler/llssa_llvm_codegen.rs
@@ -514,7 +514,6 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                             .build_right_shift(lhs, masked_rhs, false, name)
                             .unwrap()
                     }
-                    _ => panic!("Unsupported IntArithOp in LLSSA codegen: {:?}", kind),
                 };
                 self.value_map.insert(*result, val.into());
             }
@@ -588,7 +587,6 @@ impl<'ctx> LLVMCodeGen<'ctx> {
                             .try_as_basic_value()
                             .expect_basic("field_div should return a value")
                     }
-                    _ => panic!("Unsupported FieldArithOp in LLSSA codegen: {:?}", kind),
                 };
                 self.value_map.insert(*result, val);
             }
@@ -796,11 +794,10 @@ impl<'ctx> LLVMCodeGen<'ctx> {
             } => {
                 let p = self.value_map[ptr].into_pointer_value();
                 let llvm_struct_ty = self.convert_struct_type(struct_type).into_struct_type();
-                let gep = unsafe {
-                    self.builder
-                        .build_struct_gep(llvm_struct_ty, p, *field as u32, "sfp")
-                        .unwrap()
-                };
+                let gep = self
+                    .builder
+                    .build_struct_gep(llvm_struct_ty, p, *field as u32, "sfp")
+                    .unwrap();
                 self.value_map.insert(*result, gep.into());
             }
 

--- a/src/compiler/passes/common_subexpression_elimination.rs
+++ b/src/compiler/passes/common_subexpression_elimination.rs
@@ -8,7 +8,7 @@ use crate::compiler::{
     ssa::{BinaryArithOpKind, BlockId, CmpKind, ConstValue, HLFunction, HLSSA, OpCode, ValueId},
 };
 use crate::compiler::{
-    pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
+    pass_manager::{AnalysisId, AnalysisStore, Pass},
     passes::fix_double_jumps::ValueReplacements,
 };
 

--- a/src/compiler/passes/condition_propagation.rs
+++ b/src/compiler/passes/condition_propagation.rs
@@ -1,6 +1,6 @@
 use crate::compiler::{
     flow_analysis::FlowAnalysis,
-    pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
+    pass_manager::{AnalysisId, AnalysisStore, Pass},
     passes::fix_double_jumps::ValueReplacements,
     ssa::{BlockId, ConstValue, HLSSA, OpCode, Terminator, ValueId},
 };
@@ -63,7 +63,7 @@ impl ConditionPropagation {
                 }
 
                 let block = function.get_block_mut(block_id);
-                let mut instructions = block.take_instructions();
+                let instructions = block.take_instructions();
                 let mut new_instructions = const_opcodes;
                 new_instructions.extend(instructions.iter().cloned());
                 for instruction in new_instructions.iter_mut() {

--- a/src/compiler/passes/dead_code_elimination.rs
+++ b/src/compiler/passes/dead_code_elimination.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::compiler::{
     flow_analysis::{CFG, FlowAnalysis},
-    pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
+    pass_manager::{AnalysisId, AnalysisStore, Pass},
     ssa::{
         BlockId, CallTarget, FunctionId, HLFunction, HLSSA, Instruction, OpCode, Terminator,
         ValueId,

--- a/src/compiler/passes/deduplicate_phis.rs
+++ b/src/compiler/passes/deduplicate_phis.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::compiler::{
     flow_analysis::FlowAnalysis,
-    pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
+    pass_manager::{AnalysisId, AnalysisStore, Pass},
     ssa::{BlockId, HLSSA, Terminator, ValueId},
 };
 

--- a/src/compiler/passes/explicit_witness.rs
+++ b/src/compiler/passes/explicit_witness.rs
@@ -1351,7 +1351,6 @@ impl ExplicitWitness {
         let two_to_64 = b.field_const(Field::from(2u128).pow([64u64]));
         let two_to_128 = b.field_const(Field::from(2u128).pow([128u64]));
         let zero = b.field_const(Field::ZERO);
-        let one = b.field_const(Field::ONE);
 
         // Step 1: Decompose value into 32 bytes (big-endian)
         let pure_value = b.value_of(value);
@@ -1481,7 +1480,6 @@ impl ExplicitWitness {
     ) -> ValueId {
         let hi_size = 8 - lo_size;
         let two_to_lo = b.field_const(Field::from(1u128 << lo_size));
-        let zero = b.field_const(Field::ZERO);
 
         // Compute lo and hi hints from the byte value
         let byte_pure = b.value_of(byte_wit);

--- a/src/compiler/passes/fix_double_jumps.rs
+++ b/src/compiler/passes/fix_double_jumps.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::compiler::{
     flow_analysis::FlowAnalysis,
-    pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
+    pass_manager::{AnalysisId, AnalysisStore, Pass},
     ssa::{BlockId, HLSSA, Instruction, OpCode, Terminator, ValueId},
 };
 

--- a/src/compiler/passes/rc_insertion.rs
+++ b/src/compiler/passes/rc_insertion.rs
@@ -1,5 +1,3 @@
-use std::fmt::{Debug, Display};
-
 use itertools::Itertools;
 use tracing::{Level, debug, instrument, trace};
 

--- a/src/compiler/passes/remove_unreachable_blocks.rs
+++ b/src/compiler/passes/remove_unreachable_blocks.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::compiler::{
     flow_analysis::FlowAnalysis,
-    pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
+    pass_manager::{AnalysisId, AnalysisStore, Pass},
     ssa::{BlockId, HLSSA},
 };
 

--- a/src/compiler/passes/remove_unreachable_functions.rs
+++ b/src/compiler/passes/remove_unreachable_functions.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::compiler::{
     flow_analysis::FlowAnalysis,
-    pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
+    pass_manager::{AnalysisId, AnalysisStore, Pass},
     ssa::HLSSA,
 };
 

--- a/src/compiler/passes/strip_witness_of.rs
+++ b/src/compiler/passes/strip_witness_of.rs
@@ -1,7 +1,7 @@
 use crate::compiler::{
     flow_analysis::FlowAnalysis,
     ir::r#type::Type,
-    pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
+    pass_manager::{AnalysisId, AnalysisStore, Pass},
     passes::fix_double_jumps::ValueReplacements,
     ssa::{CastTarget, HLSSA, OpCode},
 };

--- a/src/compiler/passes/witness_write_to_void.rs
+++ b/src/compiler/passes/witness_write_to_void.rs
@@ -1,6 +1,6 @@
 use crate::compiler::{
     flow_analysis::FlowAnalysis,
-    pass_manager::{Analysis as _, AnalysisId, AnalysisStore, Pass},
+    pass_manager::{AnalysisId, AnalysisStore, Pass},
     passes::fix_double_jumps::ValueReplacements,
     ssa::{HLSSA, OpCode},
 };

--- a/src/compiler/r1cs_gen.rs
+++ b/src/compiler/r1cs_gen.rs
@@ -25,14 +25,13 @@ pub use mavros_artifacts::{ConstraintsLayout, LC, R1C, R1CS, WitnessLayout};
 // }
 
 #[derive(Clone, Debug)]
-struct ArrayData {
+pub struct ArrayData {
     table_id: Option<usize>,
     data: Vec<Value>,
 }
 
 #[derive(Clone, Debug)]
-struct TupleData {
-    table_id: Option<usize>,
+pub struct TupleData {
     data: Vec<Value>,
 }
 
@@ -281,10 +280,7 @@ impl Value {
     }
 
     pub fn mk_tuple(fields: Vec<Value>) -> Value {
-        Value::Tuple(Rc::new(RefCell::new(TupleData {
-            table_id: None,
-            data: fields,
-        })))
+        Value::Tuple(Rc::new(RefCell::new(TupleData { data: fields })))
     }
 }
 

--- a/src/compiler/untaint_control_flow.rs
+++ b/src/compiler/untaint_control_flow.rs
@@ -3,13 +3,13 @@ use std::collections::HashMap;
 use tracing::{Level, instrument};
 
 use crate::compiler::{
-    analysis::types::{FunctionTypeInfo, TypeInfo, Types},
+    analysis::types::{FunctionTypeInfo, Types},
     block_builder::{HLEmitter, HLInstrBuilder},
     flow_analysis::FlowAnalysis,
     ir::r#type::{Type, TypeExpr},
     ssa::{
-        BinaryArithOpKind, BlockId, CallTarget, CastTarget, FunctionId, HLBlock, HLFunction, HLSSA,
-        OpCode, SeqType, Terminator, ValueId,
+        BinaryArithOpKind, BlockId, CallTarget, FunctionId, HLBlock, HLFunction, HLSSA, OpCode,
+        SeqType, Terminator, ValueId,
     },
     witness_info::{ConstantWitness, FunctionWitnessType, WitnessInfo, WitnessType},
     witness_type_inference::WitnessTypeInference,

--- a/vm/src/array.rs
+++ b/vm/src/array.rs
@@ -4,10 +4,8 @@ use std::{
     ptr,
 };
 
-use tracing::field;
-
 use crate::{
-    Field, InputValueOrdered,
+    Field,
     bytecode::{AllocationType, VM},
 };
 

--- a/vm/src/bytecode.rs
+++ b/vm/src/bytecode.rs
@@ -24,16 +24,16 @@ pub const ELEM_WITNESS: usize = 2;
 #[inline(always)]
 unsafe fn lookup_elem_bump_db(ptr: *mut u64, elem_kind: usize, coeff: Field, vm: &mut VM) {
     match elem_kind {
-        ELEM_WORD => {
+        ELEM_WORD => unsafe {
             let v = Field::from(*(ptr as *const u64));
             *vm.data.as_ad.out_db += coeff * v;
-        }
-        ELEM_FIELD => {
+        },
+        ELEM_FIELD => unsafe {
             let v = *(ptr as *const Field);
             *vm.data.as_ad.out_db += coeff * v;
-        }
+        },
         ELEM_WITNESS => {
-            let elem = BoxedValue(*(ptr as *const *mut u64));
+            let elem = BoxedValue(unsafe { *(ptr as *const *mut u64) });
             elem.bump_db(coeff, vm);
         }
         _ => unreachable!(),
@@ -44,8 +44,8 @@ unsafe fn lookup_elem_bump_db(ptr: *mut u64, elem_kind: usize, coeff: Field, vm:
 #[inline(always)]
 unsafe fn read_pure_elem_as_field(ptr: *mut u64, elem_kind: usize) -> Field {
     match elem_kind {
-        ELEM_WORD => Field::from(*(ptr as *const u64)),
-        ELEM_FIELD => *(ptr as *const Field),
+        ELEM_WORD => Field::from(unsafe { *(ptr as *const u64) }),
+        ELEM_FIELD => unsafe { *(ptr as *const Field) },
         _ => unreachable!(),
     }
 }
@@ -294,27 +294,31 @@ unsafe fn forward_kv_lookup_emit(
     let table_info = &vm.tables[table_idx];
 
     // Entry 1 (x-constraint): table_id, result_value, 0
-    *(vm.data.as_forward.lookups_a as *mut u64) = table_idx as u64;
-    *vm.data.as_forward.lookups_b = result;
-    *(vm.data.as_forward.lookups_c as *mut u64) = 0;
-    vm.data.as_forward.lookups_a = vm.data.as_forward.lookups_a.offset(1);
-    vm.data.as_forward.lookups_b = vm.data.as_forward.lookups_b.offset(1);
-    vm.data.as_forward.lookups_c = vm.data.as_forward.lookups_c.offset(1);
+    unsafe {
+        *(vm.data.as_forward.lookups_a as *mut u64) = table_idx as u64;
+        *vm.data.as_forward.lookups_b = result;
+        *(vm.data.as_forward.lookups_c as *mut u64) = 0;
+        vm.data.as_forward.lookups_a = vm.data.as_forward.lookups_a.offset(1);
+        vm.data.as_forward.lookups_b = vm.data.as_forward.lookups_b.offset(1);
+        vm.data.as_forward.lookups_c = vm.data.as_forward.lookups_c.offset(1);
+    }
 
     // Entry 2 (y-constraint): table_id, key, flag
-    *(vm.data.as_forward.lookups_a as *mut u64) = table_idx as u64;
-    if flag_u64 != 0 {
-        let key_u64 = ark_ff::PrimeField::into_bigint(key).0[0];
-        let ptr = table_info.multiplicities_wit.offset(key_u64 as isize);
-        *(ptr as *mut u64) += flag_u64;
-        *(vm.data.as_forward.lookups_b as *mut u64) = key_u64;
-    } else {
-        *(vm.data.as_forward.lookups_b as *mut Field) = key;
+    unsafe {
+        *(vm.data.as_forward.lookups_a as *mut u64) = table_idx as u64;
+        if flag_u64 != 0 {
+            let key_u64 = ark_ff::PrimeField::into_bigint(key).0[0];
+            let ptr = table_info.multiplicities_wit.offset(key_u64 as isize);
+            *(ptr as *mut u64) += flag_u64;
+            *(vm.data.as_forward.lookups_b as *mut u64) = key_u64;
+        } else {
+            *(vm.data.as_forward.lookups_b as *mut Field) = key;
+        }
+        *(vm.data.as_forward.lookups_c as *mut u64) = flag_u64;
+        vm.data.as_forward.lookups_a = vm.data.as_forward.lookups_a.offset(1);
+        vm.data.as_forward.lookups_b = vm.data.as_forward.lookups_b.offset(1);
+        vm.data.as_forward.lookups_c = vm.data.as_forward.lookups_c.offset(1);
     }
-    *(vm.data.as_forward.lookups_c as *mut u64) = flag_u64;
-    vm.data.as_forward.lookups_a = vm.data.as_forward.lookups_a.offset(1);
-    vm.data.as_forward.lookups_b = vm.data.as_forward.lookups_b.offset(1);
-    vm.data.as_forward.lookups_c = vm.data.as_forward.lookups_c.offset(1);
 }
 
 /// Emit AD bumps for a key-value lookup (x-constraint + y-constraint + sum).
@@ -329,7 +333,7 @@ unsafe fn ad_kv_lookup_emit(
     let cnst_off = table_info.elem_inverses_constraint_section_offset;
     let length = table_info.length;
 
-    let x_coeff = {
+    let x_coeff = unsafe {
         let r = *vm
             .data
             .as_ad
@@ -338,12 +342,12 @@ unsafe fn ad_kv_lookup_emit(
         vm.data.as_ad.current_cnst_lookups_off += 1;
         r
     };
-    let x_wit_off = {
+    let x_wit_off = unsafe {
         let r = vm.data.as_ad.current_wit_lookups_off;
         vm.data.as_ad.current_wit_lookups_off += 1;
         r
     };
-    let y_coeff = {
+    let y_coeff = unsafe {
         let r = *vm
             .data
             .as_ad
@@ -352,37 +356,46 @@ unsafe fn ad_kv_lookup_emit(
         vm.data.as_ad.current_cnst_lookups_off += 1;
         r
     };
-    let y_wit_off = {
+    let y_wit_off = unsafe {
         let r = vm.data.as_ad.current_wit_lookups_off;
         vm.data.as_ad.current_wit_lookups_off += 1;
         r
     };
-    let inv_sum_coeff = *vm
-        .data
-        .as_ad
-        .ad_coeffs
-        .offset(cnst_off as isize + 2 * length as isize);
+    let inv_sum_coeff = unsafe {
+        *vm.data
+            .as_ad
+            .ad_coeffs
+            .offset(cnst_off as isize + 2 * length as isize)
+    };
 
     // x-constraint: beta * result - x_lookup = 0
-    *vm.data
-        .as_ad
-        .out_da
-        .offset(vm.data.as_ad.logup_wit_challenge_off as isize + 1) += x_coeff;
+    unsafe {
+        *vm.data
+            .as_ad
+            .out_da
+            .offset(vm.data.as_ad.logup_wit_challenge_off as isize + 1) += x_coeff;
+    }
     result.bump_db(x_coeff, vm);
-    *vm.data.as_ad.out_dc.offset(x_wit_off as isize) -= x_coeff;
+    unsafe {
+        *vm.data.as_ad.out_dc.offset(x_wit_off as isize) -= x_coeff;
+    }
 
     // y-constraint: y * (alpha - x_lookup - key) = flag
-    *vm.data.as_ad.out_da.offset(y_wit_off as isize) += y_coeff;
-    *vm.data
-        .as_ad
-        .out_db
-        .offset(vm.data.as_ad.logup_wit_challenge_off as isize) += y_coeff;
-    *vm.data.as_ad.out_db.offset(x_wit_off as isize) -= y_coeff;
+    unsafe {
+        *vm.data.as_ad.out_da.offset(y_wit_off as isize) += y_coeff;
+        *vm.data
+            .as_ad
+            .out_db
+            .offset(vm.data.as_ad.logup_wit_challenge_off as isize) += y_coeff;
+        *vm.data.as_ad.out_db.offset(x_wit_off as isize) -= y_coeff;
+    }
     key.bump_db(-y_coeff, vm);
     flag.bump_dc(y_coeff, vm);
 
     // Sum constraint
-    *vm.data.as_ad.out_dc.offset(y_wit_off as isize) += inv_sum_coeff;
+    unsafe {
+        *vm.data.as_ad.out_dc.offset(y_wit_off as isize) += inv_sum_coeff;
+    }
 }
 
 #[interpreter]

--- a/vm/src/interpreter.rs
+++ b/vm/src/interpreter.rs
@@ -6,13 +6,13 @@ use std::{
 };
 
 use ark_ff::{AdditiveGroup, BigInt, Field as _, Fp, PrimeField as _};
-use tracing::{field, instrument};
+use tracing::instrument;
 
 pub use crate::InputValueOrdered;
 
 use crate::{
     ConstraintsLayout, Field, WitnessLayout,
-    array::{BoxedLayout, BoxedValue},
+    array::BoxedValue,
     bytecode::{self, AllocationInstrumenter, AllocationType, OpCode, TableInfo, VM},
 };
 
@@ -204,7 +204,7 @@ pub fn run_phase1(
     let mut out_wit_pre_comm = vec![Field::ZERO; witness_layout.pre_commitment_size()];
     let flat_inputs = flatten_param_vec(ordered_inputs);
     // The program itself writes inputs to the witness tape via pinned WriteWitness instructions.
-    let mut out_wit_post_comm = vec![Field::ZERO; witness_layout.post_commitment_size()];
+    let out_wit_post_comm = vec![Field::ZERO; witness_layout.post_commitment_size()];
     let mut global_frame = vec![0u64; global_frame_size];
     let mut vm = VM::new_witgen(
         out_a.as_mut_ptr(),


### PR DESCRIPTION
This is in preparation for enabling a basic set of clippy lints on CI, where compilation warnings will be errors.