### PR TITLE
Refactor value identifier allocation

### DIFF
--- a/compiler/src/compiler/analysis/flow_analysis.rs
+++ b/compiler/src/compiler/analysis/flow_analysis.rs
@@ -6,6 +6,7 @@ use petgraph::algo::dominators::{self, Dominators};
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 use petgraph::visit::{Bfs, DfsPostOrder, EdgeRef, Walker};
 use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
 use std::fs;
 use std::path::PathBuf;
 
@@ -398,10 +399,10 @@ impl CFG {
 }
 
 impl CFG {
-    pub fn generate_image<Op: Instruction, Ty: SSAType>(
+    pub fn generate_image<Op: Instruction, Ty: SSAType, C: Clone + Debug + 'static>(
         &self,
         output_path: PathBuf,
-        ssa: &SSA<Op, Ty>,
+        ssa: &SSA<Op, Ty, C>,
         function: &crate::compiler::ssa::Function<Op, Ty>,
         func_id: FunctionId,
         label: String,
@@ -566,10 +567,10 @@ impl CallGraph {
 }
 
 impl CallGraph {
-    pub fn generate_image<Op: Instruction, Ty: SSAType>(
+    pub fn generate_image<Op: Instruction, Ty: SSAType, C: Clone + Debug + 'static>(
         &self,
         output_path: PathBuf,
-        ssa: &SSA<Op, Ty>,
+        ssa: &SSA<Op, Ty, C>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         use std::fs;
         use std::process::Command;
@@ -633,7 +634,9 @@ pub struct FlowAnalysis {
 }
 
 impl FlowAnalysis {
-    pub fn run<Op: Instruction, Ty: SSAType>(ssa: &SSA<Op, Ty>) -> Self {
+    pub fn run<Op: Instruction, Ty: SSAType, C: Clone + Debug + 'static>(
+        ssa: &SSA<Op, Ty, C>,
+    ) -> Self {
         let mut call_graph = CallGraph::new();
         let mut function_cfgs = HashMap::new();
 
@@ -688,10 +691,10 @@ impl FlowAnalysis {
         &self.function_cfgs[&function_id]
     }
 
-    pub fn generate_images<Op: Instruction, Ty: SSAType>(
+    pub fn generate_images<Op: Instruction, Ty: SSAType, C: Clone + Debug + 'static>(
         &self,
         debug_output_dir: PathBuf,
-        ssa: &SSA<Op, Ty>,
+        ssa: &SSA<Op, Ty, C>,
         phase_label: String,
     ) {
         if !debug_output_dir.exists() {
@@ -726,15 +729,17 @@ impl FlowAnalysis {
 use crate::compiler::pass_manager::{Analysis, AnalysisId, AnalysisStore};
 
 impl FlowAnalysis {
-    /// HLSSA analysis id — inherent method so callers can write
-    /// `FlowAnalysis::id()` without disambiguating the generic impl.
+    /// Convenience inherent shim so callers can write `FlowAnalysis::id()`
+    /// without bringing the `Analysis` trait into scope.
     pub fn id() -> AnalysisId {
         <Self as Analysis>::id()
     }
 }
 
-impl<Op: Instruction, Ty: SSAType> Analysis<Op, Ty> for FlowAnalysis {
-    fn compute(ssa: &SSA<Op, Ty>, _store: &AnalysisStore) -> Self {
+impl<Op: Instruction, Ty: SSAType, Cn: Clone + Debug + 'static> Analysis<Op, Ty, Cn>
+    for FlowAnalysis
+{
+    fn compute(ssa: &SSA<Op, Ty, Cn>, _store: &AnalysisStore) -> Self {
         FlowAnalysis::run(ssa)
     }
 }

--- a/compiler/src/compiler/analysis/symbolic_executor.rs
+++ b/compiler/src/compiler/analysis/symbolic_executor.rs
@@ -2,13 +2,15 @@
 //! into by providing their own `Value` and `Context` implementations that specialize it for their
 //! use-case.
 
+use std::collections::HashMap;
+
 use tracing::{Level, instrument};
 
 use crate::compiler::{
     Field,
     analysis::types::TypeInfo,
     ssa::{
-        BlockId, FunctionId, Instruction, Terminator,
+        BlockId, FunctionId, Instruction, Terminator, ValueId,
         hlssa::{
             BinaryArithOpKind, CastTarget, CmpKind, Endianness, HLSSA, LookupTarget, OpCode, Radix,
             RefCountOp, SequenceTargetType, SliceOpDir, Type, TypeExpr,
@@ -172,7 +174,7 @@ impl SymbolicExecutor {
         let fn_body = ssa.get_function(fn_id);
         let fn_type_info = type_info.get_function(fn_id);
         let entry = fn_body.get_entry();
-        let mut scope: Vec<Option<V>> = vec![None; fn_body.get_var_num_bound()];
+        let mut scope: HashMap<ValueId, V> = HashMap::new();
 
         let call_result = ctx.on_call(
             fn_id,
@@ -187,7 +189,7 @@ impl SymbolicExecutor {
         }
 
         for (pval, ppos) in inputs.iter_mut().zip(entry.get_parameter_values()) {
-            scope[ppos.0 as usize] = Some(pval.clone());
+            scope.insert(*ppos, pval.clone());
         }
 
         let mut current = Some(entry);
@@ -202,16 +204,19 @@ impl SymbolicExecutor {
                         rhs: b,
                     } => {
                         let lhs_type = fn_type_info.get_value_type(*a);
-                        let a = scope[a.0 as usize].as_ref().unwrap();
-                        let b = scope[b.0 as usize].as_ref().unwrap();
+                        let a = &scope[a];
+                        let b = &scope[b];
                         let stripped = lhs_type.strip_witness();
-                        scope[r.0 as usize] = Some(match cmp_kind {
-                            CmpKind::Eq => a.eq(b, ctx),
-                            CmpKind::Lt => match &stripped.expr {
-                                TypeExpr::I(bits) => a.slt(b, *bits, ctx),
-                                _ => a.ult(b, ctx),
+                        scope.insert(
+                            *r,
+                            match cmp_kind {
+                                CmpKind::Eq => a.eq(b, ctx),
+                                CmpKind::Lt => match &stripped.expr {
+                                    TypeExpr::I(bits) => a.slt(b, *bits, ctx),
+                                    _ => a.ult(b, ctx),
+                                },
                             },
-                        });
+                        );
                     }
                     crate::compiler::ssa::hlssa::OpCode::BinaryArithOp {
                         kind: binary_arith_op_kind,
@@ -219,23 +224,28 @@ impl SymbolicExecutor {
                         lhs: a,
                         rhs: b,
                     } => {
-                        let a = scope[a.0 as usize].as_ref().unwrap();
-                        let b = scope[b.0 as usize].as_ref().unwrap();
-                        scope[r.0 as usize] = Some(a.arith(
-                            b,
-                            *binary_arith_op_kind,
-                            &fn_type_info.get_value_type(*r),
-                            ctx,
-                        ));
+                        let a = &scope[a];
+                        let b = &scope[b];
+                        scope.insert(
+                            *r,
+                            a.arith(
+                                b,
+                                *binary_arith_op_kind,
+                                &fn_type_info.get_value_type(*r),
+                                ctx,
+                            ),
+                        );
                     }
                     crate::compiler::ssa::hlssa::OpCode::Cast {
                         result: r,
                         value: a,
                         target: cast_target,
                     } => {
-                        let a = scope[a.0 as usize].as_ref().unwrap();
-                        scope[r.0 as usize] =
-                            Some(a.cast(cast_target, &fn_type_info.get_value_type(*r), ctx));
+                        let a = &scope[a];
+                        scope.insert(
+                            *r,
+                            a.cast(cast_target, &fn_type_info.get_value_type(*r), ctx),
+                        );
                     }
                     crate::compiler::ssa::hlssa::OpCode::Truncate {
                         result: r,
@@ -243,9 +253,11 @@ impl SymbolicExecutor {
                         to_bits: to,
                         from_bits: from,
                     } => {
-                        let a = scope[a.0 as usize].as_ref().unwrap();
-                        scope[r.0 as usize] =
-                            Some(a.truncate(*from, *to, &fn_type_info.get_value_type(*r), ctx));
+                        let a = &scope[a];
+                        scope.insert(
+                            *r,
+                            a.truncate(*from, *to, &fn_type_info.get_value_type(*r), ctx),
+                        );
                     }
                     crate::compiler::ssa::hlssa::OpCode::SExt {
                         result: r,
@@ -253,16 +265,18 @@ impl SymbolicExecutor {
                         from_bits: from,
                         to_bits: to,
                     } => {
-                        let a = scope[a.0 as usize].as_ref().unwrap();
-                        scope[r.0 as usize] =
-                            Some(a.sext(*from, *to, &fn_type_info.get_value_type(*r), ctx));
+                        let a = &scope[a];
+                        scope.insert(
+                            *r,
+                            a.sext(*from, *to, &fn_type_info.get_value_type(*r), ctx),
+                        );
                     }
                     crate::compiler::ssa::hlssa::OpCode::Not {
                         result: r,
                         value: a,
                     } => {
-                        let a = scope[a.0 as usize].as_ref().unwrap();
-                        scope[r.0 as usize] = Some(a.not(&fn_type_info.get_value_type(*r), ctx));
+                        let a = &scope[a];
+                        scope.insert(*r, a.not(&fn_type_info.get_value_type(*r), ctx));
                     }
                     crate::compiler::ssa::hlssa::OpCode::MkSeq {
                         result: r,
@@ -270,11 +284,8 @@ impl SymbolicExecutor {
                         seq_type,
                         elem_type,
                     } => {
-                        let a = a
-                            .iter()
-                            .map(|id| scope[id.0 as usize].as_ref().unwrap().clone())
-                            .collect::<Vec<_>>();
-                        scope[r.0 as usize] = Some(V::mk_array(a, ctx, *seq_type, elem_type));
+                        let a = a.iter().map(|id| scope[id].clone()).collect::<Vec<_>>();
+                        scope.insert(*r, V::mk_array(a, ctx, *seq_type, elem_type));
                     }
                     crate::compiler::ssa::hlssa::OpCode::MkRepeated {
                         result: r,
@@ -283,30 +294,29 @@ impl SymbolicExecutor {
                         count,
                         elem_type,
                     } => {
-                        let elem = scope[element.0 as usize].as_ref().unwrap().clone();
+                        let elem = scope[element].clone();
                         let a = vec![elem; *count];
-                        scope[r.0 as usize] = Some(V::mk_array(a, ctx, *seq_type, elem_type));
+                        scope.insert(*r, V::mk_array(a, ctx, *seq_type, elem_type));
                     }
                     crate::compiler::ssa::hlssa::OpCode::Alloc {
                         result: r,
                         elem_type,
                     } => {
-                        scope[r.0 as usize] = Some(V::alloc(elem_type, ctx));
+                        scope.insert(*r, V::alloc(elem_type, ctx));
                     }
                     crate::compiler::ssa::hlssa::OpCode::Store { ptr, value: val } => {
-                        let ptr = scope[ptr.0 as usize].as_ref().unwrap();
-                        let val = scope[val.0 as usize].as_ref().unwrap();
+                        let ptr = &scope[ptr];
+                        let val = &scope[val];
                         ptr.ptr_write(val, ctx);
                     }
                     crate::compiler::ssa::hlssa::OpCode::Load { result: r, ptr } => {
-                        let ptr = scope[ptr.0 as usize].as_ref().unwrap();
-                        scope[r.0 as usize] =
-                            Some(ptr.ptr_read(&fn_type_info.get_value_type(*r), ctx));
+                        let ptr = &scope[ptr];
+                        scope.insert(*r, ptr.ptr_read(&fn_type_info.get_value_type(*r), ctx));
                     }
                     crate::compiler::ssa::hlssa::OpCode::AssertR1C { a, b, c } => {
-                        let a = scope[a.0 as usize].as_ref().unwrap();
-                        let b = scope[b.0 as usize].as_ref().unwrap();
-                        let c = scope[c.0 as usize].as_ref().unwrap();
+                        let a = &scope[a];
+                        let b = &scope[b];
+                        let c = &scope[c];
                         V::assert_r1c(a, b, c, ctx);
                     }
                     crate::compiler::ssa::hlssa::OpCode::Call {
@@ -315,10 +325,8 @@ impl SymbolicExecutor {
                         args: arguments,
                         unconstrained,
                     } => {
-                        let mut params: Vec<_> = arguments
-                            .iter()
-                            .map(|id| scope[id.0 as usize].as_ref().unwrap().clone())
-                            .collect();
+                        let mut params: Vec<_> =
+                            arguments.iter().map(|id| scope[id].clone()).collect();
                         let outputs = if *unconstrained {
                             let entry = ssa.get_function(*function_id).get_entry();
                             let param_types: Vec<_> =
@@ -340,7 +348,7 @@ impl SymbolicExecutor {
                             self.run_fn(ssa, type_info, *function_id, params, globals, ctx)
                         };
                         for (i, val) in returns.iter().enumerate() {
-                            scope[val.0 as usize] = Some(outputs[i].clone());
+                            scope.insert(*val, outputs[i].clone());
                         }
                     }
                     crate::compiler::ssa::hlssa::OpCode::Call {
@@ -354,10 +362,9 @@ impl SymbolicExecutor {
                         array: a,
                         index: i,
                     } => {
-                        let a = scope[a.0 as usize].as_ref().unwrap();
-                        let i = scope[i.0 as usize].as_ref().unwrap();
-                        scope[r.0 as usize] =
-                            Some(a.array_get(i, &fn_type_info.get_value_type(*r), ctx));
+                        let a = &scope[a];
+                        let i = &scope[i];
+                        scope.insert(*r, a.array_get(i, &fn_type_info.get_value_type(*r), ctx));
                     }
                     crate::compiler::ssa::hlssa::OpCode::ArraySet {
                         result: r,
@@ -365,11 +372,10 @@ impl SymbolicExecutor {
                         index: i,
                         value: v,
                     } => {
-                        let a = scope[arr.0 as usize].as_ref().unwrap();
-                        let i = scope[i.0 as usize].as_ref().unwrap();
-                        let v = scope[v.0 as usize].as_ref().unwrap();
-                        scope[r.0 as usize] =
-                            Some(a.array_set(i, v, &fn_type_info.get_value_type(*r), ctx));
+                        let a = &scope[arr];
+                        let i = &scope[i];
+                        let v = &scope[v];
+                        scope.insert(*r, a.array_set(i, v, &fn_type_info.get_value_type(*r), ctx));
                     }
                     crate::compiler::ssa::hlssa::OpCode::SlicePush {
                         result,
@@ -377,19 +383,16 @@ impl SymbolicExecutor {
                         values,
                         dir,
                     } => {
-                        let sl = scope[slice.0 as usize].as_ref().unwrap();
-                        let vals: Vec<_> = values
-                            .iter()
-                            .map(|v| scope[v.0 as usize].as_ref().unwrap().clone())
-                            .collect();
-                        scope[result.0 as usize] = Some(ctx.slice_push(sl, &vals, *dir));
+                        let sl = &scope[slice];
+                        let vals: Vec<_> = values.iter().map(|v| scope[v].clone()).collect();
+                        scope.insert(*result, ctx.slice_push(sl, &vals, *dir));
                     }
                     crate::compiler::ssa::hlssa::OpCode::SliceLen {
                         result: r,
                         slice: sl,
                     } => {
-                        let sl = scope[sl.0 as usize].as_ref().unwrap();
-                        scope[r.0 as usize] = Some(ctx.slice_len(sl));
+                        let sl = &scope[sl];
+                        scope.insert(*r, ctx.slice_len(sl));
                     }
                     crate::compiler::ssa::hlssa::OpCode::Select {
                         result: r,
@@ -397,11 +400,13 @@ impl SymbolicExecutor {
                         if_t,
                         if_f,
                     } => {
-                        let cond = scope[cond.0 as usize].as_ref().unwrap();
-                        let if_t = scope[if_t.0 as usize].as_ref().unwrap();
-                        let if_f = scope[if_f.0 as usize].as_ref().unwrap();
-                        scope[r.0 as usize] =
-                            Some(cond.select(if_t, if_f, &fn_type_info.get_value_type(*r), ctx));
+                        let cond = &scope[cond];
+                        let if_t = &scope[if_t];
+                        let if_f = &scope[if_f];
+                        scope.insert(
+                            *r,
+                            cond.select(if_t, if_f, &fn_type_info.get_value_type(*r), ctx),
+                        );
                     }
                     crate::compiler::ssa::hlssa::OpCode::ToBits {
                         result: r,
@@ -409,13 +414,11 @@ impl SymbolicExecutor {
                         endianness,
                         count: size,
                     } => {
-                        let a = scope[a.0 as usize].as_ref().unwrap();
-                        scope[r.0 as usize] = Some(a.to_bits(
-                            *endianness,
-                            *size,
-                            &fn_type_info.get_value_type(*r),
-                            ctx,
-                        ));
+                        let a = &scope[a];
+                        scope.insert(
+                            *r,
+                            a.to_bits(*endianness, *size, &fn_type_info.get_value_type(*r), ctx),
+                        );
                     }
                     crate::compiler::ssa::hlssa::OpCode::ToRadix {
                         result: r,
@@ -424,30 +427,33 @@ impl SymbolicExecutor {
                         endianness,
                         count: size,
                     } => {
-                        let a = scope[a.0 as usize].as_ref().unwrap();
+                        let a = &scope[a];
                         let radix = match radix {
                             Radix::Bytes => Radix::Bytes,
-                            Radix::Dyn(radix) => {
-                                Radix::Dyn(scope[radix.0 as usize].as_ref().unwrap().clone())
-                            }
+                            Radix::Dyn(radix) => Radix::Dyn(scope[radix].clone()),
                         };
-                        scope[r.0 as usize] = Some(a.to_radix(
-                            &radix,
-                            *endianness,
-                            *size,
-                            &fn_type_info.get_value_type(*r),
-                            ctx,
-                        ));
+                        scope.insert(
+                            *r,
+                            a.to_radix(
+                                &radix,
+                                *endianness,
+                                *size,
+                                &fn_type_info.get_value_type(*r),
+                                ctx,
+                            ),
+                        );
                     }
                     crate::compiler::ssa::hlssa::OpCode::WriteWitness {
                         result: r,
                         value: a,
                         ..
                     } => {
-                        let a = scope[a.0 as usize].as_ref().unwrap();
+                        let a = &scope[a];
                         if let Some(r) = r {
-                            scope[r.0 as usize] =
-                                Some(a.write_witness(Some(fn_type_info.get_value_type(*r)), ctx));
+                            scope.insert(
+                                *r,
+                                a.write_witness(Some(fn_type_info.get_value_type(*r)), ctx),
+                            );
                         } else {
                             a.write_witness(None, ctx);
                         }
@@ -456,16 +462,16 @@ impl SymbolicExecutor {
                         result: r,
                         result_type,
                     } => {
-                        scope[r.0 as usize] = Some(V::fresh_witness(result_type, ctx));
+                        scope.insert(*r, V::fresh_witness(result_type, ctx));
                     }
                     crate::compiler::ssa::hlssa::OpCode::Constrain { a, b, c } => {
-                        let a = scope[a.0 as usize].as_ref().unwrap();
-                        let b = scope[b.0 as usize].as_ref().unwrap();
-                        let c = scope[c.0 as usize].as_ref().unwrap();
+                        let a = &scope[a];
+                        let b = &scope[b];
+                        let c = &scope[c];
                         V::constrain(a, b, c, ctx);
                     }
                     crate::compiler::ssa::hlssa::OpCode::Assert { value } => {
-                        let v = scope[value.0 as usize].as_ref().unwrap();
+                        let v = &scope[value];
                         V::assert_bool(v, ctx);
                     }
                     crate::compiler::ssa::hlssa::OpCode::AssertCmp {
@@ -474,12 +480,12 @@ impl SymbolicExecutor {
                         rhs: b,
                     } => {
                         let lhs_type = fn_type_info.get_value_type(*a);
-                        let a = scope[a.0 as usize].as_ref().unwrap();
-                        let b = scope[b.0 as usize].as_ref().unwrap();
+                        let a = &scope[a];
+                        let b = &scope[b];
                         V::assert_cmp(*kind, a, b, lhs_type, ctx);
                     }
                     crate::compiler::ssa::hlssa::OpCode::MemOp { kind, value } => {
-                        let value = scope[value.0 as usize].as_ref().unwrap();
+                        let value = &scope[value];
                         value.mem_op(*kind, ctx);
                     }
                     crate::compiler::ssa::hlssa::OpCode::NextDCoeff { result: _a } => {
@@ -500,7 +506,7 @@ impl SymbolicExecutor {
                         todo!()
                     }
                     crate::compiler::ssa::hlssa::OpCode::Rangecheck { value: v, max_bits } => {
-                        let v = scope[v.0 as usize].as_ref().unwrap();
+                        let v = &scope[v];
                         v.rangecheck(*max_bits, ctx);
                     }
                     crate::compiler::ssa::hlssa::OpCode::ReadGlobal {
@@ -512,10 +518,10 @@ impl SymbolicExecutor {
                             .as_ref()
                             .expect("ReadGlobal: global slot not initialized")
                             .clone();
-                        scope[result.0 as usize] = Some(r);
+                        scope.insert(*result, r);
                     }
                     crate::compiler::ssa::hlssa::OpCode::InitGlobal { global, value } => {
-                        globals[*global] = Some(scope[value.0 as usize].as_ref().unwrap().clone());
+                        globals[*global] = Some(scope[value].clone());
                     }
                     crate::compiler::ssa::hlssa::OpCode::DropGlobal { global } => {
                         globals[*global] = None;
@@ -529,22 +535,17 @@ impl SymbolicExecutor {
                         let target = match target {
                             LookupTarget::Rangecheck(n) => LookupTarget::Rangecheck(*n),
                             LookupTarget::Spread(n) => LookupTarget::Spread(*n),
-                            LookupTarget::DynRangecheck(v) => LookupTarget::DynRangecheck(
-                                scope[v.0 as usize].as_ref().unwrap().clone(),
-                            ),
-                            LookupTarget::Array(arr) => {
-                                LookupTarget::Array(scope[arr.0 as usize].as_ref().unwrap().clone())
+                            LookupTarget::DynRangecheck(v) => {
+                                LookupTarget::DynRangecheck(scope[v].clone())
                             }
+                            LookupTarget::Array(arr) => LookupTarget::Array(scope[arr].clone()),
                         };
-                        let keys = keys
-                            .iter()
-                            .map(|id| scope[id.0 as usize].as_ref().unwrap().clone())
-                            .collect::<Vec<_>>();
+                        let keys = keys.iter().map(|id| scope[id].clone()).collect::<Vec<_>>();
                         let results = results
                             .iter()
-                            .map(|id| scope[id.0 as usize].as_ref().unwrap().clone())
+                            .map(|id| scope[id].clone())
                             .collect::<Vec<_>>();
-                        let flag_value = scope[flag.0 as usize].as_ref().unwrap().clone();
+                        let flag_value = scope[flag].clone();
                         ctx.lookup(target, keys, results, flag_value);
                     }
                     crate::compiler::ssa::hlssa::OpCode::DLookup {
@@ -556,22 +557,17 @@ impl SymbolicExecutor {
                         let target = match target {
                             LookupTarget::Rangecheck(n) => LookupTarget::Rangecheck(*n),
                             LookupTarget::Spread(n) => LookupTarget::Spread(*n),
-                            LookupTarget::DynRangecheck(v) => LookupTarget::DynRangecheck(
-                                scope[v.0 as usize].as_ref().unwrap().clone(),
-                            ),
-                            LookupTarget::Array(arr) => {
-                                LookupTarget::Array(scope[arr.0 as usize].as_ref().unwrap().clone())
+                            LookupTarget::DynRangecheck(v) => {
+                                LookupTarget::DynRangecheck(scope[v].clone())
                             }
+                            LookupTarget::Array(arr) => LookupTarget::Array(scope[arr].clone()),
                         };
-                        let keys = keys
-                            .iter()
-                            .map(|id| scope[id.0 as usize].as_ref().unwrap().clone())
-                            .collect::<Vec<_>>();
+                        let keys = keys.iter().map(|id| scope[id].clone()).collect::<Vec<_>>();
                         let results = results
                             .iter()
-                            .map(|id| scope[id.0 as usize].as_ref().unwrap().clone())
+                            .map(|id| scope[id].clone())
                             .collect::<Vec<_>>();
-                        let flag_value = scope[flag.0 as usize].as_ref().unwrap().clone();
+                        let flag_value = scope[flag].clone();
                         ctx.dlookup(target, keys, results, flag_value);
                     }
                     crate::compiler::ssa::hlssa::OpCode::TupleProj {
@@ -579,20 +575,16 @@ impl SymbolicExecutor {
                         tuple: a,
                         idx,
                     } => {
-                        let a = scope[a.0 as usize].as_ref().unwrap();
-                        scope[r.0 as usize] =
-                            Some(a.tuple_get(*idx, &fn_type_info.get_value_type(*r), ctx));
+                        let a = &scope[a];
+                        scope.insert(*r, a.tuple_get(*idx, &fn_type_info.get_value_type(*r), ctx));
                     }
                     crate::compiler::ssa::hlssa::OpCode::MkTuple {
                         result,
                         elems,
                         element_types,
                     } => {
-                        let elems = elems
-                            .iter()
-                            .map(|id| scope[id.0 as usize].as_ref().unwrap().clone())
-                            .collect::<Vec<_>>();
-                        scope[result.0 as usize] = Some(V::mk_tuple(elems, ctx, element_types));
+                        let elems = elems.iter().map(|id| scope[id].clone()).collect::<Vec<_>>();
+                        scope.insert(*result, V::mk_tuple(elems, ctx, element_types));
                     }
                     crate::compiler::ssa::hlssa::OpCode::Todo {
                         payload,
@@ -609,7 +601,7 @@ impl SymbolicExecutor {
                             );
                         }
                         for (result_id, result_value) in results.iter().zip(result_values.iter()) {
-                            scope[result_id.0 as usize] = Some(result_value.clone());
+                            scope.insert(*result_id, result_value.clone());
                         }
                     }
                     crate::compiler::ssa::hlssa::OpCode::Spread {
@@ -617,8 +609,8 @@ impl SymbolicExecutor {
                         value,
                         bits,
                     } => {
-                        let val = scope[value.0 as usize].as_ref().unwrap();
-                        scope[result.0 as usize] = Some(val.spread(*bits, ctx));
+                        let val = &scope[value];
+                        scope.insert(*result, val.spread(*bits, ctx));
                     }
                     crate::compiler::ssa::hlssa::OpCode::Unspread {
                         result_odd,
@@ -626,35 +618,32 @@ impl SymbolicExecutor {
                         value,
                         bits,
                     } => {
-                        let val = scope[value.0 as usize].as_ref().unwrap();
+                        let val = &scope[value];
                         let (odd_val, even_val) = val.unspread(*bits, ctx);
-                        scope[result_odd.0 as usize] = Some(odd_val);
-                        scope[result_even.0 as usize] = Some(even_val);
+                        scope.insert(*result_odd, odd_val);
+                        scope.insert(*result_even, even_val);
                     }
                     crate::compiler::ssa::hlssa::OpCode::ValueOf { result, value } => {
-                        let val = scope[value.0 as usize].clone().unwrap();
-                        scope[result.0 as usize] = Some(val.value_of(ctx));
+                        let val = scope[value].clone();
+                        scope.insert(*result, val.value_of(ctx));
                     }
                     crate::compiler::ssa::hlssa::OpCode::Const { result, value } => match value {
                         crate::compiler::ssa::hlssa::ConstValue::U(size, val) => {
-                            scope[result.0 as usize] = Some(V::of_u(*size, *val, ctx));
+                            scope.insert(*result, V::of_u(*size, *val, ctx));
                         }
                         crate::compiler::ssa::hlssa::ConstValue::I(size, val) => {
-                            scope[result.0 as usize] = Some(V::of_i(*size, *val, ctx));
+                            scope.insert(*result, V::of_i(*size, *val, ctx));
                         }
                         crate::compiler::ssa::hlssa::ConstValue::Field(val) => {
-                            scope[result.0 as usize] = Some(V::of_field(*val, ctx));
+                            scope.insert(*result, V::of_field(*val, ctx));
                         }
                         crate::compiler::ssa::hlssa::ConstValue::FnPtr(_) => {
                             todo!("FnPtrConst in symbolic executor");
                         }
                     },
                     crate::compiler::ssa::hlssa::OpCode::Guard { condition, inner } => {
-                        let condition_val = scope[condition.0 as usize].as_ref().unwrap();
-                        let inputs: Vec<&V> = inner
-                            .get_inputs()
-                            .map(|id| scope[id.0 as usize].as_ref().unwrap())
-                            .collect();
+                        let condition_val = &scope[condition];
+                        let inputs: Vec<&V> = inner.get_inputs().map(|id| &scope[id]).collect();
                         let result_ids: Vec<_> = inner.get_results().cloned().collect();
                         let result_types: Vec<&Type> = result_ids
                             .iter()
@@ -662,7 +651,7 @@ impl SymbolicExecutor {
                             .collect();
                         let results = ctx.on_guard(inner, condition_val, inputs, result_types);
                         for (result_id, result_val) in result_ids.iter().zip(results.into_iter()) {
-                            scope[result_id.0 as usize] = Some(result_val);
+                            scope.insert(*result_id, result_val);
                         }
                     }
                 }
@@ -672,7 +661,7 @@ impl SymbolicExecutor {
                 Terminator::Return(returns) => {
                     let mut outputs = returns
                         .iter()
-                        .map(|id| scope[id.0 as usize].as_ref().unwrap().clone())
+                        .map(|id| scope[id].clone())
                         .collect::<Vec<_>>();
                     ctx.on_return(&mut outputs, &fn_body.get_returns());
                     return outputs;
@@ -680,7 +669,7 @@ impl SymbolicExecutor {
                 Terminator::Jmp(target, params) => {
                     let mut params = params
                         .iter()
-                        .map(|id| scope[id.0 as usize].as_ref().unwrap().clone())
+                        .map(|id| scope[id].clone())
                         .collect::<Vec<_>>();
                     let target_block = fn_body.get_block(*target);
                     let target_params = target_block.get_parameter_values();
@@ -693,12 +682,12 @@ impl SymbolicExecutor {
                             .collect::<Vec<_>>(),
                     );
                     for (i, val) in target_params.zip(params.into_iter()) {
-                        scope[i.0 as usize] = Some(val);
+                        scope.insert(*i, val);
                     }
                     current = Some(target_block);
                 }
                 Terminator::JmpIf(cond, if_true, if_false) => {
-                    let cond = scope[cond.0 as usize].as_ref().unwrap();
+                    let cond = &scope[cond];
                     if cond.expect_constant_bool(ctx) {
                         current = Some(fn_body.get_block(*if_true));
                     } else {

--- a/compiler/src/compiler/lowering/mod.rs
+++ b/compiler/src/compiler/lowering/mod.rs
@@ -16,7 +16,7 @@ use crate::compiler::ssa::{
     FunctionId,
     hlssa::{
         HLFunction, HLSSA,
-        builder::{HLEmitter, HLFunctionBuilder},
+        builder::{HLEmitter, HLFunctionBuilder, HLSSABuilder},
     },
 };
 
@@ -97,17 +97,20 @@ impl SSAConverter {
             if ast_func.unconstrained {
                 // Natively unconstrained: convert once with is_unconstrained=true
                 let ssa_func_id = *self.constrained_mapper.get(&ast_func.id).unwrap();
-                let converted = self.convert_function(ast_func, &self.unconstrained_mapper, true);
+                let converted =
+                    self.convert_function(&mut ssa, ast_func, &self.unconstrained_mapper, true);
                 *ssa.get_function_mut(ssa_func_id) = converted;
             } else {
                 // Constrained version
                 let constrained_id = *self.constrained_mapper.get(&ast_func.id).unwrap();
-                let converted = self.convert_function(ast_func, &self.constrained_mapper, false);
+                let converted =
+                    self.convert_function(&mut ssa, ast_func, &self.constrained_mapper, false);
                 *ssa.get_function_mut(constrained_id) = converted;
 
                 // Unconstrained variant (for calls from unconstrained context)
                 let unconstrained_id = *self.unconstrained_mapper.get(&ast_func.id).unwrap();
-                let converted = self.convert_function(ast_func, &self.unconstrained_mapper, true);
+                let converted =
+                    self.convert_function(&mut ssa, ast_func, &self.unconstrained_mapper, true);
                 *ssa.get_function_mut(unconstrained_id) = converted;
             }
         }
@@ -245,11 +248,9 @@ impl SSAConverter {
 
         // Build init function
         let init_fn_id = ssa.add_function("globals_init".to_string());
-        {
-            let init_fn = ssa.get_function_mut(init_fn_id);
-            let entry = init_fn.get_entry_id();
-
-            let mut b = HLFunctionBuilder::new(init_fn);
+        let mut sb = HLSSABuilder::new(ssa);
+        sb.modify_function(init_fn_id, |b| {
+            let entry = b.function.get_entry_id();
 
             // We need an ExpressionConverter to evaluate initializer expressions
             let mut expr_converter = ExpressionConverter::new_with_globals(
@@ -263,9 +264,7 @@ impl SSAConverter {
 
             for gid in &ordered_ids {
                 let (_name, _typ, init_expr) = &program.globals[gid];
-                let value = expr_converter
-                    .convert_expression(init_expr, &mut b)
-                    .unwrap();
+                let value = expr_converter.convert_expression(init_expr, b).unwrap();
                 let idx = self.global_slots[gid];
                 b.block(expr_converter.current_block())
                     .init_global(idx, value);
@@ -273,21 +272,19 @@ impl SSAConverter {
 
             b.block(expr_converter.current_block())
                 .terminate_return(vec![]);
-        }
+        });
 
         // Build deinit function
-        let deinit_fn_id = ssa.add_function("globals_deinit".to_string());
-        {
-            let deinit_fn = ssa.get_function_mut(deinit_fn_id);
-            let entry = deinit_fn.get_entry_id();
-            let mut b = HLFunctionBuilder::new(deinit_fn);
+        let deinit_fn_id = sb.ssa().add_function("globals_deinit".to_string());
+        sb.modify_function(deinit_fn_id, |b| {
+            let entry = b.function.get_entry_id();
             for (i, typ) in global_types.iter().enumerate() {
                 if typ.is_heap_allocated() {
                     b.block(entry).drop_global(i);
                 }
             }
             b.block(entry).terminate_return(vec![]);
-        }
+        });
 
         ssa.set_global_types(global_types);
         ssa.set_globals_init_fn(init_fn_id);
@@ -297,6 +294,7 @@ impl SSAConverter {
     /// Convert a single function to SSA.
     fn convert_function(
         &self,
+        ssa: &mut HLSSA,
         ast_func: &AstFunction,
         function_mapper: &HashMap<AstFuncId, FunctionId>,
         in_unconstrained: bool,
@@ -318,7 +316,7 @@ impl SSAConverter {
             function.add_return_type(return_type);
         }
 
-        let mut b = HLFunctionBuilder::new(&mut function);
+        let mut b = HLFunctionBuilder::new(&mut function, ssa);
 
         // Create expression converter
         let mut expr_converter = ExpressionConverter::new_with_globals(

--- a/compiler/src/compiler/pass_manager.rs
+++ b/compiler/src/compiler/pass_manager.rs
@@ -1,13 +1,14 @@
 use std::{
     any::{Any, TypeId},
     collections::HashMap,
+    fmt::Debug,
     fs,
     path::PathBuf,
 };
 
 use crate::compiler::ssa::{
     DefaultSSAAnnotator, Instruction, SSA, SSAType,
-    hlssa::{OpCode, Type},
+    hlssa::{Constants, OpCode, Type},
 };
 
 // ---------------------------------------------------------------------------
@@ -23,18 +24,19 @@ pub struct AnalysisId {
 }
 
 impl AnalysisId {
-    pub fn of<A: Analysis<Op, Ty>, Op: Instruction, Ty: SSAType>() -> Self {
+    pub fn of<A: Analysis<Op, Ty, C>, Op: Instruction, Ty: SSAType, C: Clone + Debug + 'static>()
+    -> Self {
         Self {
             type_id: TypeId::of::<A>(),
             type_name: std::any::type_name::<A>(),
-            dependencies: <A as Analysis<Op, Ty>>::dependencies,
+            dependencies: <A as Analysis<Op, Ty, C>>::dependencies,
             compute_and_store: |ssa_any, store| {
                 if !store.contains_type(TypeId::of::<A>()) {
-                    let ssa: &SSA<Op, Ty> = ssa_any
-                        .downcast_ref::<SSA<Op, Ty>>()
+                    let ssa: &SSA<Op, Ty, C> = ssa_any
+                        .downcast_ref::<SSA<Op, Ty, C>>()
                         .expect("AnalysisId::compute_and_store: SSA downcast failed");
-                    let val = <A as Analysis<Op, Ty>>::compute(ssa, store);
-                    let dep_ids = <A as Analysis<Op, Ty>>::dependencies()
+                    let val = <A as Analysis<Op, Ty, C>>::compute(ssa, store);
+                    let dep_ids = <A as Analysis<Op, Ty, C>>::dependencies()
                         .iter()
                         .map(|d| d.type_id)
                         .collect();
@@ -68,12 +70,17 @@ impl std::fmt::Debug for AnalysisId {
 // Analysis trait
 // ---------------------------------------------------------------------------
 
-pub trait Analysis<Op: Instruction = OpCode, Ty: SSAType = Type>: Any + 'static {
+pub trait Analysis<
+    Op: Instruction = OpCode,
+    Ty: SSAType = Type,
+    C: Clone + Debug + 'static = Constants,
+>: Any + 'static
+{
     fn id() -> AnalysisId
     where
         Self: Sized,
     {
-        AnalysisId::of::<Self, Op, Ty>()
+        AnalysisId::of::<Self, Op, Ty, C>()
     }
 
     fn dependencies() -> Vec<AnalysisId>
@@ -83,7 +90,7 @@ pub trait Analysis<Op: Instruction = OpCode, Ty: SSAType = Type>: Any + 'static 
         vec![]
     }
 
-    fn compute(ssa: &SSA<Op, Ty>, store: &AnalysisStore) -> Self
+    fn compute(ssa: &SSA<Op, Ty, C>, store: &AnalysisStore) -> Self
     where
         Self: Sized;
 }
@@ -165,12 +172,13 @@ impl AnalysisStore {
 // Pass trait — parametric
 // ---------------------------------------------------------------------------
 
-pub trait Pass<Op: Instruction = OpCode, Ty: SSAType = Type> {
+pub trait Pass<Op: Instruction = OpCode, Ty: SSAType = Type, C: Clone + Debug + 'static = Constants>
+{
     fn name(&self) -> &'static str;
     fn needs(&self) -> Vec<AnalysisId> {
         vec![]
     }
-    fn run(&self, ssa: &mut SSA<Op, Ty>, store: &AnalysisStore);
+    fn run(&self, ssa: &mut SSA<Op, Ty, C>, store: &AnalysisStore);
     fn preserves(&self) -> Vec<AnalysisId> {
         vec![]
     }
@@ -209,16 +217,20 @@ fn topo_sort(roots: Vec<AnalysisId>, store: &AnalysisStore) -> Vec<AnalysisId> {
 // PassManager — parametric
 // ---------------------------------------------------------------------------
 
-pub struct PassManager<Op: Instruction = OpCode, Ty: SSAType = Type> {
-    passes: Vec<Box<dyn Pass<Op, Ty>>>,
+pub struct PassManager<
+    Op: Instruction = OpCode,
+    Ty: SSAType = Type,
+    C: Clone + Debug + 'static = Constants,
+> {
+    passes: Vec<Box<dyn Pass<Op, Ty, C>>>,
     analyses: AnalysisStore,
     draw_cfg: bool,
     debug_output_dir: Option<PathBuf>,
     phase_label: String,
 }
 
-impl<Op: Instruction, Ty: SSAType> PassManager<Op, Ty> {
-    pub fn new(phase_label: String, draw_cfg: bool, passes: Vec<Box<dyn Pass<Op, Ty>>>) -> Self {
+impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + 'static> PassManager<Op, Ty, C> {
+    pub fn new(phase_label: String, draw_cfg: bool, passes: Vec<Box<dyn Pass<Op, Ty, C>>>) -> Self {
         Self {
             passes,
             analyses: AnalysisStore::new(),
@@ -237,7 +249,7 @@ impl<Op: Instruction, Ty: SSAType> PassManager<Op, Ty> {
     }
 
     #[tracing::instrument(skip_all, name = "PassManager::run", fields(phase = %self.phase_label))]
-    pub fn run(&mut self, ssa: &mut SSA<Op, Ty>) {
+    pub fn run(&mut self, ssa: &mut SSA<Op, Ty, C>) {
         if let Some(debug_output_dir) = &self.debug_output_dir {
             if debug_output_dir.exists() {
                 fs::remove_dir_all(debug_output_dir).unwrap();
@@ -254,7 +266,12 @@ impl<Op: Instruction, Ty: SSAType> PassManager<Op, Ty> {
     }
 
     #[tracing::instrument(skip_all, fields(pass = %pass.name()))]
-    fn run_pass(&mut self, ssa: &mut SSA<Op, Ty>, pass: &dyn Pass<Op, Ty>, pass_index: usize) {
+    fn run_pass(
+        &mut self,
+        ssa: &mut SSA<Op, Ty, C>,
+        pass: &dyn Pass<Op, Ty, C>,
+        pass_index: usize,
+    ) {
         // Ensure all needed analyses are computed (in dependency order)
         let ordered = topo_sort(pass.needs(), &self.analyses);
         for id in ordered {
@@ -266,7 +283,7 @@ impl<Op: Instruction, Ty: SSAType> PassManager<Op, Ty> {
         self.analyses.apply_preserved(&pass.preserves());
     }
 
-    fn output_debug_info(&mut self, ssa: &SSA<Op, Ty>, pass_index: usize, pass_name: &str) {
+    fn output_debug_info(&mut self, ssa: &SSA<Op, Ty, C>, pass_index: usize, pass_name: &str) {
         use crate::compiler::analysis::flow_analysis::FlowAnalysis;
 
         let Some(debug_output_dir) = &self.debug_output_dir else {
@@ -290,7 +307,7 @@ impl<Op: Instruction, Ty: SSAType> PassManager<Op, Ty> {
         }
     }
 
-    fn output_final_debug_info(&mut self, ssa: &mut SSA<Op, Ty>) {
+    fn output_final_debug_info(&mut self, ssa: &mut SSA<Op, Ty, C>) {
         use crate::compiler::analysis::flow_analysis::FlowAnalysis;
 
         if self.analyses.try_get::<FlowAnalysis>().is_none() {

--- a/compiler/src/compiler/passes/condition_propagation.rs
+++ b/compiler/src/compiler/passes/condition_propagation.rs
@@ -6,7 +6,7 @@ use crate::compiler::{
     passes::fix_double_jumps::ValueReplacements,
     ssa::{
         BlockId, Terminator, ValueId,
-        hlssa::{ConstValue, HLSSA, OpCode},
+        hlssa::{ConstValue, HLSSA, OpCode, builder::HLSSABuilder},
     },
 };
 
@@ -36,44 +36,47 @@ impl ConditionPropagation {
     }
 
     pub fn do_run(&self, ssa: &mut HLSSA, cfg: &FlowAnalysis) {
-        for (function_id, function) in ssa.iter_functions_mut() {
-            let mut replaces: Vec<(BlockId, ValueId, bool)> = vec![];
+        let fids: Vec<_> = ssa.get_function_ids().collect();
+        let mut sb = HLSSABuilder::new(ssa);
+        for function_id in fids {
+            let func_cfg = cfg.get_function_cfg(function_id);
+            sb.modify_function(function_id, |fb| {
+                let mut replaces: Vec<(BlockId, ValueId, bool)> = vec![];
 
-            for (_, block) in function.get_blocks() {
-                if let Some(Terminator::JmpIf(cond, then_b, else_b)) = block.get_terminator() {
-                    replaces.push((*then_b, *cond, true));
-                    replaces.push((*else_b, *cond, false));
-                }
-            }
-
-            let cfg = cfg.get_function_cfg(*function_id);
-
-            for block_id in cfg.get_domination_pre_order() {
-                let mut replacements = ValueReplacements::new();
-                let replaces = replaces
-                    .iter()
-                    .filter(|(cond_block, _, _)| cfg.dominates(*cond_block, block_id));
-
-                let mut const_opcodes = Vec::new();
-                for (_, vid, value) in replaces {
-                    let const_id = function.fresh_value();
-                    const_opcodes.push(OpCode::Const {
-                        result: const_id,
-                        value: ConstValue::U(1, if *value { 1 } else { 0 }),
-                    });
-                    replacements.insert(*vid, const_id);
+                for (_, block) in fb.function.get_blocks() {
+                    if let Some(Terminator::JmpIf(cond, then_b, else_b)) = block.get_terminator() {
+                        replaces.push((*then_b, *cond, true));
+                        replaces.push((*else_b, *cond, false));
+                    }
                 }
 
-                let block = function.get_block_mut(block_id);
-                let instructions = block.take_instructions();
-                let mut new_instructions = const_opcodes;
-                new_instructions.extend(instructions.iter().cloned());
-                for instruction in new_instructions.iter_mut() {
-                    replacements.replace_inputs(instruction);
+                for block_id in func_cfg.get_domination_pre_order() {
+                    let mut replacements = ValueReplacements::new();
+                    let dominated = replaces
+                        .iter()
+                        .filter(|(cond_block, _, _)| func_cfg.dominates(*cond_block, block_id));
+
+                    let mut const_opcodes = Vec::new();
+                    for (_, vid, value) in dominated {
+                        let const_id = fb.ssa.fresh_value();
+                        const_opcodes.push(OpCode::Const {
+                            result: const_id,
+                            value: ConstValue::U(1, if *value { 1 } else { 0 }),
+                        });
+                        replacements.insert(*vid, const_id);
+                    }
+
+                    let block = fb.function.get_block_mut(block_id);
+                    let instructions = block.take_instructions();
+                    let mut new_instructions = const_opcodes;
+                    new_instructions.extend(instructions.iter().cloned());
+                    for instruction in new_instructions.iter_mut() {
+                        replacements.replace_inputs(instruction);
+                    }
+                    block.put_instructions(new_instructions);
+                    replacements.replace_terminator(block.get_terminator_mut());
                 }
-                block.put_instructions(new_instructions);
-                replacements.replace_terminator(block.get_terminator_mut());
-            }
+            });
         }
     }
 }

--- a/compiler/src/compiler/passes/defunctionalize.rs
+++ b/compiler/src/compiler/passes/defunctionalize.rs
@@ -17,7 +17,7 @@ use crate::compiler::{
         BlockId, FunctionId, Terminator, ValueId,
         hlssa::{
             CallTarget, ConstValue, HLSSA, OpCode, Type, TypeExpr,
-            builder::{HLEmitter, HLFunctionBuilder},
+            builder::{HLEmitter, HLSSABuilder},
         },
     },
 };
@@ -548,75 +548,75 @@ fn build_dispatch_function(
     variants: &[FunctionId],
 ) -> FunctionId {
     let dispatch_fn_id = ssa.add_function(format!("apply_dispatch@{}", counter));
-    let func = ssa.get_function_mut(dispatch_fn_id);
-
-    for ret_type in return_types {
-        func.add_return_type(ret_type.clone());
-    }
-
-    let entry_block = func.get_entry_id();
-    let mut b = HLFunctionBuilder::new(func);
-
-    let fn_id_param;
-    let mut forwarded_params: Vec<ValueId> = Vec::new();
-    {
-        let mut entry = b.block(entry_block);
-        fn_id_param = entry.add_parameter(Type::u32());
-        for param_type in param_types {
-            forwarded_params.push(entry.add_parameter(param_type.clone()));
-        }
-    }
-
-    let mut merge_results: Vec<ValueId> = Vec::new();
-    let merge_block = b.add_block(|merge| {
+    let mut sb = HLSSABuilder::new(ssa);
+    sb.modify_function(dispatch_fn_id, |b| {
         for ret_type in return_types {
-            merge_results.push(merge.add_parameter(ret_type.clone()));
+            b.function.add_return_type(ret_type.clone());
         }
-        merge.terminate_return(merge_results.clone());
-    });
 
-    let mut current_block = entry_block;
+        let entry_block = b.function.get_entry_id();
 
-    if variants.len() == 1 {
-        let variant_id = variants[0];
-        let mut cb = b.block(current_block);
-        let const_val = cb.u_const(32, variant_id.0 as u128);
-        cb.assert_eq(fn_id_param, const_val);
-        let call_results = cb.call(variant_id, forwarded_params.clone(), return_types.len());
-        cb.terminate_jmp(merge_block, call_results);
-    } else {
-        for (i, &variant_id) in variants.iter().enumerate() {
-            let is_last = i == variants.len() - 1;
+        let fn_id_param;
+        let mut forwarded_params: Vec<ValueId> = Vec::new();
+        {
+            let mut entry = b.block(entry_block);
+            fn_id_param = entry.add_parameter(Type::u32());
+            for param_type in param_types {
+                forwarded_params.push(entry.add_parameter(param_type.clone()));
+            }
+        }
 
-            if is_last {
-                let mut cb = b.block(current_block);
-                let const_val = cb.u_const(32, variant_id.0 as u128);
-                cb.assert_eq(fn_id_param, const_val);
-                let call_results =
-                    cb.call(variant_id, forwarded_params.clone(), return_types.len());
-                cb.terminate_jmp(merge_block, call_results);
-            } else {
-                let call_block = b.add_block(|_| {});
-                let next_check_block = b.add_block(|_| {});
+        let mut merge_results: Vec<ValueId> = Vec::new();
+        let merge_block = b.add_block(|merge| {
+            for ret_type in return_types {
+                merge_results.push(merge.add_parameter(ret_type.clone()));
+            }
+            merge.terminate_return(merge_results.clone());
+        });
 
-                {
+        let mut current_block = entry_block;
+
+        if variants.len() == 1 {
+            let variant_id = variants[0];
+            let mut cb = b.block(current_block);
+            let const_val = cb.u_const(32, variant_id.0 as u128);
+            cb.assert_eq(fn_id_param, const_val);
+            let call_results = cb.call(variant_id, forwarded_params.clone(), return_types.len());
+            cb.terminate_jmp(merge_block, call_results);
+        } else {
+            for (i, &variant_id) in variants.iter().enumerate() {
+                let is_last = i == variants.len() - 1;
+
+                if is_last {
                     let mut cb = b.block(current_block);
                     let const_val = cb.u_const(32, variant_id.0 as u128);
-                    let eq_result = cb.eq(fn_id_param, const_val);
-                    cb.terminate_jmp_if(eq_result, call_block, next_check_block);
-                }
-
-                {
-                    let mut cb = b.block(call_block);
+                    cb.assert_eq(fn_id_param, const_val);
                     let call_results =
                         cb.call(variant_id, forwarded_params.clone(), return_types.len());
                     cb.terminate_jmp(merge_block, call_results);
-                }
+                } else {
+                    let call_block = b.add_block(|_| {});
+                    let next_check_block = b.add_block(|_| {});
 
-                current_block = next_check_block;
+                    {
+                        let mut cb = b.block(current_block);
+                        let const_val = cb.u_const(32, variant_id.0 as u128);
+                        let eq_result = cb.eq(fn_id_param, const_val);
+                        cb.terminate_jmp_if(eq_result, call_block, next_check_block);
+                    }
+
+                    {
+                        let mut cb = b.block(call_block);
+                        let call_results =
+                            cb.call(variant_id, forwarded_params.clone(), return_types.len());
+                        cb.terminate_jmp(merge_block, call_results);
+                    }
+
+                    current_block = next_check_block;
+                }
             }
         }
-    }
+    });
 
     dispatch_fn_id
 }

--- a/compiler/src/compiler/passes/explicit_witness.rs
+++ b/compiler/src/compiler/passes/explicit_witness.rs
@@ -21,7 +21,7 @@ use crate::compiler::{
         hlssa::{
             BinaryArithOpKind, CastTarget, CmpKind, Endianness, HLBlock, HLSSA, LookupTarget,
             OpCode, Radix, SequenceTargetType, Type, TypeExpr,
-            builder::{HLEmitter, HLInstrBuilder},
+            builder::{HLEmitter, HLInstrBuilder, HLSSABuilder},
         },
     },
 };
@@ -115,25 +115,30 @@ impl ExplicitWitness {
     }
 
     pub fn do_run(&self, ssa: &mut HLSSA, type_info: &TypeInfo, value_ranges: &ValueRanges) {
-        for (function_id, function) in ssa.iter_functions_mut() {
-            let function_type_info = type_info.get_function(*function_id);
-            let function_value_ranges = value_ranges.get_function(*function_id);
-            let mut new_blocks = HashMap::<BlockId, HLBlock>::new();
-            for (bid, mut block) in function.take_blocks().into_iter() {
-                let mut new_instructions = Vec::new();
-                for instruction in block.take_instructions().into_iter() {
-                    let b = &mut HLInstrBuilder::new(function, &mut new_instructions);
-                    self.process_instruction(
-                        b,
-                        function_type_info,
-                        function_value_ranges,
-                        instruction,
-                    );
+        let fids: Vec<_> = ssa.get_function_ids().collect();
+        let mut sb = HLSSABuilder::new(ssa);
+        for function_id in fids {
+            let function_type_info = type_info.get_function(function_id);
+            let function_value_ranges = value_ranges.get_function(function_id);
+            sb.modify_function(function_id, |fb| {
+                let mut new_blocks = HashMap::<BlockId, HLBlock>::new();
+                for (bid, mut block) in fb.function.take_blocks().into_iter() {
+                    let mut new_instructions = Vec::new();
+                    for instruction in block.take_instructions().into_iter() {
+                        let b =
+                            &mut HLInstrBuilder::new(fb.function, fb.ssa, &mut new_instructions);
+                        self.process_instruction(
+                            b,
+                            function_type_info,
+                            function_value_ranges,
+                            instruction,
+                        );
+                    }
+                    block.put_instructions(new_instructions);
+                    new_blocks.insert(bid, block);
                 }
-                block.put_instructions(new_instructions);
-                new_blocks.insert(bid, block);
-            }
-            function.put_blocks(new_blocks);
+                fb.function.put_blocks(new_blocks);
+            });
         }
     }
 

--- a/compiler/src/compiler/passes/lower_guards.rs
+++ b/compiler/src/compiler/passes/lower_guards.rs
@@ -11,8 +11,8 @@ use crate::compiler::{
     ssa::{
         BlockId, Instruction, Terminator,
         hlssa::{
-            HLFunction, HLSSA, OpCode,
-            builder::{HLBlockEmitter, HLEmitter},
+            HLSSA, OpCode,
+            builder::{HLEmitter, HLFunctionBuilder, HLSSABuilder},
         },
     },
 };
@@ -44,45 +44,46 @@ impl LowerGuards {
 
     fn do_run(&self, ssa: &mut HLSSA, type_info: &TypeInfo) {
         let function_ids: Vec<_> = ssa.get_function_ids().collect();
+        let mut sb = HLSSABuilder::new(ssa);
         for function_id in function_ids {
-            let mut function = ssa.take_function(function_id);
             let func_types = type_info.get_function(function_id);
-            self.run_function(&mut function, func_types);
-            ssa.put_function(function_id, function);
+            sb.modify_function(function_id, |fb| {
+                self.run_function(fb, func_types);
+            });
         }
     }
 
     fn run_function(
         &self,
-        function: &mut HLFunction,
+        fb: &mut HLFunctionBuilder<'_>,
         type_info: &crate::compiler::analysis::types::FunctionTypeInfo,
     ) {
         // Process blocks iteratively. We collect block IDs upfront, but new blocks
         // created during lowering don't need processing (they contain no Guards/Selects).
-        let block_ids: Vec<_> = function.get_blocks().map(|(bid, _)| *bid).collect();
+        let block_ids: Vec<_> = fb.function.get_blocks().map(|(bid, _)| *bid).collect();
 
         for block_id in block_ids {
-            self.lower_block(function, block_id, type_info);
+            self.lower_block(fb, block_id, type_info);
         }
     }
 
     fn lower_block(
         &self,
-        function: &mut HLFunction,
+        fb: &mut HLFunctionBuilder<'_>,
         block_id: BlockId,
         type_info: &crate::compiler::analysis::types::FunctionTypeInfo,
     ) {
         // Extract instructions and terminator, then put the empty block back
-        // so HLBlockEmitter can take it.
+        // so the block emitter can take it.
         let (instructions, terminator) = {
-            let mut block = function.take_block(block_id);
+            let mut block = fb.function.take_block(block_id);
             let instructions = block.take_instructions();
             let terminator = block.take_terminator();
-            function.put_block(block_id, block);
+            fb.function.put_block(block_id, block);
             (instructions, terminator)
         };
 
-        let mut emitter = HLBlockEmitter::new(function, block_id);
+        let mut emitter = fb.block(block_id);
 
         for instruction in instructions {
             match instruction {

--- a/compiler/src/compiler/passes/lower_pure_guards.rs
+++ b/compiler/src/compiler/passes/lower_pure_guards.rs
@@ -28,8 +28,8 @@ use crate::compiler::{
     ssa::{
         BlockId, Instruction, ValueId,
         hlssa::{
-            BinaryArithOpKind, CastTarget, CmpKind, HLFunction, HLSSA, OpCode, Type, TypeExpr,
-            builder::{HLBlockEmitter, HLEmitter},
+            BinaryArithOpKind, CastTarget, CmpKind, HLSSA, OpCode, Type, TypeExpr,
+            builder::{HLBlockEmitter, HLEmitter, HLFunctionBuilder, HLSSABuilder},
         },
     },
 };
@@ -61,40 +61,41 @@ impl LowerPureGuards {
 
     fn do_run(&self, ssa: &mut HLSSA, type_info: &TypeInfo) {
         let function_ids: Vec<_> = ssa.get_function_ids().collect();
+        let mut sb = HLSSABuilder::new(ssa);
         for function_id in &function_ids {
-            let mut function = ssa.take_function(*function_id);
             let func_types = type_info.get_function(*function_id);
-            self.run_function(&mut function, func_types);
-            ssa.put_function(*function_id, function);
+            sb.modify_function(*function_id, |fb| {
+                self.run_function(fb, func_types);
+            });
         }
     }
 
     fn run_function(
         &self,
-        function: &mut HLFunction,
+        fb: &mut HLFunctionBuilder<'_>,
         type_info: &crate::compiler::analysis::types::FunctionTypeInfo,
     ) {
-        let block_ids: Vec<_> = function.get_blocks().map(|(bid, _)| *bid).collect();
+        let block_ids: Vec<_> = fb.function.get_blocks().map(|(bid, _)| *bid).collect();
         for block_id in block_ids {
-            self.lower_block(function, block_id, type_info);
+            self.lower_block(fb, block_id, type_info);
         }
     }
 
     fn lower_block(
         &self,
-        function: &mut HLFunction,
+        fb: &mut HLFunctionBuilder<'_>,
         block_id: BlockId,
         type_info: &crate::compiler::analysis::types::FunctionTypeInfo,
     ) {
         let (instructions, terminator) = {
-            let mut block = function.take_block(block_id);
+            let mut block = fb.function.take_block(block_id);
             let instructions = block.take_instructions();
             let terminator = block.take_terminator();
-            function.put_block(block_id, block);
+            fb.function.put_block(block_id, block);
             (instructions, terminator)
         };
 
-        let mut emitter = HLBlockEmitter::new(function, block_id);
+        let mut emitter = fb.block(block_id);
 
         for instruction in instructions {
             match instruction {

--- a/compiler/src/compiler/passes/mem2reg.rs
+++ b/compiler/src/compiler/passes/mem2reg.rs
@@ -16,7 +16,10 @@ use crate::compiler::{
     pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
     ssa::{
         BlockId, Terminator, ValueId,
-        hlssa::{HLFunction, HLSSA, OpCode, Type, TypeExpr},
+        hlssa::{
+            HLFunction, HLSSA, OpCode, Type, TypeExpr,
+            builder::{HLFunctionBuilder, HLSSABuilder},
+        },
     },
 };
 
@@ -42,29 +45,35 @@ impl Mem2Reg {
     }
 
     pub fn do_run(&self, ssa: &mut HLSSA, cfg: &FlowAnalysis, type_info: &TypeInfo) {
-        for (function_id, function) in ssa.iter_functions_mut() {
-            let function_type_info = type_info.get_function(*function_id);
-            if self.escape_safe(function, function_type_info) {
-                self.run_function(
-                    function,
-                    cfg.get_function_cfg(*function_id),
-                    function_type_info,
-                );
-            } else {
-                debug!(
-                    "Skipping mem2reg for function: {:?} because it failed escape analysis",
-                    function.get_name()
-                );
-            }
+        let fids: Vec<_> = ssa.get_function_ids().collect();
+        let mut sb = HLSSABuilder::new(ssa);
+        for function_id in fids {
+            let function_type_info = type_info.get_function(function_id);
+            let func_cfg = cfg.get_function_cfg(function_id);
+            sb.modify_function(function_id, |fb| {
+                if self.escape_safe(fb.function, function_type_info) {
+                    self.run_function(fb, func_cfg, function_type_info);
+                } else {
+                    debug!(
+                        "Skipping mem2reg for function: {:?} because it failed escape analysis",
+                        fb.function.get_name()
+                    );
+                }
+            });
         }
     }
 
-    #[instrument(skip_all, level = Level::DEBUG, fields(function = %function.get_name()))]
-    fn run_function(&self, function: &mut HLFunction, cfg: &CFG, type_info: &FunctionTypeInfo) {
-        let (writes, defs) = self.find_pointer_writes_and_defs(function);
+    #[instrument(skip_all, level = Level::DEBUG, fields(function = %fb.function.get_name()))]
+    fn run_function(
+        &self,
+        fb: &mut HLFunctionBuilder<'_>,
+        cfg: &CFG,
+        type_info: &FunctionTypeInfo,
+    ) {
+        let (writes, defs) = self.find_pointer_writes_and_defs(fb.function);
         let phi_blocks = self.find_phi_blocks(&writes, &defs, cfg);
-        let phi_args = self.initialize_phis(function, &phi_blocks, type_info);
-        self.remove_ptrs(function, cfg, &phi_args);
+        let phi_args = self.initialize_phis(fb, &phi_blocks, type_info);
+        self.remove_ptrs(fb.function, cfg, &phi_args);
     }
 
     fn remove_ptrs(
@@ -188,15 +197,16 @@ impl Mem2Reg {
     // and value_id is the id of the pointer that is being replaced
     fn initialize_phis(
         &self,
-        function: &mut HLFunction,
+        fb: &mut HLFunctionBuilder<'_>,
         phi_blocks: &HashMap<ValueId, HashSet<BlockId>>,
         type_info: &FunctionTypeInfo,
     ) -> HashMap<BlockId, Vec<(ValueId, ValueId)>> {
         let mut result: HashMap<BlockId, Vec<(ValueId, ValueId)>> = HashMap::new();
         for (value, blocks) in phi_blocks {
             for block in blocks {
-                let param =
-                    function.add_parameter(*block, type_info.get_value_type(*value).get_pointed());
+                let param = fb
+                    .block(*block)
+                    .add_parameter(type_info.get_value_type(*value).get_pointed());
                 result.entry(*block).or_default().push((param, *value));
             }
         }

--- a/compiler/src/compiler/passes/prepare_entry_point.rs
+++ b/compiler/src/compiler/passes/prepare_entry_point.rs
@@ -24,9 +24,8 @@ use crate::compiler::{
     ssa::{
         BlockId, FunctionId, ValueId,
         hlssa::{
-            CallTarget, CastTarget, ConstValue, HLFunction, HLSSA, OpCode, SequenceTargetType,
-            Type, TypeExpr,
-            builder::{HLBlockEmitter, HLEmitter, HLFunctionBuilder},
+            CallTarget, CastTarget, ConstValue, HLSSA, OpCode, SequenceTargetType, Type, TypeExpr,
+            builder::{HLBlockEmitter, HLEmitter, HLSSABuilder},
         },
     },
 };
@@ -77,10 +76,9 @@ impl PrepareEntryPoint {
         ssa.get_main_mut().set_name("original_main".to_string());
 
         let wrapper_id = ssa.add_function("wrapper_main".to_string());
-        {
-            let wrapper = ssa.get_function_mut(wrapper_id);
-            let entry_block = wrapper.get_entry_id();
-            let mut b = HLFunctionBuilder::new(wrapper);
+        let mut sb = HLSSABuilder::new(ssa);
+        sb.modify_function(wrapper_id, |b| {
+            let entry_block = b.function.get_entry_id();
             let mut e = b.block(entry_block);
 
             let mut arg_values = Vec::new();
@@ -115,7 +113,7 @@ impl PrepareEntryPoint {
             }
 
             e.terminate_return(vec![]);
-        }
+        });
         ssa.set_entry_point(wrapper_id);
     }
 
@@ -153,61 +151,65 @@ impl PrepareEntryPoint {
     /// Insert pinned WriteWitness instructions in wrapper_main entry.
     /// The first write emits constant one for witness[0], then writes each entry param.
     fn insert_witness_writes(ssa: &mut HLSSA) {
-        let main = ssa.get_main_mut();
-        let entry_id = main.get_entry_id();
+        let main_id = ssa.get_main_id();
+        let mut sb = HLSSABuilder::new(ssa);
+        sb.modify_function(main_id, |fb| {
+            let entry_id = fb.function.get_entry_id();
 
-        // Collect entry params
-        let params: Vec<(ValueId, Type)> = main
-            .get_entry()
-            .get_parameters()
-            .map(|(id, typ)| (*id, typ.clone()))
-            .collect();
+            // Collect entry params
+            let params: Vec<(ValueId, Type)> = fb
+                .function
+                .get_entry()
+                .get_parameters()
+                .map(|(id, typ)| (*id, typ.clone()))
+                .collect();
 
-        // witness[0] must be constant one, emitted by the program.
-        let witness_one_value = main.fresh_value();
-        let one_const_value = main.fresh_value();
-        let mut write_witness_instructions = vec![
-            OpCode::Const {
-                result: one_const_value,
-                value: ConstValue::Field(ark_bn254::Fr::from(1u64)),
-            },
-            OpCode::WriteWitness {
-                result: Some(witness_one_value),
-                value: one_const_value,
-                pinned: true,
-            },
-        ];
+            // witness[0] must be constant one, emitted by the program.
+            let witness_one_value = fb.ssa.fresh_value();
+            let one_const_value = fb.ssa.fresh_value();
+            let mut write_witness_instructions = vec![
+                OpCode::Const {
+                    result: one_const_value,
+                    value: ConstValue::Field(ark_bn254::Fr::from(1u64)),
+                },
+                OpCode::WriteWitness {
+                    result: Some(witness_one_value),
+                    value: one_const_value,
+                    pinned: true,
+                },
+            ];
 
-        // Create pinned WriteWitness for each param and build replacements.
-        // These must be pinned so they survive DCE even when their results become unused
-        // (e.g. when inter-procedural DCE prunes call args to original_main).
-        let mut replacements = ValueReplacements::new();
-        for (param_id, param_type) in &params {
-            if param_type.is_witness_of() {
-                panic!(
-                    "ICE: wrapper_main entry parameter v{} still has WitnessOf type after main parameter reconstruction: {:?}",
-                    param_id.0, param_type
-                );
+            // Create pinned WriteWitness for each param and build replacements.
+            // These must be pinned so they survive DCE even when their results become unused
+            // (e.g. when inter-procedural DCE prunes call args to original_main).
+            let mut replacements = ValueReplacements::new();
+            for (param_id, param_type) in &params {
+                if param_type.is_witness_of() {
+                    panic!(
+                        "ICE: wrapper_main entry parameter v{} still has WitnessOf type after main parameter reconstruction: {:?}",
+                        param_id.0, param_type
+                    );
+                }
+                let witness_val = fb.ssa.fresh_value();
+                write_witness_instructions.push(OpCode::WriteWitness {
+                    result: Some(witness_val),
+                    value: *param_id,
+                    pinned: true,
+                });
+                replacements.insert(*param_id, witness_val);
             }
-            let witness_val = main.fresh_value();
-            write_witness_instructions.push(OpCode::WriteWitness {
-                result: Some(witness_val),
-                value: *param_id,
-                pinned: true,
-            });
-            replacements.insert(*param_id, witness_val);
-        }
 
-        // Prepend WriteWitness instructions and apply replacements to existing instructions
-        let entry_block = main.get_block_mut(entry_id);
-        let old_instructions = entry_block.take_instructions();
-        let mut new_instructions = write_witness_instructions;
-        for mut instruction in old_instructions {
-            replacements.replace_instruction(&mut instruction);
-            new_instructions.push(instruction);
-        }
-        entry_block.put_instructions(new_instructions);
-        replacements.replace_terminator(entry_block.get_terminator_mut());
+            // Prepend WriteWitness instructions and apply replacements to existing instructions
+            let entry_block = fb.function.get_block_mut(entry_id);
+            let old_instructions = entry_block.take_instructions();
+            let mut new_instructions = write_witness_instructions;
+            for mut instruction in old_instructions {
+                replacements.replace_instruction(&mut instruction);
+                new_instructions.push(instruction);
+            }
+            entry_block.put_instructions(new_instructions);
+            replacements.replace_terminator(entry_block.get_terminator_mut());
+        });
     }
 
     /// Process unconstrained call results: flatten to Fields, WriteWitness,
@@ -242,63 +244,66 @@ impl PrepareEntryPoint {
 
         // Process each function/block: single pass over instructions, handling
         // all unconstrained calls inline so indices never go stale.
-        for &fid in &func_ids {
-            let block_ids: Vec<BlockId> = ssa
+        let mut sb = HLSSABuilder::new(ssa);
+        for fid in func_ids {
+            let block_ids: Vec<BlockId> = sb
+                .ssa()
                 .get_function(fid)
                 .get_blocks()
                 .map(|(id, _)| *id)
                 .collect();
-            for bid in block_ids {
-                let function = ssa.get_function_mut(fid);
-                let block = function.get_block_mut(bid);
-                let old_instructions = block.take_instructions();
+            sb.modify_function(fid, |fb| {
+                for bid in block_ids {
+                    let block = fb.function.get_block_mut(bid);
+                    let old_instructions = block.take_instructions();
 
-                let mut replacements = ValueReplacements::new();
-                let mut new_instructions = Vec::new();
+                    let mut replacements = ValueReplacements::new();
+                    let mut new_instructions = Vec::new();
 
-                for mut instr in old_instructions {
-                    replacements.replace_instruction(&mut instr);
+                    for mut instr in old_instructions {
+                        replacements.replace_instruction(&mut instr);
 
-                    let call_results: Vec<(ValueId, Type)> = if let OpCode::Call {
-                        unconstrained: true,
-                        results,
-                        function: CallTarget::Static(callee_id),
-                        ..
-                    } = &instr
-                    {
-                        callee_return_types
-                            .get(callee_id)
-                            .map(|rt| {
-                                results
-                                    .iter()
-                                    .zip(rt.iter())
-                                    .map(|(r, t)| (*r, t.clone()))
-                                    .collect()
-                            })
-                            .unwrap_or_default()
-                    } else {
-                        vec![]
-                    };
+                        let call_results: Vec<(ValueId, Type)> = if let OpCode::Call {
+                            unconstrained: true,
+                            results,
+                            function: CallTarget::Static(callee_id),
+                            ..
+                        } = &instr
+                        {
+                            callee_return_types
+                                .get(callee_id)
+                                .map(|rt| {
+                                    results
+                                        .iter()
+                                        .zip(rt.iter())
+                                        .map(|(r, t)| (*r, t.clone()))
+                                        .collect()
+                                })
+                                .unwrap_or_default()
+                        } else {
+                            vec![]
+                        };
 
-                    new_instructions.push(instr);
+                        new_instructions.push(instr);
 
-                    for (result_vid, return_type) in call_results {
-                        let reconstructed = function.fresh_value();
-                        let prepare_fn = Self::find_prepare_fn(&return_type, &prepare_fns);
-                        new_instructions.push(OpCode::Call {
-                            results: vec![reconstructed],
-                            function: CallTarget::Static(prepare_fn),
-                            args: vec![result_vid],
-                            unconstrained: false,
-                        });
-                        replacements.insert(result_vid, reconstructed);
+                        for (result_vid, return_type) in call_results {
+                            let reconstructed = fb.ssa.fresh_value();
+                            let prepare_fn = Self::find_prepare_fn(&return_type, &prepare_fns);
+                            new_instructions.push(OpCode::Call {
+                                results: vec![reconstructed],
+                                function: CallTarget::Static(prepare_fn),
+                                args: vec![result_vid],
+                                unconstrained: false,
+                            });
+                            replacements.insert(result_vid, reconstructed);
+                        }
                     }
-                }
 
-                let block = function.get_block_mut(bid);
-                block.put_instructions(new_instructions);
-                replacements.replace_terminator(block.get_terminator_mut());
-            }
+                    let block = fb.function.get_block_mut(bid);
+                    block.put_instructions(new_instructions);
+                    replacements.replace_terminator(block.get_terminator_mut());
+                }
+            });
         }
     }
 
@@ -356,16 +361,15 @@ impl PrepareEntryPoint {
             _ => Vec::new(),
         };
 
-        {
-            let function = ssa.get_function_mut(fn_id);
-            function.add_return_type(typ.clone());
-            let entry_block = function.get_entry_id();
-            let mut b = HLFunctionBuilder::new(function);
+        let mut sb = HLSSABuilder::new(ssa);
+        sb.modify_function(fn_id, |b| {
+            b.function.add_return_type(typ.clone());
+            let entry_block = b.function.get_entry_id();
             let mut e = b.block(entry_block);
             let param = e.add_parameter(typ.clone());
             let result = Self::emit_prepare_body(&mut e, param, typ, &child_fns);
             e.terminate_return(vec![result]);
-        }
+        });
 
         fn_id
     }
@@ -444,24 +448,26 @@ impl PrepareEntryPoint {
             Self::get_or_create_reconstruct_fn(typ, ssa, &mut reconstruct_fns);
         }
 
-        let function = ssa.get_main_mut();
+        let main_id = ssa.get_main_id();
+        let mut sb = HLSSABuilder::new(ssa);
+        sb.modify_function(main_id, |fb| {
+            let mut new_instructions = Vec::new();
+            let mut new_parameters = Vec::new();
 
-        let mut new_instructions = Vec::new();
-        let mut new_parameters = Vec::new();
+            for (value_id, typ) in params.iter() {
+                let (_, child_parameters, child_instructions) =
+                    Self::reconstruct_param(Some(*value_id), typ, fb.ssa, &reconstruct_fns);
+                new_parameters.extend(child_parameters);
+                new_instructions.extend(child_instructions);
+            }
 
-        for (value_id, typ) in params.iter() {
-            let (_, child_parameters, child_instructions) =
-                Self::reconstruct_param(Some(*value_id), typ, function, &reconstruct_fns);
-            new_parameters.extend(child_parameters);
-            new_instructions.extend(child_instructions);
-        }
+            let entry_id = fb.function.get_entry_id();
+            let entry_block = fb.function.get_block_mut(entry_id);
+            new_instructions.extend(entry_block.take_instructions());
 
-        let entry_id = function.get_entry_id();
-        let entry_block = function.get_block_mut(entry_id);
-        new_instructions.extend(entry_block.take_instructions());
-
-        entry_block.put_parameters(new_parameters);
-        entry_block.put_instructions(new_instructions);
+            entry_block.put_parameters(new_parameters);
+            entry_block.put_instructions(new_instructions);
+        });
     }
 
     fn find_reconstruct_fn(typ: &Type, reconstruct_fns: &[ReconstructFnEntry]) -> FunctionId {
@@ -505,18 +511,17 @@ impl PrepareEntryPoint {
             fn_id,
         });
 
-        {
-            let function = ssa.get_function_mut(fn_id);
-            function.add_return_type(typ.clone());
-            let entry_block = function.get_entry_id();
-            let mut b = HLFunctionBuilder::new(function);
+        let mut sb = HLSSABuilder::new(ssa);
+        sb.modify_function(fn_id, |b| {
+            b.function.add_return_type(typ.clone());
+            let entry_block = b.function.get_entry_id();
             let mut e = b.block(entry_block);
 
             let input_len = Self::flattened_field_count(typ);
             let input_array = e.add_parameter(Type::field().array_of(input_len));
             let result = Self::emit_reconstruct_body(&mut e, typ, input_array, reconstruct_fns);
             e.terminate_return(vec![result]);
-        }
+        });
 
         fn_id
     }
@@ -680,13 +685,13 @@ impl PrepareEntryPoint {
     fn reconstruct_param(
         value_id: Option<ValueId>,
         typ: &Type,
-        function: &mut HLFunction,
+        ssa: &mut HLSSA,
         reconstruct_fns: &[ReconstructFnEntry],
     ) -> (ValueId, Vec<(ValueId, Type)>, Vec<OpCode>) {
         let mut new_instructions = Vec::new();
         let mut new_parameters = Vec::new();
 
-        let value_id = value_id.unwrap_or_else(|| function.fresh_value());
+        let value_id = value_id.unwrap_or_else(|| ssa.fresh_value());
 
         match &typ.expr {
             TypeExpr::Field => new_parameters.push((value_id, typ.clone())),
@@ -694,12 +699,12 @@ impl PrepareEntryPoint {
                 let input_len = Self::flattened_field_count(typ);
                 let mut fields = Vec::with_capacity(input_len);
                 for _ in 0..input_len {
-                    let field_id = function.fresh_value();
+                    let field_id = ssa.fresh_value();
                     new_parameters.push((field_id, Type::field()));
                     fields.push(field_id);
                 }
 
-                let input_array = function.fresh_value();
+                let input_array = ssa.fresh_value();
                 new_instructions.push(OpCode::MkSeq {
                     result: input_array,
                     elems: fields,

--- a/compiler/src/compiler/passes/simplifier.rs
+++ b/compiler/src/compiler/passes/simplifier.rs
@@ -16,8 +16,8 @@ use crate::compiler::{
     ssa::{
         FunctionId, ValueId,
         hlssa::{
-            BinaryArithOpKind, CastTarget, CmpKind, ConstValue, HLFunction, HLSSA, OpCode, Type,
-            TypeExpr,
+            BinaryArithOpKind, CastTarget, CmpKind, ConstValue, HLSSA, OpCode, Type, TypeExpr,
+            builder::{HLFunctionBuilder, HLSSABuilder},
         },
     },
 };
@@ -75,31 +75,35 @@ impl Simplifier {
             .iter()
             .map(|(id, (params, returns))| (*id, (params.clone(), returns.as_slice())))
             .collect();
-        for (function_id, function) in ssa.iter_functions_mut() {
-            let cfg = flow.get_function_cfg(*function_id);
-            for _ in 0..self.max_iterations {
-                // Recompute locally so newly emitted opcodes (the Const+Cast
-                // pair from `materialize_const`) appear with the right types.
-                let fti = Types::new().run_function(function, &function_types, cfg);
-                if !self.run_function(function, &fti) {
-                    break;
+        let fids: Vec<_> = ssa.get_function_ids().collect();
+        let mut sb = HLSSABuilder::new(ssa);
+        for function_id in fids {
+            let cfg = flow.get_function_cfg(function_id);
+            sb.modify_function(function_id, |fb| {
+                for _ in 0..self.max_iterations {
+                    // Recompute locally so newly emitted opcodes (the Const+Cast
+                    // pair from `materialize_const`) appear with the right types.
+                    let fti = Types::new().run_function(fb.function, &function_types, cfg);
+                    if !self.run_function(fb, &fti) {
+                        break;
+                    }
                 }
-            }
+            });
         }
     }
 
     /// One iteration over a function. Returns `true` if anything changed.
     fn run_function(
         &self,
-        function: &mut HLFunction,
+        fb: &mut HLFunctionBuilder<'_>,
         function_type_info: &FunctionTypeInfo,
     ) -> bool {
-        let definitions = FunctionValueDefinitions::from_ssa(function);
+        let definitions = FunctionValueDefinitions::from_ssa(fb.function);
         let mut aliases = ValueReplacements::new();
         let mut changed = false;
 
         let mut new_blocks = HashMap::new();
-        for (bid, mut block) in function.take_blocks().into_iter() {
+        for (bid, mut block) in fb.function.take_blocks().into_iter() {
             let mut new_instructions = Vec::new();
             for instruction in block.take_instructions().into_iter() {
                 // Apply aliases collected so far in this iteration before
@@ -108,7 +112,7 @@ impl Simplifier {
                 aliases.replace_inputs(&mut instruction);
 
                 let rewrite =
-                    self.try_algebraic(&instruction, &definitions, function_type_info, function);
+                    self.try_algebraic(&instruction, &definitions, function_type_info, fb);
 
                 match rewrite {
                     Some(Rewrite::Alias { result, target }) => {
@@ -127,12 +131,12 @@ impl Simplifier {
             block.put_instructions(new_instructions);
             new_blocks.insert(bid, block);
         }
-        function.put_blocks(new_blocks);
+        fb.function.put_blocks(new_blocks);
 
         // Apply aliases globally. Block iteration order is non-deterministic,
         // so a block processed before its predecessor sees stale operands;
         // sweep here to fix references the in-walk substitution missed.
-        for (_, block) in function.get_blocks_mut() {
+        for (_, block) in fb.function.get_blocks_mut() {
             for instr in block.get_instructions_mut() {
                 aliases.replace_inputs(instr);
             }
@@ -148,7 +152,7 @@ impl Simplifier {
         instruction: &OpCode,
         defs: &FunctionValueDefinitions,
         types: &FunctionTypeInfo,
-        function: &mut HLFunction,
+        fb: &mut HLFunctionBuilder<'_>,
     ) -> Option<Rewrite> {
         match instruction {
             OpCode::BinaryArithOp {
@@ -180,7 +184,7 @@ impl Simplifier {
                             });
                         }
                         if *lhs == *rhs {
-                            return materialize_zero(types, *result, function);
+                            return materialize_zero(types, *result, fb);
                         }
                     }
                     BinaryArithOpKind::Mul => {
@@ -271,7 +275,7 @@ impl Simplifier {
                             });
                         }
                         if *lhs == *rhs {
-                            return materialize_zero(types, *result, function);
+                            return materialize_zero(types, *result, fb);
                         }
                     }
                     BinaryArithOpKind::Shl | BinaryArithOpKind::Shr => {
@@ -373,7 +377,7 @@ impl Simplifier {
                 result,
                 lhs,
                 rhs,
-            } if *lhs == *rhs => materialize_one(types, *result, function),
+            } if *lhs == *rhs => materialize_one(types, *result, fb),
             OpCode::ValueOf { result, value } => {
                 // ValueOf(ValueOf(x)) → ValueOf(x)
                 if let ValueDefinition::Instruction(_, _, OpCode::ValueOf { .. }) =
@@ -436,14 +440,14 @@ impl Simplifier {
 fn materialize_const(
     types: &FunctionTypeInfo,
     result: ValueId,
-    function: &mut HLFunction,
+    fb: &mut HLFunctionBuilder<'_>,
     pure_value: impl Fn(&TypeExpr) -> Option<ConstValue>,
 ) -> Option<Rewrite> {
     let ty = types.get_value_type(result).clone();
     let inner = ty.strip_witness();
     let value = pure_value(&inner.expr)?;
     if ty.is_witness_of() {
-        let tmp = function.fresh_value();
+        let tmp = fb.fresh_value();
         Some(Rewrite::Replace(vec![
             OpCode::Const { result: tmp, value },
             OpCode::Cast {
@@ -460,9 +464,9 @@ fn materialize_const(
 fn materialize_zero(
     types: &FunctionTypeInfo,
     result: ValueId,
-    function: &mut HLFunction,
+    fb: &mut HLFunctionBuilder<'_>,
 ) -> Option<Rewrite> {
-    materialize_const(types, result, function, |t| match t {
+    materialize_const(types, result, fb, |t| match t {
         TypeExpr::U(s) => Some(ConstValue::U(*s, 0)),
         TypeExpr::I(s) => Some(ConstValue::I(*s, 0)),
         TypeExpr::Field => Some(ConstValue::Field(ark_bn254::Fr::zero())),
@@ -473,9 +477,9 @@ fn materialize_zero(
 fn materialize_one(
     types: &FunctionTypeInfo,
     result: ValueId,
-    function: &mut HLFunction,
+    fb: &mut HLFunctionBuilder<'_>,
 ) -> Option<Rewrite> {
-    materialize_const(types, result, function, |t| match t {
+    materialize_const(types, result, fb, |t| match t {
         TypeExpr::U(s) => Some(ConstValue::U(*s, 1)),
         TypeExpr::I(s) => Some(ConstValue::I(*s, 1)),
         TypeExpr::Field => Some(ConstValue::Field(ark_bn254::Fr::one())),

--- a/compiler/src/compiler/passes/specializer.rs
+++ b/compiler/src/compiler/passes/specializer.rs
@@ -48,12 +48,26 @@ struct Val(ValueId);
 
 struct SpecializationState {
     function: HLFunction,
+    /// Transient counter for `ValueId`s allocated during specialization. Starts at the SSA's
+    /// `value_num_bound` and is reconciled back into the SSA only if specialization is accepted.
+    transient_counter: u64,
     const_vals: HashMap<ValueId, ConstVal>,
+}
+
+impl SpecializationState {
+    fn add_entry_parameter(&mut self, ty: Type) -> ValueId {
+        let id = self.fresh_value();
+        let entry = self.function.get_entry_id();
+        self.function.get_block_mut(entry).push_parameter(id, ty);
+        id
+    }
 }
 
 impl HLEmitter for SpecializationState {
     fn fresh_value(&mut self) -> ValueId {
-        self.function.fresh_value()
+        let id = ValueId(self.transient_counter);
+        self.transient_counter += 1;
+        id
     }
 
     fn emit(&mut self, op: OpCode) {
@@ -804,6 +818,7 @@ impl Specializer {
 
         let mut state = SpecializationState {
             function: HLFunction::empty(name),
+            transient_counter: ssa.value_num_bound() as u64,
             const_vals: HashMap::new(),
         };
 
@@ -824,9 +839,7 @@ impl Specializer {
                     return;
                 }
                 ValueSignature::Unknown(_) | ValueSignature::WitnessOf(_) => {
-                    call_params.push(Val(state
-                        .function
-                        .add_parameter(state.function.get_entry_id(), param.clone())));
+                    call_params.push(Val(state.add_entry_parameter(param.clone())));
                 }
                 ValueSignature::Field(f) => {
                     let val = state.field_const(*f);
@@ -871,6 +884,7 @@ impl Specializer {
 
         if savings_to_code_ratio > self.savings_to_code_ratio {
             info!(message = %"Specialization accepted", code_bloat = code_bloat,  savings_to_code_ratio = savings_to_code_ratio, threshold_ratio = self.savings_to_code_ratio);
+            ssa.reserve_values_up_to(state.transient_counter);
             let original_fn = ssa.take_function(signature.get_fun_id());
             let new_fn_id = ssa.add_function("".to_string());
             let new_original_id = ssa.add_function("".to_string()); // Temporary
@@ -879,6 +893,7 @@ impl Specializer {
             let original_returns = original_fn.get_returns().to_vec();
 
             let dispatcher = self.build_dispatcher_for(
+                ssa,
                 original_params,
                 original_returns,
                 &signature,
@@ -897,6 +912,7 @@ impl Specializer {
 
     fn build_dispatcher_for(
         &self,
+        ssa: &mut HLSSA,
         params: Vec<Type>,
         returns: Vec<Type>,
         signature: &FunctionSignature,
@@ -907,7 +923,7 @@ impl Specializer {
         let mut dispatcher = HLFunction::empty(fn_name);
         let entry_block = dispatcher.get_entry_id();
 
-        let mut b = HLFunctionBuilder::new(&mut dispatcher);
+        let mut b = HLFunctionBuilder::new(&mut dispatcher, ssa);
 
         let mut dispatcher_params = vec![];
         {

--- a/compiler/src/compiler/passes/witness_lowering.rs
+++ b/compiler/src/compiler/passes/witness_lowering.rs
@@ -11,7 +11,7 @@ use crate::compiler::{
         BlockId, Terminator, ValueId,
         hlssa::{
             BinaryArithOpKind, DMatrix, HLSSA, OpCode, SequenceTargetType, Type, TypeExpr,
-            builder::{HLBlockEmitter, HLEmitter},
+            builder::{HLBlockEmitter, HLEmitter, HLSSABuilder},
         },
     },
 };
@@ -43,14 +43,18 @@ impl WitnessLowering {
         type_info: &crate::compiler::analysis::types::TypeInfo,
         flow_analysis: &FlowAnalysis,
     ) {
-        for (function_id, function) in ssa.iter_functions_mut() {
-            let type_info = type_info.get_function(*function_id);
-            let cfg = flow_analysis.get_function_cfg(*function_id);
-            for rtp in function.iter_returns_mut() {
+        let fids: Vec<_> = ssa.get_function_ids().collect();
+        let mut sb = HLSSABuilder::new(ssa);
+        for function_id in fids {
+            let type_info = type_info.get_function(function_id);
+            let cfg = flow_analysis.get_function_cfg(function_id);
+            sb.modify_function(function_id, |fb| {
+            for rtp in fb.function.iter_returns_mut() {
                 *rtp = self.witness_lowering_in_type(rtp);
             }
             // Collect converted block parameter types before taking blocks
-            let block_param_types: HashMap<BlockId, Vec<Type>> = function
+            let block_param_types: HashMap<BlockId, Vec<Type>> = fb
+                .function
                 .get_blocks()
                 .map(|(bid, block)| {
                     let types = block
@@ -65,17 +69,17 @@ impl WitnessLowering {
             let block_ids: Vec<BlockId> = cfg.get_domination_pre_order().collect();
             for bid in block_ids {
                 // Convert block parameters in-place
-                let old_params = function.get_block_mut(bid).take_parameters();
+                let old_params = fb.function.get_block_mut(bid).take_parameters();
                 let new_params = old_params
                     .into_iter()
                     .map(|(r, tp)| (r, self.witness_lowering_in_type(&tp)))
                     .collect();
-                function.get_block_mut(bid).put_parameters(new_params);
+                fb.function.get_block_mut(bid).put_parameters(new_params);
 
-                let terminator = function.get_block_mut(bid).take_terminator();
-                let instructions = function.get_block_mut(bid).take_instructions();
+                let terminator = fb.function.get_block_mut(bid).take_terminator();
+                let instructions = fb.function.get_block_mut(bid).take_instructions();
 
-                let mut emitter = HLBlockEmitter::new(function, bid);
+                let mut emitter = fb.block(bid);
 
                 for mut instruction in instructions.into_iter() {
                     replacements.replace_instruction(&mut instruction);
@@ -485,6 +489,7 @@ impl WitnessLowering {
                     emitter.set_terminator(terminator);
                 }
             }
+            });
         }
     }
 

--- a/compiler/src/compiler/ssa/builder.rs
+++ b/compiler/src/compiler/ssa/builder.rs
@@ -1,18 +1,28 @@
-use crate::compiler::ssa::{Block, BlockId, Function, Instruction, SSAType, Terminator, ValueId};
+use std::fmt::Debug;
+
+use crate::compiler::ssa::{
+    Block, BlockId, Function, FunctionId, Instruction, SSA, SSAType, Terminator, ValueId,
+};
 
 // ---------------------------------------------------------------------------
 // InstrBuilder — lightweight instruction emitter
 // ---------------------------------------------------------------------------
 
-pub struct InstrBuilder<'a, Op: Instruction, Ty: SSAType> {
+pub struct InstrBuilder<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> {
     pub function: &'a mut Function<Op, Ty>,
+    pub ssa: &'a mut SSA<Op, Ty, Cn>,
     pub instructions: &'a mut Vec<Op>,
 }
 
-impl<'a, Op: Instruction, Ty: SSAType> InstrBuilder<'a, Op, Ty> {
-    pub fn new(function: &'a mut Function<Op, Ty>, instructions: &'a mut Vec<Op>) -> Self {
+impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> InstrBuilder<'a, Op, Ty, Cn> {
+    pub fn new(
+        function: &'a mut Function<Op, Ty>,
+        ssa: &'a mut SSA<Op, Ty, Cn>,
+        instructions: &'a mut Vec<Op>,
+    ) -> Self {
         Self {
             function,
+            ssa,
             instructions,
         }
     }
@@ -27,23 +37,24 @@ impl<'a, Op: Instruction, Ty: SSAType> InstrBuilder<'a, Op, Ty> {
 // FunctionBuilder — function-level coordinator (no current_block)
 // ---------------------------------------------------------------------------
 
-pub struct FunctionBuilder<'a, Op: Instruction, Ty: SSAType> {
+pub struct FunctionBuilder<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> {
     pub function: &'a mut Function<Op, Ty>,
+    pub ssa: &'a mut SSA<Op, Ty, Cn>,
 }
 
-impl<'a, Op: Instruction, Ty: SSAType> FunctionBuilder<'a, Op, Ty> {
-    pub fn new(function: &'a mut Function<Op, Ty>) -> Self {
-        Self { function }
+impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> FunctionBuilder<'a, Op, Ty, Cn> {
+    pub fn new(function: &'a mut Function<Op, Ty>, ssa: &'a mut SSA<Op, Ty, Cn>) -> Self {
+        Self { function, ssa }
     }
 
-    pub fn add_block(&mut self, f: impl FnOnce(&mut BlockEmitter<'_, Op, Ty>)) -> BlockId {
-        let (id, mut emitter) = BlockEmitter::from_new_block(self.function);
+    pub fn add_block(&mut self, f: impl FnOnce(&mut BlockEmitter<'_, Op, Ty, Cn>)) -> BlockId {
+        let (id, mut emitter) = BlockEmitter::from_new_block(self.function, self.ssa);
         f(&mut emitter);
         id
     }
 
     pub fn fresh_value(&mut self) -> ValueId {
-        self.function.fresh_value()
+        self.ssa.fresh_value()
     }
 
     /// Escape hatch for direct function access.
@@ -51,9 +62,14 @@ impl<'a, Op: Instruction, Ty: SSAType> FunctionBuilder<'a, Op, Ty> {
         self.function
     }
 
+    /// Escape hatch for direct SSA access.
+    pub fn ssa(&mut self) -> &mut SSA<Op, Ty, Cn> {
+        self.ssa
+    }
+
     /// Get a BlockEmitter for a specific block.
-    pub fn block(&mut self, id: BlockId) -> BlockEmitter<'_, Op, Ty> {
-        BlockEmitter::new(self.function, id)
+    pub fn block(&mut self, id: BlockId) -> BlockEmitter<'_, Op, Ty, Cn> {
+        BlockEmitter::new(self.function, self.ssa, id)
     }
 }
 
@@ -64,25 +80,31 @@ impl<'a, Op: Instruction, Ty: SSAType> FunctionBuilder<'a, Op, Ty> {
 /// Holds the current block *taken out* of the function, so `emit()` is a
 /// direct `Vec::push` with no HashMap lookup.  The block is put back into the
 /// function on `seal_and_switch` or `Drop`.
-pub struct BlockEmitter<'a, Op: Instruction, Ty: SSAType> {
+pub struct BlockEmitter<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> {
     pub function: &'a mut Function<Op, Ty>,
+    pub ssa: &'a mut SSA<Op, Ty, Cn>,
     pub(crate) block_id: BlockId,
     pub(crate) block: Block<Op, Ty>,
 }
 
-impl<Op: Instruction, Ty: SSAType> Drop for BlockEmitter<'_, Op, Ty> {
+impl<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> Drop for BlockEmitter<'_, Op, Ty, Cn> {
     fn drop(&mut self) {
         let block = std::mem::replace(&mut self.block, Block::empty());
         self.function.put_block(self.block_id, block);
     }
 }
 
-impl<'a, Op: Instruction, Ty: SSAType> BlockEmitter<'a, Op, Ty> {
+impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> BlockEmitter<'a, Op, Ty, Cn> {
     /// Create an emitter for an existing block (takes it out of the function).
-    pub fn new(function: &'a mut Function<Op, Ty>, block_id: BlockId) -> Self {
+    pub fn new(
+        function: &'a mut Function<Op, Ty>,
+        ssa: &'a mut SSA<Op, Ty, Cn>,
+        block_id: BlockId,
+    ) -> Self {
         let block = function.take_block(block_id);
         Self {
             function,
+            ssa,
             block_id,
             block,
         }
@@ -90,12 +112,16 @@ impl<'a, Op: Instruction, Ty: SSAType> BlockEmitter<'a, Op, Ty> {
 
     /// Create an emitter for a fresh block (not yet in the function).
     /// The block is inserted into the function on drop.
-    pub(crate) fn from_new_block(function: &'a mut Function<Op, Ty>) -> (BlockId, Self) {
+    pub(crate) fn from_new_block(
+        function: &'a mut Function<Op, Ty>,
+        ssa: &'a mut SSA<Op, Ty, Cn>,
+    ) -> (BlockId, Self) {
         let (block_id, block) = function.next_virtual_block();
         (
             block_id,
             Self {
                 function,
+                ssa,
                 block_id,
                 block,
             },
@@ -111,7 +137,7 @@ impl<'a, Op: Instruction, Ty: SSAType> BlockEmitter<'a, Op, Ty> {
     }
 
     pub fn add_parameter(&mut self, typ: Ty) -> ValueId {
-        let v = self.function.fresh_value();
+        let v = self.ssa.fresh_value();
         self.block.push_parameter(v, typ);
         v
     }
@@ -162,7 +188,7 @@ impl<'a, Op: Instruction, Ty: SSAType> BlockEmitter<'a, Op, Ty> {
     pub fn build_loop(
         &mut self,
         params: Vec<(ValueId, Ty)>,
-        header: impl FnOnce(&mut InstrBuilder<'_, Op, Ty>, &[ValueId]) -> ValueId,
+        header: impl FnOnce(&mut InstrBuilder<'_, Op, Ty, Cn>, &[ValueId]) -> ValueId,
         body: impl FnOnce(&mut Self, &[ValueId]) -> Vec<ValueId>,
     ) -> Vec<ValueId> {
         // Create blocks
@@ -177,7 +203,7 @@ impl<'a, Op: Instruction, Ty: SSAType> BlockEmitter<'a, Op, Ty> {
         // Build header parameters
         let mut param_ids = vec![];
         for _ in 0..params.len() {
-            let v = self.function.fresh_value();
+            let v = self.ssa.fresh_value();
             param_ids.push(v);
         }
         let header_params: Vec<_> = param_ids
@@ -192,7 +218,7 @@ impl<'a, Op: Instruction, Ty: SSAType> BlockEmitter<'a, Op, Ty> {
         // Call header closure to emit condition into a temporary instruction buffer
         let mut header_instructions = vec![];
         let cond = {
-            let mut b = InstrBuilder::new(self.function, &mut header_instructions);
+            let mut b = InstrBuilder::new(self.function, self.ssa, &mut header_instructions);
             header(&mut b, &param_ids)
         };
         self.function
@@ -233,7 +259,7 @@ impl<'a, Op: Instruction, Ty: SSAType> BlockEmitter<'a, Op, Ty> {
     ) -> Vec<ValueId> {
         let results: Vec<_> = result_types
             .into_iter()
-            .map(|ty| (self.function.fresh_value(), ty))
+            .map(|ty| (self.ssa.fresh_value(), ty))
             .collect();
         let merge_params: Vec<_> = results.iter().map(|(v, _)| *v).collect();
         self.build_if_else_into(cond, results, then_branch, else_branch);
@@ -270,5 +296,138 @@ impl<'a, Op: Instruction, Ty: SSAType> BlockEmitter<'a, Op, Ty> {
         // Build else branch
         let else_results = else_branch(self);
         self.seal_and_switch(Terminator::Jmp(merge_blk, else_results), merge_blk);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SSABuilder — top-level coordinator that owns `&mut SSA` and dispenses
+//              function builders via closure-based scopes.
+// ---------------------------------------------------------------------------
+
+pub struct SSABuilder<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> {
+    ssa: &'a mut SSA<Op, Ty, Cn>,
+}
+
+impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSABuilder<'a, Op, Ty, Cn> {
+    pub fn new(ssa: &'a mut SSA<Op, Ty, Cn>) -> Self {
+        Self { ssa }
+    }
+
+    /// Build a fresh function from scratch, inserting it into the SSA on
+    /// closure return. The function being built is held by a local variable
+    /// (NOT in `ssa.functions`) for the closure's lifetime, so the builder
+    /// can hand out `&mut Function` and `&mut SSA` without aliasing.
+    pub fn add_function<R>(
+        &mut self,
+        name: String,
+        body: impl FnOnce(&mut FunctionBuilder<'_, Op, Ty, Cn>) -> R,
+    ) -> (FunctionId, R) {
+        let mut function = Function::<Op, Ty>::empty(name);
+        let result = {
+            let mut fb = FunctionBuilder::new(&mut function, self.ssa);
+            body(&mut fb)
+        };
+        let id = self.ssa.insert_function(function);
+        (id, result)
+    }
+
+    /// Edit an existing function: take it out of `ssa.functions`, hand it
+    /// to the closure as a `FunctionBuilder`, put it back on return.
+    ///
+    /// Panics if `fid` does not exist or has already been taken out
+    /// (re-entrant `modify_function` for the same `fid`).
+    pub fn modify_function<R>(
+        &mut self,
+        fid: FunctionId,
+        body: impl FnOnce(&mut FunctionBuilder<'_, Op, Ty, Cn>) -> R,
+    ) -> R {
+        let mut function = self.ssa.take_function(fid);
+        let result = {
+            let mut fb = FunctionBuilder::new(&mut function, self.ssa);
+            body(&mut fb)
+        };
+        self.ssa.put_function(fid, function);
+        result
+    }
+
+    /// Convenience: add a parameter to a specific block of a specific function
+    /// without spelling out the `modify_function` closure.
+    pub fn add_block_parameter(&mut self, fid: FunctionId, blk: BlockId, ty: Ty) -> ValueId {
+        self.modify_function(fid, |fb| fb.block(blk).add_parameter(ty))
+    }
+
+    /// Allocate a fresh `ValueId` from the SSA-wide counter.
+    pub fn fresh_value(&mut self) -> ValueId {
+        self.ssa.fresh_value()
+    }
+
+    /// Escape hatch for direct SSA access.
+    pub fn ssa(&mut self) -> &mut SSA<Op, Ty, Cn> {
+        self.ssa
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::compiler::ssa::hlssa::builder::HLSSABuilder;
+    use crate::compiler::ssa::hlssa::{Constants, HLSSA};
+
+    /// `ValueId`s issued inside two different functions must not collide:
+    /// the counter lives on the SSA, not the function.
+    #[test]
+    fn global_value_ids_are_unique_across_functions() {
+        let mut ssa = HLSSA::with_main("main".to_string(), Constants::default());
+        let mut sb = HLSSABuilder::new(&mut ssa);
+        let main_id = sb.ssa().get_main_id();
+        let other_id = sb.ssa().add_function("other".to_string());
+
+        let v_main = sb.modify_function(main_id, |fb| fb.fresh_value());
+        let v_other = sb.modify_function(other_id, |fb| fb.fresh_value());
+
+        assert_ne!(v_main, v_other);
+    }
+
+    /// `prepare_rebuild` forwards the SSA-wide counter, so allocations after
+    /// rebuild continue from where the original counter left off.
+    #[test]
+    fn prepare_rebuild_preserves_value_counter() {
+        let mut ssa = HLSSA::with_main("main".to_string(), Constants::default());
+        let _v0 = ssa.fresh_value();
+        let _v1 = ssa.fresh_value();
+        let _v2 = ssa.fresh_value();
+        let bound_before = ssa.value_num_bound();
+
+        let (mut rebuilt, _functions, _globals) = ssa.prepare_rebuild();
+        assert_eq!(rebuilt.value_num_bound(), bound_before);
+
+        let next = rebuilt.fresh_value();
+        assert_eq!(next.0 as usize, bound_before);
+    }
+
+    /// An empty `modify_function` closure must leave the SSA structurally
+    /// unchanged: function count, counter, and the surviving function map
+    /// all preserved.
+    #[test]
+    fn modify_function_noop_roundtrip() {
+        let mut ssa = HLSSA::with_main("main".to_string(), Constants::default());
+        let main_id = ssa.get_main_id();
+        let _ = ssa.add_function("other".to_string());
+
+        // Allocate some values so the counter is non-zero.
+        let _v0 = ssa.fresh_value();
+        let _v1 = ssa.fresh_value();
+
+        let function_ids_before: Vec<_> = ssa.get_function_ids().collect();
+        let counter_before = ssa.value_num_bound();
+
+        let mut sb = HLSSABuilder::new(&mut ssa);
+        for fid in &function_ids_before {
+            sb.modify_function(*fid, |_fb| {});
+        }
+
+        assert_eq!(ssa.value_num_bound(), counter_before);
+        let function_ids_after: Vec<_> = ssa.get_function_ids().collect();
+        assert_eq!(function_ids_after.len(), function_ids_before.len());
+        assert!(ssa.get_function(main_id).get_blocks().count() > 0);
     }
 }

--- a/compiler/src/compiler/ssa/hlssa/builder.rs
+++ b/compiler/src/compiler/ssa/hlssa/builder.rs
@@ -1,9 +1,9 @@
 use crate::compiler::ssa::{
     ValueId,
-    builder::{BlockEmitter, FunctionBuilder, InstrBuilder},
+    builder::{BlockEmitter, FunctionBuilder, InstrBuilder, SSABuilder},
     hlssa::{
-        BinaryArithOpKind, CallTarget, CastTarget, CmpKind, ConstValue, Endianness, LookupTarget,
-        OpCode, Radix, RefCountOp, SequenceTargetType, SliceOpDir, Type,
+        BinaryArithOpKind, CallTarget, CastTarget, CmpKind, ConstValue, Constants, Endianness,
+        LookupTarget, OpCode, Radix, RefCountOp, SequenceTargetType, SliceOpDir, Type,
     },
 };
 
@@ -613,9 +613,10 @@ pub trait HLEmitter {
 // Type aliases
 // ---------------------------------------------------------------------------
 
-pub type HLInstrBuilder<'a> = InstrBuilder<'a, OpCode, Type>;
-pub type HLFunctionBuilder<'a> = FunctionBuilder<'a, OpCode, Type>;
-pub type HLBlockEmitter<'a> = BlockEmitter<'a, OpCode, Type>;
+pub type HLInstrBuilder<'a> = InstrBuilder<'a, OpCode, Type, Constants>;
+pub type HLFunctionBuilder<'a> = FunctionBuilder<'a, OpCode, Type, Constants>;
+pub type HLBlockEmitter<'a> = BlockEmitter<'a, OpCode, Type, Constants>;
+pub type HLSSABuilder<'a> = SSABuilder<'a, OpCode, Type, Constants>;
 
 // ---------------------------------------------------------------------------
 // HLEmitter impls
@@ -623,7 +624,7 @@ pub type HLBlockEmitter<'a> = BlockEmitter<'a, OpCode, Type>;
 
 impl HLEmitter for HLInstrBuilder<'_> {
     fn fresh_value(&mut self) -> ValueId {
-        self.function.fresh_value()
+        self.ssa.fresh_value()
     }
 
     fn emit(&mut self, op: OpCode) {
@@ -633,7 +634,7 @@ impl HLEmitter for HLInstrBuilder<'_> {
 
 impl HLEmitter for HLBlockEmitter<'_> {
     fn fresh_value(&mut self) -> ValueId {
-        self.function.fresh_value()
+        self.ssa.fresh_value()
     }
 
     fn emit(&mut self, op: OpCode) {

--- a/compiler/src/compiler/ssa/hlssa/mod.rs
+++ b/compiler/src/compiler/ssa/hlssa/mod.rs
@@ -13,13 +13,20 @@ pub use type_system::{Type, TypeExpr};
 // ================================================================================================
 
 /// The high-level SSA is designed for domain-level analysis without concretizing runtime details.
-pub type HLSSA = SSA<OpCode, Type>;
+pub type HLSSA = SSA<OpCode, Type, Constants>;
 
 impl HLSSA {
     pub fn new() -> Self {
-        Self::with_main("main".to_string())
+        Self::with_main("main".to_string(), ())
     }
 }
+
+// CONSTANT STORAGE
+// ================================================================================================
+
+/// Constant storage for the high-level SSA. Currently a placeholder while constants still live
+/// inline as `OpCode::Const` instructions.
+pub type Constants = ();
 
 // HLSSA OPCODES
 // ================================================================================================

--- a/compiler/src/compiler/ssa/hlssa_to_llssa.rs
+++ b/compiler/src/compiler/ssa/hlssa_to_llssa.rs
@@ -423,7 +423,7 @@ fn lower_inner(
 ) -> LLSSA {
     let main_id = hlssa.get_main_id();
     let main_name = hlssa.get_main().get_name().to_string();
-    let mut llssa = LLSSA::with_main(main_name);
+    let mut llssa = LLSSA::with_main(main_name, ());
     let mut fn_map: HashMap<FunctionId, FunctionId> = HashMap::new();
     let mut drop_fns: Vec<DropFnEntry> = Vec::new();
     let mut ad_fns = AdFunctions::new();
@@ -510,7 +510,7 @@ fn lower_function(
     let hl_entry_id = function.get_entry_id();
     let ll_entry_id = ll_func.get_entry_id();
     block_map.insert(hl_entry_id, ll_entry_id);
-    add_vm_parameter(&mut ll_func);
+    add_vm_parameter(&mut ll_func, llssa);
 
     // Create blocks for non-entry blocks
     for (block_id, _) in function.get_blocks() {
@@ -531,7 +531,10 @@ fn lower_function(
         let ll_block_id = block_map[block_id];
         for (param_id, param_type) in block.get_parameters() {
             let ll_type = lower_type(param_type);
-            let ll_param_id = ll_func.add_parameter(ll_block_id, ll_type);
+            let ll_param_id = llssa.fresh_value();
+            ll_func
+                .get_block_mut(ll_block_id)
+                .push_parameter(ll_param_id, ll_type);
             val_map.insert(*param_id, ll_param_id);
         }
     }
@@ -542,7 +545,7 @@ fn lower_function(
         let ll_block_id = block_map[&block_id];
 
         // Create a BlockEmitter for this block
-        let mut emitter = LLBlockEmitter::new(&mut ll_func, ll_block_id);
+        let mut emitter = LLBlockEmitter::new(&mut ll_func, llssa, ll_block_id);
 
         // Lower instructions
         for instruction in block.get_instructions() {
@@ -552,7 +555,6 @@ fn lower_function(
                 &mut val_map,
                 fn_type_info,
                 fn_map,
-                llssa,
                 drop_fns,
                 ad_fns,
                 lookup_fns,
@@ -576,15 +578,17 @@ fn lower_function(
     ll_func
 }
 
-fn new_ll_function(name: impl Into<String>) -> LLFunction {
+fn new_ll_function(llssa: &mut LLSSA, name: impl Into<String>) -> LLFunction {
     let mut func = LLFunction::empty(name.into());
-    add_vm_parameter(&mut func);
+    add_vm_parameter(&mut func, llssa);
     func
 }
 
-fn add_vm_parameter(func: &mut LLFunction) -> ValueId {
+fn add_vm_parameter(func: &mut LLFunction, llssa: &mut LLSSA) -> ValueId {
     let entry = func.get_entry_id();
-    func.add_parameter(entry, LLType::Ptr)
+    let id = llssa.fresh_value();
+    func.get_block_mut(entry).push_parameter(id, LLType::Ptr);
+    id
 }
 
 // =============================================================================
@@ -599,7 +603,6 @@ fn lower_instruction(
     val_map: &mut HashMap<ValueId, ValueId>,
     fn_type_info: &FunctionTypeInfo,
     fn_map: &HashMap<FunctionId, FunctionId>,
-    llssa: &mut LLSSA,
     drop_fns: &mut Vec<DropFnEntry>,
     ad_fns: &mut AdFunctions,
     lookup_fns: &mut LookupFunctions,
@@ -820,7 +823,6 @@ fn lower_instruction(
                 *array,
                 *index,
                 *value,
-                llssa,
                 drop_fns,
                 ad_fns,
             );
@@ -845,9 +847,9 @@ fn lower_instruction(
         } => {
             let val_type = fn_type_info.get_value_type(*value);
             if val_type.is_witness_of() {
-                lower_ad_rc_drop(e, val_map, *value, llssa, ad_fns);
+                lower_ad_rc_drop(e, val_map, *value, ad_fns);
             } else {
-                lower_rc_drop(e, val_map, fn_type_info, *value, llssa, drop_fns, ad_fns);
+                lower_rc_drop(e, val_map, fn_type_info, *value, drop_fns, ad_fns);
             }
         }
 
@@ -864,7 +866,7 @@ fn lower_instruction(
         } => {
             let ll_var = val_map[variable];
             let ll_sens = val_map[sensitivity];
-            let bump_fn = ad_fns.get_bump_fn(*matrix, llssa);
+            let bump_fn = ad_fns.get_bump_fn(*matrix, e.ssa);
             e.call(bump_fn, vec![ll_var, ll_sens], 0);
         }
 
@@ -1052,16 +1054,7 @@ fn lower_instruction(
         OpCode::Store { ptr, value } => {
             let ptr_type = fn_type_info.get_value_type(*ptr);
             let inner_type = ptr_type.get_pointed();
-            lower_ref_store(
-                e,
-                val_map,
-                *ptr,
-                *value,
-                &inner_type,
-                llssa,
-                drop_fns,
-                ad_fns,
-            );
+            lower_ref_store(e, val_map, *ptr, *value, &inner_type, drop_fns, ad_fns);
         }
 
         OpCode::Load { result, ptr } => {
@@ -1156,7 +1149,7 @@ fn lower_instruction(
             });
             let ll_type = lower_type(global_type);
             let ll_value = e.ll_load(r, ll_type);
-            let drop_fn_id = get_or_create_drop_fn(global_type, llssa, drop_fns, ad_fns);
+            let drop_fn_id = get_or_create_drop_fn(global_type, e.ssa, drop_fns, ad_fns);
             e.call(drop_fn_id, vec![ll_value], 0);
         }
 
@@ -1206,7 +1199,7 @@ fn lower_instruction(
             let key = val_map[&keys[0]];
             let result = val_map[&results[0]];
             let flag_val = val_map[flag];
-            let fn_id = lookup_fns.get_array_lookup_fn(arr_type, llssa);
+            let fn_id = lookup_fns.get_array_lookup_fn(arr_type, e.ssa);
             e.call(fn_id, vec![ll_arr, key, result, flag_val], 0);
         }
         OpCode::Lookup {
@@ -1226,7 +1219,7 @@ fn lower_instruction(
             );
             let key = val_map[&keys[0]];
             let flag_val = val_map[flag];
-            let fn_id = lookup_fns.get_rngchk_8_fn(llssa);
+            let fn_id = lookup_fns.get_rngchk_8_fn(e.ssa);
             e.call(fn_id, vec![key, flag_val], 0);
         }
         OpCode::Lookup {
@@ -1244,7 +1237,7 @@ fn lower_instruction(
             let key = val_map[&keys[0]];
             let result = val_map[&results[0]];
             let flag_val = val_map[flag];
-            let fn_id = lookup_fns.get_spread_fn(*bits, llssa);
+            let fn_id = lookup_fns.get_spread_fn(*bits, e.ssa);
             e.call(fn_id, vec![key, result, flag_val], 0);
         }
         OpCode::Lookup { .. } => {
@@ -1271,7 +1264,7 @@ fn lower_instruction(
             let key = val_map[&keys[0]];
             let result = val_map[&results[0]];
             let flag_val = val_map[flag];
-            let fn_id = lookup_fns.get_darray_call_fn(arr_type, llssa);
+            let fn_id = lookup_fns.get_darray_call_fn(arr_type, e.ssa);
             e.call(fn_id, vec![ll_arr, key, result, flag_val], 0);
         }
         OpCode::DLookup {
@@ -1291,7 +1284,7 @@ fn lower_instruction(
             );
             let key = val_map[&keys[0]];
             let flag_val = val_map[flag];
-            let fn_id = lookup_fns.get_drngchk_8_call_fn(llssa);
+            let fn_id = lookup_fns.get_drngchk_8_call_fn(e.ssa);
             e.call(fn_id, vec![key, flag_val], 0);
         }
         OpCode::DLookup {
@@ -1309,7 +1302,7 @@ fn lower_instruction(
             let key = val_map[&keys[0]];
             let result = val_map[&results[0]];
             let flag_val = val_map[flag];
-            let fn_id = lookup_fns.get_dspread_call_fn(*bits, llssa);
+            let fn_id = lookup_fns.get_dspread_call_fn(*bits, e.ssa);
             e.call(fn_id, vec![key, result, flag_val], 0);
         }
         OpCode::DLookup { .. } => {
@@ -1652,7 +1645,6 @@ fn lower_ref_store(
     ptr: ValueId,
     value: ValueId,
     inner_type: &HLType,
-    llssa: &mut LLSSA,
     drop_fns: &mut Vec<DropFnEntry>,
     ad_fns: &mut AdFunctions,
 ) {
@@ -1663,7 +1655,7 @@ fn lower_ref_store(
     let slot = e.struct_field_ptr(ll_ptr, rc_struct, 1);
 
     if needs_drop(&inner_type.expr) {
-        let drop_fn = get_or_create_drop_fn(inner_type, llssa, drop_fns, ad_fns);
+        let drop_fn = get_or_create_drop_fn(inner_type, e.ssa, drop_fns, ad_fns);
         let old = e.ll_load(slot, LLType::Ptr);
         let null = e.null_ptr();
         let is_null = e.int_eq(old, null);
@@ -1742,7 +1734,6 @@ fn lower_array_set(
     array: ValueId,
     index: ValueId,
     value: ValueId,
-    llssa: &mut LLSSA,
     drop_fns: &mut Vec<DropFnEntry>,
     ad_fns: &mut AdFunctions,
 ) {
@@ -1753,7 +1744,7 @@ fn lower_array_set(
     let elem_is_rc = needs_drop(&et.expr);
 
     let inner_drop_fn = if elem_is_rc {
-        Some(get_or_create_drop_fn(et, llssa, drop_fns, ad_fns))
+        Some(get_or_create_drop_fn(et, e.ssa, drop_fns, ad_fns))
     } else {
         None
     };
@@ -1896,12 +1887,11 @@ fn lower_rc_drop(
     val_map: &HashMap<ValueId, ValueId>,
     fn_type_info: &FunctionTypeInfo,
     value: ValueId,
-    llssa: &mut LLSSA,
     drop_fns: &mut Vec<DropFnEntry>,
     ad_fns: &mut AdFunctions,
 ) {
     let arr_type = fn_type_info.get_value_type(value);
-    let drop_fn_id = get_or_create_drop_fn(arr_type, llssa, drop_fns, ad_fns);
+    let drop_fn_id = get_or_create_drop_fn(arr_type, e.ssa, drop_fns, ad_fns);
     let ll_arr = val_map[&value];
     e.call(drop_fn_id, vec![ll_arr], 0);
 }
@@ -2091,11 +2081,10 @@ fn lower_ad_rc_drop(
     e: &mut LLBlockEmitter<'_>,
     val_map: &HashMap<ValueId, ValueId>,
     value: ValueId,
-    llssa: &mut LLSSA,
     ad_fns: &mut AdFunctions,
 ) {
     let ll_node = val_map[&value];
-    let drop_fn = ad_fns.get_drop_fn(llssa);
+    let drop_fn = ad_fns.get_drop_fn(e.ssa);
     e.call(drop_fn, vec![ll_node], 0);
 }
 
@@ -2114,7 +2103,7 @@ fn generate_all_ad_functions(llssa: &mut LLSSA, ad_fns: &AdFunctions) {
     if let Some(bumps) = &ad_fns.bumps {
         for matrix in [DMatrix::A, DMatrix::B, DMatrix::C] {
             let id = bumps.get(matrix);
-            let func = generate_ad_bump_function(matrix);
+            let func = generate_ad_bump_function(llssa, matrix);
             let _old = llssa.take_function(id);
             llssa.put_function(id, func);
         }
@@ -2125,7 +2114,7 @@ fn generate_all_ad_functions(llssa: &mut LLSSA, ad_fns: &AdFunctions) {
             "ICE: ad_drop allocated without bump functions. \
              This is a bug in AdFunctions — get_drop_fn must call ensure_bumps.",
         );
-        let func = generate_ad_drop_function(bumps, drop_id);
+        let func = generate_ad_drop_function(llssa, bumps, drop_id);
         let _old = llssa.take_function(drop_id);
         llssa.put_function(drop_id, func);
     }
@@ -2138,7 +2127,7 @@ fn generate_all_ad_functions(llssa: &mut LLSSA, ad_fns: &AdFunctions) {
 ///   WITNESS:   ad_write_witness(matrix, node.index, amount)
 ///   SUM:       node.d{a,b,c} += amount  (field add)
 ///   MUL_CONST: node.d{a,b,c} += amount  (field add)
-fn generate_ad_bump_function(matrix: DMatrix) -> LLFunction {
+fn generate_ad_bump_function(llssa: &mut LLSSA, matrix: DMatrix) -> LLFunction {
     let name = match matrix {
         DMatrix::A => "__ad_bump_da",
         DMatrix::B => "__ad_bump_db",
@@ -2150,10 +2139,10 @@ fn generate_ad_bump_function(matrix: DMatrix) -> LLFunction {
         DMatrix::C => 6,
     };
 
-    let mut func = new_ll_function(name.to_string());
+    let mut func = new_ll_function(llssa, name.to_string());
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, entry);
+    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
     let node = e.add_parameter(LLType::Ptr);
     let amount = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
 
@@ -2237,8 +2226,12 @@ fn generate_ad_bump_function(matrix: DMatrix) -> LLFunction {
 ///   CONST/WITNESS: free
 ///   SUM: propagate da/db/dc to children, drop children, free
 ///   MUL_CONST: propagate da*coeff/db*coeff/dc*coeff to child, drop child, free
-fn generate_ad_drop_function(bumps: &AdBumpIds, ad_drop_id: FunctionId) -> LLFunction {
-    let mut func = new_ll_function("__ad_drop".to_string());
+fn generate_ad_drop_function(
+    llssa: &mut LLSSA,
+    bumps: &AdBumpIds,
+    ad_drop_id: FunctionId,
+) -> LLFunction {
+    let mut func = new_ll_function(llssa, "__ad_drop".to_string());
     let entry = func.get_entry_id();
 
     let field_type = LLType::Struct(LLStruct::field_elem());
@@ -2247,7 +2240,7 @@ fn generate_ad_drop_function(bumps: &AdBumpIds, ad_drop_id: FunctionId) -> LLFun
     let bump_db = bumps.db;
     let bump_dc = bumps.dc;
 
-    let mut e = LLBlockEmitter::new(&mut func, entry);
+    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
     let node = e.add_parameter(LLType::Ptr);
 
     // Decrement RC
@@ -2364,11 +2357,13 @@ fn generate_ad_drop_function(bumps: &AdBumpIds, ad_drop_id: FunctionId) -> LLFun
 fn generate_all_drop_functions(llssa: &mut LLSSA, drop_fns: &[DropFnEntry]) {
     for entry in drop_fns {
         let func = match &entry.ty.expr {
-            HLTypeExpr::Array(..) => generate_drop_function_for_array(&entry.ty, drop_fns),
+            HLTypeExpr::Array(..) => generate_drop_function_for_array(llssa, &entry.ty, drop_fns),
             HLTypeExpr::Tuple(elements) => {
-                generate_drop_function_for_tuple(elements, &entry.ty, drop_fns)
+                generate_drop_function_for_tuple(llssa, elements, &entry.ty, drop_fns)
             }
-            HLTypeExpr::Ref(inner) => generate_drop_function_for_ref(inner, &entry.ty, drop_fns),
+            HLTypeExpr::Ref(inner) => {
+                generate_drop_function_for_ref(llssa, inner, &entry.ty, drop_fns)
+            }
             // WitnessOf points to ad_drop, whose body is generated by generate_all_ad_functions
             HLTypeExpr::WitnessOf(_) => continue,
             other => panic!("No drop function generator for type: {:?}", other),
@@ -2398,16 +2393,20 @@ fn needs_drop(expr: &HLTypeExpr) -> bool {
 ///         drop(ptr.data[i])
 ///       free(ptr)
 ///     return
-fn generate_drop_function_for_array(ty: &HLType, drop_fns: &[DropFnEntry]) -> LLFunction {
+fn generate_drop_function_for_array(
+    llssa: &mut LLSSA,
+    ty: &HLType,
+    drop_fns: &[DropFnEntry],
+) -> LLFunction {
     let (et, count) = array_info(ty);
     let rc_struct = rc_array_struct(et, count);
     let es = elem_struct(et);
     let elem_is_rc = needs_drop(&et.expr);
 
-    let mut func = new_ll_function(format!("drop_{}", ty));
+    let mut func = new_ll_function(llssa, format!("drop_{}", ty));
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, entry);
+    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
 
     let ptr = e.add_parameter(LLType::Ptr);
 
@@ -2465,16 +2464,17 @@ fn generate_drop_function_for_array(ty: &HLType, drop_fns: &[DropFnEntry]) -> LL
 ///       free(ptr)
 ///     return
 fn generate_drop_function_for_tuple(
+    llssa: &mut LLSSA,
     element_types: &[HLType],
     ty: &HLType,
     drop_fns: &[DropFnEntry],
 ) -> LLFunction {
     let rc_struct = rc_tuple_struct(element_types);
 
-    let mut func = new_ll_function(format!("drop_{}", ty));
+    let mut func = new_ll_function(llssa, format!("drop_{}", ty));
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, entry);
+    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
     let ptr = e.add_parameter(LLType::Ptr);
 
     // Decrement RC
@@ -2532,6 +2532,7 @@ fn generate_drop_function_for_tuple(
 ///       free(ptr)
 ///     return
 fn generate_drop_function_for_ref(
+    llssa: &mut LLSSA,
     inner_type: &HLType,
     ty: &HLType,
     drop_fns: &[DropFnEntry],
@@ -2539,10 +2540,10 @@ fn generate_drop_function_for_ref(
     let rc_struct = rc_ref_cell_struct(inner_type);
     let inner_is_rc = needs_drop(&inner_type.expr);
 
-    let mut func = new_ll_function(format!("drop_{}", ty));
+    let mut func = new_ll_function(llssa, format!("drop_{}", ty));
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, entry);
+    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
     let ptr = e.add_parameter(LLType::Ptr);
 
     let hdr = e.struct_field_ptr(ptr, rc_struct.clone(), 0);
@@ -2658,7 +2659,7 @@ fn generate_all_lookup_functions(
         let table_idx_global = lookup_fns
             .rngchk_8_table_idx_global
             .expect("rangecheck-8 helper registered without internal table-id global");
-        let func = generate_rngchk_8_function(table_idx_global);
+        let func = generate_rngchk_8_function(llssa, table_idx_global);
         llssa.put_function(id, func);
     }
 
@@ -2668,12 +2669,12 @@ fn generate_all_lookup_functions(
             .get(bits)
             .copied()
             .expect("spread helper registered without internal table-id global");
-        let func = generate_spread_lookup_function(*bits, table_idx_global);
+        let func = generate_spread_lookup_function(llssa, *bits, table_idx_global);
         llssa.put_function(*id, func);
     }
 
     for entry in &lookup_fns.array {
-        let func = generate_array_lookup_function(&entry.ty);
+        let func = generate_array_lookup_function(llssa, &entry.ty);
         llssa.put_function(entry.fn_id, func);
     }
 
@@ -2686,6 +2687,7 @@ fn generate_all_lookup_functions(
         let bump_db_id = ad_fns.get_bump_fn(DMatrix::B, llssa);
         let bump_dc_id = ad_fns.get_bump_fn(DMatrix::C, llssa);
         let call_fn = generate_drngchk_8_ad_call(
+            llssa,
             inv_cnst_off_global,
             witness_layout,
             constraints_layout,
@@ -2707,6 +2709,7 @@ fn generate_all_lookup_functions(
         let bump_db_id = ad_fns.get_bump_fn(DMatrix::B, llssa);
         let bump_dc_id = ad_fns.get_bump_fn(DMatrix::C, llssa);
         let call_fn = generate_dspread_ad_call(
+            llssa,
             *bits,
             inv_cnst_off_global,
             witness_layout,
@@ -2724,6 +2727,7 @@ fn generate_all_lookup_functions(
         let bump_db_id = ad_fns.get_bump_fn(DMatrix::B, llssa);
         let bump_dc_id = ad_fns.get_bump_fn(DMatrix::C, llssa);
         let call_fn = generate_darray_ad_call(
+            llssa,
             &entry.ty,
             witness_layout,
             constraints_layout,
@@ -3116,15 +3120,15 @@ fn ad_bump_lookup_elem_db(
     }
 }
 
-fn generate_array_lookup_function(array_type: &HLType) -> LLFunction {
+fn generate_array_lookup_function(llssa: &mut LLSSA, array_type: &HLType) -> LLFunction {
     let (elem_type, count) = array_info(array_type);
     let lookup = LookupTableSpec::array(count);
     let rc_struct = rc_array_struct(elem_type, count);
     let elem_struct = elem_struct(elem_type);
-    let mut func = new_ll_function(format!("__array_lookup_{}", array_type));
+    let mut func = new_ll_function(llssa, format!("__array_lookup_{}", array_type));
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, entry);
+    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
     let array = e.add_parameter(LLType::Ptr);
     let key_field = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
     let result_field = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
@@ -3188,7 +3192,11 @@ fn generate_array_lookup_function(array_type: &HLType) -> LLFunction {
     func
 }
 
-fn generate_spread_lookup_function(bits: u8, table_idx_global: usize) -> LLFunction {
+fn generate_spread_lookup_function(
+    llssa: &mut LLSSA,
+    bits: u8,
+    table_idx_global: usize,
+) -> LLFunction {
     assert!(
         bits <= 16,
         "Spread lookup helper currently supports bit-widths up to 16, got {}",
@@ -3196,10 +3204,10 @@ fn generate_spread_lookup_function(bits: u8, table_idx_global: usize) -> LLFunct
     );
     let lookup = LookupTableSpec::spread(bits);
     let length = lookup.length;
-    let mut func = new_ll_function(format!("__spread_{}_lookup", bits));
+    let mut func = new_ll_function(llssa, format!("__spread_{}_lookup", bits));
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, entry);
+    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
     let key_field = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
     let result_field = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
     let flag_field = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
@@ -3288,12 +3296,12 @@ fn generate_spread_lookup_function(bits: u8, table_idx_global: usize) -> LLFunct
 /// Phase 2 — which runs on the host after WASM returns — fixes the raw-u64
 /// multiplicity slots into Montgomery form and materializes the per-slot
 /// inverses + sum constraint.
-fn generate_rngchk_8_function(table_idx_global: usize) -> LLFunction {
+fn generate_rngchk_8_function(llssa: &mut LLSSA, table_idx_global: usize) -> LLFunction {
     let lookup = LookupTableSpec::rangecheck8();
-    let mut func = new_ll_function("__rngchk_8".to_string());
+    let mut func = new_ll_function(llssa, "__rngchk_8".to_string());
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, entry);
+    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
     let val = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
     let flag = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
 
@@ -3635,6 +3643,7 @@ fn emit_array_ad_init_body(
 }
 
 fn generate_darray_ad_call(
+    llssa: &mut LLSSA,
     array_type: &HLType,
     witness_layout: WitnessLayout,
     constraints_layout: ConstraintsLayout,
@@ -3644,10 +3653,10 @@ fn generate_darray_ad_call(
     let (elem_type, count) = array_info(array_type);
     let lookup = LookupTableSpec::array(count);
     let rc_struct = rc_array_struct(elem_type, count);
-    let mut func = new_ll_function(format!("__darray_lookup_{}_ad_call", array_type));
+    let mut func = new_ll_function(llssa, format!("__darray_lookup_{}_ad_call", array_type));
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, entry);
+    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
     let array = e.add_parameter(LLType::Ptr);
     let key_ptr = e.add_parameter(LLType::Ptr);
     let result_ptr = e.add_parameter(LLType::Ptr);
@@ -3695,6 +3704,7 @@ fn generate_darray_ad_call(
 }
 
 fn generate_dspread_ad_call(
+    llssa: &mut LLSSA,
     bits: u8,
     inv_cnst_off_global: usize,
     witness_layout: WitnessLayout,
@@ -3704,10 +3714,10 @@ fn generate_dspread_ad_call(
     bump_dc_fn: FunctionId,
 ) -> LLFunction {
     let lookup = LookupTableSpec::spread(bits);
-    let mut func = new_ll_function(format!("__dspread_{}_ad_call", bits));
+    let mut func = new_ll_function(llssa, format!("__dspread_{}_ad_call", bits));
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, entry);
+    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
     let key_ptr = e.add_parameter(LLType::Ptr);
     let result_ptr = e.add_parameter(LLType::Ptr);
     let flag_ptr = e.add_parameter(LLType::Ptr);
@@ -3771,16 +3781,17 @@ fn generate_dspread_ad_call(
 /// branch reads the table region's start from runtime cursors rather than
 /// baking `tables_data_start` constants.
 fn generate_drngchk_8_ad_call(
+    llssa: &mut LLSSA,
     inv_cnst_off_global: usize,
     witness_layout: WitnessLayout,
     constraints_layout: ConstraintsLayout,
     bump_db_fn: FunctionId,
     bump_dc_fn: FunctionId,
 ) -> LLFunction {
-    let mut func = new_ll_function("__drngchk_8_ad_call".to_string());
+    let mut func = new_ll_function(llssa, "__drngchk_8_ad_call".to_string());
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, entry);
+    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
     let val_ptr = e.add_parameter(LLType::Ptr);
     let flag_ptr = e.add_parameter(LLType::Ptr);
 

--- a/compiler/src/compiler/ssa/llssa/builder.rs
+++ b/compiler/src/compiler/ssa/llssa/builder.rs
@@ -1,8 +1,8 @@
 use crate::compiler::ssa::{
     FunctionId, ValueId,
-    builder::{BlockEmitter, FunctionBuilder, InstrBuilder},
+    builder::{BlockEmitter, FunctionBuilder, InstrBuilder, SSABuilder},
     hlssa::DMatrix,
-    llssa::{FieldArithOp, IntArithOp, IntCmpOp, LLOp, LLStruct, Type},
+    llssa::{Constants, FieldArithOp, IntArithOp, IntCmpOp, LLOp, LLStruct, Type},
 };
 
 // ---------------------------------------------------------------------------
@@ -387,9 +387,10 @@ fn ad_out_field(matrix: DMatrix) -> usize {
 // Type aliases
 // ---------------------------------------------------------------------------
 
-pub type LLInstrBuilder<'a> = InstrBuilder<'a, LLOp, Type>;
-pub type LLFunctionBuilder<'a> = FunctionBuilder<'a, LLOp, Type>;
-pub type LLBlockEmitter<'a> = BlockEmitter<'a, LLOp, Type>;
+pub type LLInstrBuilder<'a> = InstrBuilder<'a, LLOp, Type, Constants>;
+pub type LLFunctionBuilder<'a> = FunctionBuilder<'a, LLOp, Type, Constants>;
+pub type LLBlockEmitter<'a> = BlockEmitter<'a, LLOp, Type, Constants>;
+pub type LLSSABuilder<'a> = SSABuilder<'a, LLOp, Type, Constants>;
 
 // ---------------------------------------------------------------------------
 // LLEmitter impls
@@ -397,7 +398,7 @@ pub type LLBlockEmitter<'a> = BlockEmitter<'a, LLOp, Type>;
 
 impl LLEmitter for LLInstrBuilder<'_> {
     fn fresh_value(&mut self) -> ValueId {
-        self.function.fresh_value()
+        self.ssa.fresh_value()
     }
 
     fn emit_ll(&mut self, op: LLOp) {
@@ -416,7 +417,7 @@ impl LLEmitter for LLInstrBuilder<'_> {
 
 impl LLEmitter for LLBlockEmitter<'_> {
     fn fresh_value(&mut self) -> ValueId {
-        self.function.fresh_value()
+        self.ssa.fresh_value()
     }
 
     fn emit_ll(&mut self, op: LLOp) {

--- a/compiler/src/compiler/ssa/llssa/mod.rs
+++ b/compiler/src/compiler/ssa/llssa/mod.rs
@@ -17,7 +17,15 @@ pub use super::hlssa::DMatrix;
 
 /// The low-level SSA exposes runtime details: explicit struct layouts, pointer arithmetic,
 /// integer/field arithmetic split, and explicit memory management.
-pub type LLSSA = SSA<LLOp, Type>;
+pub type LLSSA = SSA<LLOp, Type, Constants>;
+
+// CONSTANT STORAGE
+// ================================================================================================
+
+/// Constant storage for the low-level SSA. Currently a placeholder while constants still live
+/// inline as `LLOp::IntConst` / `LLOp::NullPtr` instructions; future work moves the constant data
+/// into this side-table for the LLVM backend.
+pub type Constants = ();
 
 // LLSSA OPCODES
 // ================================================================================================
@@ -1016,7 +1024,7 @@ impl Display for FieldArithOp {
 mod tests {
     use super::*;
     use crate::compiler::ssa::DefaultSSAAnnotator;
-    use crate::compiler::ssa::llssa::builder::{LLBlockEmitter, LLEmitter};
+    use crate::compiler::ssa::llssa::builder::{LLEmitter, LLSSABuilder};
 
     #[test]
     fn field_elem_is_value_safe() {
@@ -1111,17 +1119,17 @@ mod tests {
 
     #[test]
     fn build_simple_function() {
-        let mut ssa = LLSSA::with_main("test_main".to_string());
-        let func = ssa.get_main_mut();
-        let entry = func.get_entry_id();
-
-        {
-            let mut e = LLBlockEmitter::new(func, entry);
+        let mut ssa = LLSSA::with_main("test_main".to_string(), ());
+        let main_id = ssa.get_main_id();
+        let mut sb = LLSSABuilder::new(&mut ssa);
+        sb.modify_function(main_id, |fb| {
+            let entry = fb.function.get_entry_id();
+            let mut e = fb.block(entry);
             let x = e.int_const(64, 42);
             let y = e.int_const(64, 7);
             let z = e.int_add(x, y);
             e.terminate_return(vec![z]);
-        }
+        });
 
         let dump = ssa.to_string(&DefaultSSAAnnotator);
         assert!(dump.contains("int_const i64 42"));
@@ -1132,9 +1140,8 @@ mod tests {
 
     #[test]
     fn build_struct_ops() {
-        let mut ssa = LLSSA::with_main("struct_test".to_string());
-        let func = ssa.get_main_mut();
-        let entry = func.get_entry_id();
+        let mut ssa = LLSSA::with_main("struct_test".to_string(), ());
+        let main_id = ssa.get_main_id();
 
         let field_elem = LLStruct::new(vec![
             LLFieldType::Int(64),
@@ -1143,8 +1150,10 @@ mod tests {
             LLFieldType::Int(64),
         ]);
 
-        {
-            let mut e = LLBlockEmitter::new(func, entry);
+        let mut sb = LLSSABuilder::new(&mut ssa);
+        sb.modify_function(main_id, |fb| {
+            let entry = fb.function.get_entry_id();
+            let mut e = fb.block(entry);
             let l0 = e.int_const(64, 1);
             let l1 = e.int_const(64, 0);
             let l2 = e.int_const(64, 0);
@@ -1152,7 +1161,7 @@ mod tests {
             let s = e.mk_struct(field_elem.clone(), vec![l0, l1, l2, l3]);
             let f0 = e.extract_field(s, field_elem, 0);
             e.terminate_return(vec![f0, s]);
-        }
+        });
 
         let dump = ssa.to_string(&DefaultSSAAnnotator);
         assert!(dump.contains("mk_struct"));
@@ -1161,9 +1170,8 @@ mod tests {
 
     #[test]
     fn build_memory_ops() {
-        let mut ssa = LLSSA::with_main("memory_test".to_string());
-        let func = ssa.get_main_mut();
-        let entry = func.get_entry_id();
+        let mut ssa = LLSSA::with_main("memory_test".to_string(), ());
+        let main_id = ssa.get_main_id();
 
         let rc_header = LLStruct::new(vec![LLFieldType::Int(64)]);
         let field_elem = LLStruct::new(vec![
@@ -1177,8 +1185,10 @@ mod tests {
             LLFieldType::InlineArray(field_elem.clone(), 3),
         ]);
 
-        {
-            let mut e = LLBlockEmitter::new(func, entry);
+        let mut sb = LLSSABuilder::new(&mut ssa);
+        sb.modify_function(main_id, |fb| {
+            let entry = fb.function.get_entry_id();
+            let mut e = fb.block(entry);
             let arr = e.heap_alloc(rc_array.clone(), None);
             let rc_ptr = e.struct_field_ptr(arr, rc_array.clone(), 0);
             let rc_word = e.struct_field_ptr(rc_ptr, rc_header, 0);
@@ -1191,7 +1201,7 @@ mod tests {
             let loaded = e.ll_load(elem_ptr, Type::i64());
             e.free(arr);
             e.terminate_return(vec![loaded]);
-        }
+        });
 
         let dump = ssa.to_string(&DefaultSSAAnnotator);
         assert!(dump.contains("heap_alloc"));
@@ -1204,20 +1214,20 @@ mod tests {
 
     #[test]
     fn build_call_and_select() {
-        let mut ssa = LLSSA::with_main("call_test".to_string());
+        let mut ssa = LLSSA::with_main("call_test".to_string(), ());
         let helper_id = ssa.add_function("helper".to_string());
-        let func = ssa.get_main_mut();
-        let entry = func.get_entry_id();
-
-        {
-            let mut e = LLBlockEmitter::new(func, entry);
+        let main_id = ssa.get_main_id();
+        let mut sb = LLSSABuilder::new(&mut ssa);
+        sb.modify_function(main_id, |fb| {
+            let entry = fb.function.get_entry_id();
+            let mut e = fb.block(entry);
             let a = e.int_const(64, 1);
             let b = e.int_const(64, 2);
             let results = e.call(helper_id, vec![a, b], 1);
             let cond = e.int_eq(results[0], a);
             let selected = e.select(cond, a, b);
             e.terminate_return(vec![selected]);
-        }
+        });
 
         let dump = ssa.to_string(&DefaultSSAAnnotator);
         assert!(dump.contains("call helper@"));
@@ -1227,9 +1237,8 @@ mod tests {
 
     #[test]
     fn build_field_ops() {
-        let mut ssa = LLSSA::with_main("field_test".to_string());
-        let func = ssa.get_main_mut();
-        let entry = func.get_entry_id();
+        let mut ssa = LLSSA::with_main("field_test".to_string(), ());
+        let main_id = ssa.get_main_id();
 
         let field_elem = LLStruct::new(vec![
             LLFieldType::Int(64),
@@ -1238,8 +1247,10 @@ mod tests {
             LLFieldType::Int(64),
         ]);
 
-        {
-            let mut e = LLBlockEmitter::new(func, entry);
+        let mut sb = LLSSABuilder::new(&mut ssa);
+        sb.modify_function(main_id, |fb| {
+            let entry = fb.function.get_entry_id();
+            let mut e = fb.block(entry);
             let l0 = e.int_const(64, 1);
             let l1 = e.int_const(64, 0);
             let l2 = e.int_const(64, 0);
@@ -1253,7 +1264,7 @@ mod tests {
             let limbs = e.field_to_limbs(d);
             let back = e.field_from_limbs(limbs);
             e.terminate_return(vec![eq, back]);
-        }
+        });
 
         let dump = ssa.to_string(&DefaultSSAAnnotator);
         assert!(dump.contains("field.add"));
@@ -1265,19 +1276,19 @@ mod tests {
 
     #[test]
     fn build_width_and_global() {
-        let mut ssa = LLSSA::with_main("width_test".to_string());
-        let func = ssa.get_main_mut();
-        let entry = func.get_entry_id();
-
-        {
-            let mut e = LLBlockEmitter::new(func, entry);
+        let mut ssa = LLSSA::with_main("width_test".to_string(), ());
+        let main_id = ssa.get_main_id();
+        let mut sb = LLSSABuilder::new(&mut ssa);
+        sb.modify_function(main_id, |fb| {
+            let entry = fb.function.get_entry_id();
+            let mut e = fb.block(entry);
             let x = e.int_const(64, 256);
             let narrow = e.truncate(x, 8);
             let wide = e.zext(narrow, 64);
             let gp = e.global_addr(3);
             e.ll_store(gp, wide);
             e.trap();
-        }
+        });
 
         let dump = ssa.to_string(&DefaultSSAAnnotator);
         assert!(dump.contains("trunc"));
@@ -1288,32 +1299,35 @@ mod tests {
 
     #[test]
     fn build_branching() {
-        let mut ssa = LLSSA::with_main("branch_test".to_string());
-        let func = ssa.get_main_mut();
-        let entry = func.get_entry_id();
-        let then_blk = func.add_block();
-        let else_blk = func.add_block();
-        let merge_blk = func.add_block();
+        let mut ssa = LLSSA::with_main("branch_test".to_string(), ());
+        let main_id = ssa.get_main_id();
+        let mut sb = LLSSABuilder::new(&mut ssa);
+        sb.modify_function(main_id, |fb| {
+            let entry = fb.function.get_entry_id();
+            let then_blk = fb.function.add_block();
+            let else_blk = fb.function.add_block();
+            let merge_blk = fb.function.add_block();
 
-        {
-            let mut e = LLBlockEmitter::new(func, entry);
-            let x = e.int_const(64, 42);
-            let zero = e.int_const(64, 0);
-            let cond = e.int_eq(x, zero);
-            e.terminate_jmp_if(cond, then_blk, else_blk);
-        }
-        {
-            let mut e = LLBlockEmitter::new(func, then_blk);
-            let one = e.int_const(64, 1);
-            e.terminate_jmp(merge_blk, vec![one]);
-        }
-        {
-            let mut e = LLBlockEmitter::new(func, else_blk);
-            let two = e.int_const(64, 2);
-            e.terminate_jmp(merge_blk, vec![two]);
-        }
+            {
+                let mut e = fb.block(entry);
+                let x = e.int_const(64, 42);
+                let zero = e.int_const(64, 0);
+                let cond = e.int_eq(x, zero);
+                e.terminate_jmp_if(cond, then_blk, else_blk);
+            }
+            {
+                let mut e = fb.block(then_blk);
+                let one = e.int_const(64, 1);
+                e.terminate_jmp(merge_blk, vec![one]);
+            }
+            {
+                let mut e = fb.block(else_blk);
+                let two = e.int_const(64, 2);
+                e.terminate_jmp(merge_blk, vec![two]);
+            }
 
-        func.terminate_block_with_return(merge_blk, vec![]);
+            fb.function.terminate_block_with_return(merge_blk, vec![]);
+        });
 
         let dump = ssa.to_string(&DefaultSSAAnnotator);
         assert!(dump.contains("jmp_if"));
@@ -1322,20 +1336,21 @@ mod tests {
 
     #[test]
     fn build_memcpy() {
-        let mut ssa = LLSSA::with_main("memcpy_test".to_string());
-        let func = ssa.get_main_mut();
-        let entry = func.get_entry_id();
+        let mut ssa = LLSSA::with_main("memcpy_test".to_string(), ());
+        let main_id = ssa.get_main_id();
 
         let elem = LLStruct::new(vec![LLFieldType::Int(64)]);
 
-        {
-            let mut e = LLBlockEmitter::new(func, entry);
+        let mut sb = LLSSABuilder::new(&mut ssa);
+        sb.modify_function(main_id, |fb| {
+            let entry = fb.function.get_entry_id();
+            let mut e = fb.block(entry);
             let dst = e.null_ptr();
             let src = e.null_ptr();
             let count = e.int_const(64, 10);
             e.memcpy(dst, src, elem, Some(count));
             e.terminate_return(vec![]);
-        }
+        });
 
         let dump = ssa.to_string(&DefaultSSAAnnotator);
         assert!(dump.contains("memcpy"));

--- a/compiler/src/compiler/ssa/mod.rs
+++ b/compiler/src/compiler/ssa/mod.rs
@@ -9,7 +9,7 @@ pub mod llssa;
 pub mod traits;
 
 use itertools::Itertools;
-use std::{collections::HashMap, vec};
+use std::{collections::HashMap, fmt::Debug, vec};
 
 pub use id::{BlockId, FunctionId, ValueId};
 pub use traits::{Instruction, SSAAnotator, SSAType};
@@ -19,8 +19,13 @@ pub use traits::{Instruction, SSAAnotator, SSAType};
 
 /// The SSA structure used by the Mavros compiler, providing a generic IR that can be tailored with
 /// custom instructions and types.
+///
+/// - `Op` is the type of instructions in the SSA, allowing customization of the instruction set
+///   over which the IR is operating.
+/// - `Ty` is the type system for the SSA, describing the valid types and their interactions.
+/// - `Cn` is the type of the constant storage for the SSA, providing an arbitrary interface.
 #[derive(Clone)]
-pub struct SSA<Op: Instruction, Ty: SSAType> {
+pub struct SSA<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> {
     /// A mapping from function identifiers to true functions contained in the SSA.
     functions: HashMap<FunctionId, Function<Op, Ty>>,
 
@@ -42,10 +47,16 @@ pub struct SSA<Op: Instruction, Ty: SSAType> {
 
     /// A monotonic counter for function identifiers, used to ensure uniqueness.
     next_function_id: u64,
+
+    /// A monotonic counter for `ValueId`s, globally unique within this SSA.
+    next_value_id: u64,
+
+    /// Side-table holding constant data for the SSA.
+    constants: Cn,
 }
 
-impl<Op: Instruction, Ty: SSAType> SSA<Op, Ty> {
-    pub fn with_main(name: String) -> Self {
+impl<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSA<Op, Ty, Cn> {
+    pub fn with_main(name: String, constants: Cn) -> Self {
         let main_function = Function::<Op, Ty>::empty(name);
         let main_id = FunctionId(0);
         let mut functions = HashMap::new();
@@ -57,12 +68,20 @@ impl<Op: Instruction, Ty: SSAType> SSA<Op, Ty> {
             globals_deinit_fn: None,
             main_id,
             next_function_id: 1,
+            next_value_id: 0,
+            constants,
         }
     }
 }
 
-impl<Op: Instruction, Ty: SSAType> SSA<Op, Ty> {
-    pub fn prepare_rebuild(self) -> (SSA<Op, Ty>, HashMap<FunctionId, Function<Op, Ty>>, Vec<Ty>) {
+impl<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSA<Op, Ty, Cn> {
+    pub fn prepare_rebuild(
+        self,
+    ) -> (
+        SSA<Op, Ty, Cn>,
+        HashMap<FunctionId, Function<Op, Ty>>,
+        Vec<Ty>,
+    ) {
         (
             SSA {
                 functions: HashMap::new(),
@@ -71,6 +90,8 @@ impl<Op: Instruction, Ty: SSAType> SSA<Op, Ty> {
                 globals_deinit_fn: self.globals_deinit_fn,
                 main_id: self.main_id,
                 next_function_id: self.next_function_id,
+                next_value_id: self.next_value_id,
+                constants: self.constants,
             },
             self.functions,
             self.global_types,
@@ -128,6 +149,27 @@ impl<Op: Instruction, Ty: SSAType> SSA<Op, Ty> {
         new_id
     }
 
+    /// Allocate a fresh `ValueId` from the SSA-wide counter.
+    pub fn fresh_value(&mut self) -> ValueId {
+        let value_id = ValueId(self.next_value_id);
+        self.next_value_id += 1;
+        value_id
+    }
+
+    /// Upper bound on `ValueId`s issued so far. Useful for sizing dense per-value tables.
+    pub fn value_num_bound(&self) -> usize {
+        self.next_value_id as usize
+    }
+
+    /// Advance the value counter to `end` if it is currently lower. Used by passes that
+    /// allocate `ValueId`s into a transient buffer (see e.g. the specializer) and want to
+    /// reconcile the buffer's IDs back into the SSA.
+    pub fn reserve_values_up_to(&mut self, end: u64) {
+        if end > self.next_value_id {
+            self.next_value_id = end;
+        }
+    }
+
     pub fn iter_functions(&self) -> impl Iterator<Item = (&FunctionId, &Function<Op, Ty>)> {
         self.functions.iter()
     }
@@ -169,9 +211,17 @@ impl<Op: Instruction, Ty: SSAType> SSA<Op, Ty> {
     pub fn get_globals_deinit_fn(&self) -> Option<FunctionId> {
         self.globals_deinit_fn
     }
+
+    pub fn const_storage(&self) -> &Cn {
+        &self.constants
+    }
+
+    pub fn const_storage_mut(&mut self) -> &mut Cn {
+        &mut self.constants
+    }
 }
 
-impl<Op: Instruction, Ty: SSAType> SSA<Op, Ty> {
+impl<Op: Instruction, Ty: SSAType, C: Clone + Debug> SSA<Op, Ty, C> {
     pub fn to_string(&self, value_annotator: &dyn SSAAnotator) -> String {
         let func_name = |id: FunctionId| self.get_function(id).get_name().to_string();
         self.functions
@@ -193,7 +243,6 @@ pub struct Function<Op: Instruction, Ty: SSAType> {
     name: String,
     returns: Vec<Ty>,
     next_block: u64,
-    next_value: u64,
 }
 
 impl<Op: Instruction, Ty: SSAType> Function<Op, Ty> {
@@ -234,7 +283,6 @@ impl<Op: Instruction, Ty: SSAType> Function<Op, Ty> {
             name,
             next_block: 1,
             returns: Vec::new(),
-            next_value: 0,
         }
     }
 
@@ -246,7 +294,6 @@ impl<Op: Instruction, Ty: SSAType> Function<Op, Ty> {
                 next_block: self.next_block,
                 name: self.name,
                 returns: vec![],
-                next_value: self.next_value,
             },
             self.blocks,
             self.returns,
@@ -259,10 +306,6 @@ impl<Op: Instruction, Ty: SSAType> Function<Op, Ty> {
 
     pub fn set_name(&mut self, name: String) {
         self.name = name;
-    }
-
-    pub fn get_var_num_bound(&self) -> usize {
-        self.next_value as usize
     }
 
     pub fn get_entry_mut(&mut self) -> &mut Block<Op, Ty> {
@@ -348,17 +391,6 @@ impl<Op: Instruction, Ty: SSAType> Function<Op, Ty> {
         self.blocks.iter()
     }
 
-    pub fn add_parameter(&mut self, block_id: BlockId, typ: Ty) -> ValueId {
-        let value_id = ValueId(self.next_value);
-        self.next_value += 1;
-        self.blocks
-            .get_mut(&block_id)
-            .unwrap()
-            .parameters
-            .push((value_id, typ));
-        value_id
-    }
-
     pub fn get_blocks_mut(&mut self) -> impl Iterator<Item = (&BlockId, &mut Block<Op, Ty>)> {
         self.blocks.iter_mut()
     }
@@ -369,12 +401,6 @@ impl<Op: Instruction, Ty: SSAType> Function<Op, Ty> {
 
     pub fn put_blocks(&mut self, blocks: HashMap<BlockId, Block<Op, Ty>>) {
         self.blocks = blocks;
-    }
-
-    pub fn fresh_value(&mut self) -> ValueId {
-        let value_id = ValueId(self.next_value);
-        self.next_value += 1;
-        value_id
     }
 
     pub fn take_returns(&mut self) -> Vec<Ty> {

--- a/compiler/src/compiler/untaint_control_flow.rs
+++ b/compiler/src/compiler/untaint_control_flow.rs
@@ -243,6 +243,7 @@ impl UntaintControlFlow {
                 self.run_function(
                     function_id,
                     &mut function,
+                    &mut ssa,
                     function_wt,
                     &flow_analysis,
                     func_type_info,
@@ -259,6 +260,7 @@ impl UntaintControlFlow {
         &mut self,
         function_id: FunctionId,
         function: &mut HLFunction,
+        ssa: &mut HLSSA,
         function_wt: &FunctionWitnessType,
         flow_analysis: &FlowAnalysis,
         type_info: Option<&FunctionTypeInfo>,
@@ -266,7 +268,12 @@ impl UntaintControlFlow {
         let cfg = flow_analysis.get_function_cfg(function_id);
 
         let cfg_witness_param = if matches!(function_wt.cfg_witness, WitnessInfo::Witness) {
-            Some(function.add_parameter(function.get_entry_id(), Type::witness_of(Type::u(1))))
+            let entry_id = function.get_entry_id();
+            let id = ssa.fresh_value();
+            function
+                .get_block_mut(entry_id)
+                .push_parameter(id, Type::witness_of(Type::u(1)));
+            Some(id)
         } else {
             None
         };
@@ -291,6 +298,7 @@ impl UntaintControlFlow {
             self.process_block(
                 block_id,
                 function,
+                ssa,
                 cfg,
                 function_wt,
                 &mut block_taint_vars,
@@ -305,6 +313,7 @@ impl UntaintControlFlow {
         &self,
         block_id: BlockId,
         function: &mut HLFunction,
+        ssa: &mut HLSSA,
         cfg: &CFG,
         function_wt: &FunctionWitnessType,
         block_taint_vars: &mut HashMap<BlockId, Option<ValueId>>,
@@ -322,6 +331,7 @@ impl UntaintControlFlow {
             self.process_instruction(
                 instruction,
                 function,
+                ssa,
                 type_info,
                 block_taint,
                 &mut new_instructions,
@@ -340,7 +350,7 @@ impl UntaintControlFlow {
                     WitnessType::Witness => {
                         let child_block_taint = match block_taint {
                             Some(tnt) => {
-                                let result_val = function.fresh_value();
+                                let result_val = ssa.fresh_value();
                                 new_instructions.push(OpCode::BinaryArithOp {
                                     kind: BinaryArithOpKind::And,
                                     result: result_val,
@@ -425,7 +435,8 @@ impl UntaintControlFlow {
                             if !args_passed_from_lhs.is_empty() {
                                 let mut instrs = Vec::new();
                                 {
-                                    let mut builder = HLInstrBuilder::new(function, &mut instrs);
+                                    let mut builder =
+                                        HLInstrBuilder::new(function, ssa, &mut instrs);
                                     for ((res, typ), (lhs, rhs)) in merge_params.iter().zip(
                                         args_passed_from_lhs
                                             .iter()
@@ -462,7 +473,7 @@ impl UntaintControlFlow {
                 if let (Some(ti), Some(param_types)) = (type_info, block_param_types.get(&target)) {
                     let mut cast_instrs = Vec::new();
                     let new_args: Vec<_> = {
-                        let mut builder = HLInstrBuilder::new(function, &mut cast_instrs);
+                        let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
                         args.iter()
                             .zip(param_types.iter())
                             .map(|(arg, expected_type)| {
@@ -480,7 +491,7 @@ impl UntaintControlFlow {
                 if let Some(ti) = type_info {
                     let mut cast_instrs = Vec::new();
                     let new_values: Vec<_> = {
-                        let mut builder = HLInstrBuilder::new(function, &mut cast_instrs);
+                        let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
                         values
                             .iter()
                             .zip(return_types.iter())
@@ -507,6 +518,7 @@ impl UntaintControlFlow {
         &self,
         instruction: OpCode,
         function: &mut HLFunction,
+        ssa: &mut HLSSA,
         type_info: Option<&FunctionTypeInfo>,
         block_taint: Option<ValueId>,
         new_instructions: &mut Vec<OpCode>,
@@ -539,7 +551,7 @@ impl UntaintControlFlow {
                 if let Some(ti) = type_info {
                     let mut cast_instrs = Vec::new();
                     let new_args: Vec<_> = {
-                        let mut builder = HLInstrBuilder::new(function, &mut cast_instrs);
+                        let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
                         args.into_iter()
                             .map(|arg| {
                                 let arg_type = ti.get_value_type(arg);
@@ -587,7 +599,7 @@ impl UntaintControlFlow {
                 let target_elem_type = tp.clone();
                 let mut cast_instrs = Vec::new();
                 let new_vs: Vec<_> = {
-                    let mut builder = HLInstrBuilder::new(function, &mut cast_instrs);
+                    let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
                     vs.iter()
                         .map(|v| convert_if_needed(*v, &target_elem_type, ti, &mut builder))
                         .collect()
@@ -618,7 +630,7 @@ impl UntaintControlFlow {
                 let target_elem_type = tp.clone();
                 let mut cast_instrs = Vec::new();
                 let new_element = {
-                    let mut builder = HLInstrBuilder::new(function, &mut cast_instrs);
+                    let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
                     convert_if_needed(element, &target_elem_type, ti, &mut builder)
                 };
                 for instr in cast_instrs {
@@ -652,7 +664,7 @@ impl UntaintControlFlow {
                 };
                 let mut cast_instrs = Vec::new();
                 let (converted_array, converted_value) = {
-                    let mut builder = HLInstrBuilder::new(function, &mut cast_instrs);
+                    let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
                     let ca = convert_if_needed(array, result_type, ti, &mut builder);
                     let cv = convert_if_needed(value, &expected_elem_type, ti, &mut builder);
                     (ca, cv)
@@ -686,7 +698,7 @@ impl UntaintControlFlow {
                 };
                 let mut cast_instrs = Vec::new();
                 let new_values: Vec<_> = {
-                    let mut builder = HLInstrBuilder::new(function, &mut cast_instrs);
+                    let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
                     values
                         .iter()
                         .map(|v| convert_if_needed(*v, &expected_elem_type, ti, &mut builder))
@@ -713,7 +725,7 @@ impl UntaintControlFlow {
                 let target_type = ptr_type.get_pointed();
                 let mut cast_instrs = Vec::new();
                 let converted = {
-                    let mut builder = HLInstrBuilder::new(function, &mut cast_instrs);
+                    let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
                     convert_if_needed(value, &target_type, ti, &mut builder)
                 };
                 for instr in cast_instrs {
@@ -741,7 +753,7 @@ impl UntaintControlFlow {
                 let target_type = if_t_type.get_arithmetic_result_type(if_f_type);
                 let mut cast_instrs = Vec::new();
                 let (new_if_t, new_if_f) = {
-                    let mut builder = HLInstrBuilder::new(function, &mut cast_instrs);
+                    let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
                     let t = convert_if_needed(if_t, &target_type, ti, &mut builder);
                     let f = convert_if_needed(if_f, &target_type, ti, &mut builder);
                     (t, f)


### PR DESCRIPTION
This commit introduces a new `Cn` type parameter to the SSA that allows it to hold an arbitrary, user-provided data type for storing constants. At the same time it updates `ValueId`s to be allocated globally within a given SSA, rather than on a per-function basis, making it much easier to seamlessly compile constants.

`HLSSA` and `LLSSA` have both been updated to comply with the new interface for building functions.

Partial work toward #184.