### PR TITLE
Use the new constants handling in HLSSA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "1.0.0-beta.19"
 source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.19#74d6be658e1ad252f87943292ba09bdd4da80bd4"
 dependencies = [
  "acir_field",
- "base64 0.22.1",
+ "base64",
  "brillig",
  "flate2",
  "noirc_span",
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -187,15 +187,6 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "ar_archive_writer"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
-dependencies = [
- "object 0.37.3",
-]
 
 [[package]]
 name = "arbitrary"
@@ -376,12 +367,6 @@ checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -391,6 +376,12 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "binary-merge"
@@ -861,33 +852,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.118.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4b56ebe316895d3fa37775d0a87b0c889cc933f5c8b253dbcc7c7bcb7fe7e4"
+checksum = "de2be1bdbf929c2a2242cbbe15d6583c56f1cc723c6c8452d0179362de28c9d5"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.118.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cabbc01dfbd7dcd6c329ca44f0212910309c221797ac736a67a5bc8857fe1b"
+checksum = "9a0336914de11298290783a95a9a7154b894da601659eb5f8f8bc62d1bea98f8"
+dependencies = [
+ "cranelift-srcgen",
+]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.118.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ffe46df300a45f1dc6f609dc808ce963f0e3a2e971682c479a2d13e3b9b8ef"
+checksum = "fb972cba51a52c1b2a329fec993b911e4d1f9cfab3795811a319b6746c28e014"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.118.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b265bed7c51e1921fdae6419791d31af77d33662ee56d7b0fa0704dc8d231cab"
+checksum = "642c920666bfed9aebca39d8c6e7cb76f09314cc7a4074b1db5edcccdde771b9"
 dependencies = [
  "serde",
  "serde_derive",
@@ -895,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.118.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e606230a7e3a6897d603761baee0d19f88d077f17b996bb5089488a29ae96e41"
+checksum = "0e1231caaeee3d2363d9b2dba9d6c1f7ff835b8ede6612fba98120af73df44bd"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -917,39 +911,42 @@ dependencies = [
  "serde",
  "smallvec",
  "target-lexicon",
+ "wasmtime-internal-math",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.118.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a63bffafc23bc60969ad528e138788495999d935f0adcfd6543cb151ca8637d"
+checksum = "eb83e89be8b413e4f7a4215a02d5c5f3e6f04b1060f5db293dd1007b2871dcf5"
 dependencies = [
- "cranelift-assembler-x64",
+ "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck 0.5.0",
  "pulley-interpreter",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.118.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af50281b67324b58e843170a6a5943cf6d387c06f7eeacc9f5696e4ab7ae7d7e"
+checksum = "9d14f8068a98f0a85ffa63dc5fe73cb486a955adbe7311465d13cde54c656d5f"
 
 [[package]]
 name = "cranelift-control"
-version = "0.118.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c20c1b38d1abfbcebb0032e497e71156c0e3b8dcb3f0a92b9863b7bcaec290c"
+checksum = "c070aee9312b9736028e99b58d45e1099683386082af38529d5e2ce8c76648f3"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.118.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2c67d95507c51b4a1ff3f3555fe4bfec36b9e13c1b684ccc602736f5d5f4a2"
+checksum = "f2d619bb3d14251e96dc9b6a846d6955d78048a168cc3876eb2b789b855c1c22"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -958,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.118.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e002691cc69c38b54fc7ec93e5be5b744f627d027031d991cc845d1d512d0ce"
+checksum = "2350fcff24d78be5e4201e1eeb4b306e474b9f21e452722b21ffc4f773e8d49a"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -970,20 +967,26 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.118.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93588ed1796cbcb0e2ad160403509e2c5d330d80dd6e0014ac6774c7ebac496"
+checksum = "8bdc2b14d7491c53c2989b967b4c07511374733abbc01a895fb01ea31e97bfc8"
 
 [[package]]
 name = "cranelift-native"
-version = "0.118.0"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b09bdd6407bf5d89661b80cf926ce731c9e8cc184bf49102267a2369a8358e"
+checksum = "e98dbe1326d0001a17b3b0675e3adafcfbd0e7f25f1f845a2f1bb9ce3029f359"
 dependencies = [
  "cranelift-codegen",
  "libc",
  "target-lexicon",
 ]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.123.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d7af563cd300c8a1e4e64387929b40e32867112143f0a0e1ce90f977ce4a41"
 
 [[package]]
 name = "crc32fast"
@@ -1615,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator",
  "indexmap 2.14.0",
@@ -1942,15 +1945,6 @@ source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.19#74d6be658
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2128,12 +2122,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2199,6 +2187,7 @@ dependencies = [
  "anyhow",
  "ark-bn254",
  "ark-ff",
+ "bimap",
  "bincode",
  "cargo_metadata",
  "clap",
@@ -2273,7 +2262,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]
@@ -2379,7 +2368,7 @@ source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.19#74d6be658
 dependencies = [
  "acir",
  "acvm",
- "base64 0.22.1",
+ "base64",
  "codespan-reporting",
  "flate2",
  "fm",
@@ -2574,22 +2563,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "crc32fast",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
@@ -2892,24 +2872,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "psm"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
-dependencies = [
- "ar_archive_writer",
- "cc",
-]
-
-[[package]]
 name = "pulley-interpreter"
-version = "31.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3325791708ad50580aeacfcce06cb5e462c9ba7a2368e109cb2012b944b70e"
+checksum = "329f575a931601f71fbcb3b31d32d16273da5ba7f532fc10be2e432e710b02de"
 dependencies = [
  "cranelift-bitset",
  "log",
- "wasmtime-math",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "36.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bccae89ed67a40989e780105fab43e6c71a077b9fc8ae4c805ff5f73d2a79c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3086,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.11.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc06e6b318142614e4a48bc725abbf08ff166694835c43c9dae5a9009704639a"
+checksum = "5216b1837de2149f8bc8e6d5f88a9326b63b8c836ed58ce4a0a29ec736a59734"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -3234,19 +3216,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.1",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3254,7 +3223,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -3435,7 +3404,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bs58",
  "chrono",
  "hex",
@@ -3587,12 +3556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3683,7 +3646,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -4002,17 +3965,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trait-variant"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "ttf-parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4196,12 +4148,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.226.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d81b727619aec227dce83e7f7420d4e56c79acd044642a356ea045b98d4e13"
+checksum = "724fccfd4f3c24b7e589d333fc0429c68042897a7e8a5f8694f31792471841e7"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.226.0",
+ "wasmparser 0.236.1",
 ]
 
 [[package]]
@@ -4238,9 +4190,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.226.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc28600dcb2ba68d7e5f1c3ba4195c2bddc918c0243fd702d0b6dbd05689b681"
+checksum = "a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
@@ -4274,20 +4226,20 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.226.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753a0516fa6c01756ee861f36878dfd9875f273aea9409d9ea390a333c5bcdc2"
+checksum = "2df225df06a6df15b46e3f73ca066ff92c2e023670969f7d50ce7d5e695abbb1"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.226.0",
+ "wasmparser 0.236.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "31.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fe78033c72da8741e724d763daf1375c93a38bfcea99c873ee4415f6098c3f"
+checksum = "507d213104e83a7519d91af444a8b19c04281f2eef162d448ee7a894ac1c827d"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4306,96 +4258,120 @@ dependencies = [
  "log",
  "mach2",
  "memfd",
- "object 0.36.7",
+ "object",
  "once_cell",
- "paste",
  "postcard",
- "psm",
  "pulley-interpreter",
  "rayon",
- "rustix 0.38.44",
+ "rustix",
  "semver",
  "serde",
  "serde_derive",
  "serde_json",
  "smallvec",
- "sptr",
  "target-lexicon",
- "trait-variant",
- "wasm-encoder 0.226.0",
- "wasmparser 0.226.0",
- "wasmtime-asm-macros",
- "wasmtime-cache",
- "wasmtime-component-macro",
- "wasmtime-component-util",
- "wasmtime-cranelift",
+ "wasm-encoder 0.236.1",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
- "wasmtime-fiber",
- "wasmtime-jit-debug",
- "wasmtime-jit-icache-coherence",
- "wasmtime-math",
- "wasmtime-slab",
- "wasmtime-versioned-export-macros",
- "wasmtime-winch",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-cache",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-math",
+ "wasmtime-internal-slab",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
  "wat",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
-name = "wasmtime-asm-macros"
-version = "31.0.0"
+name = "wasmtime-environ"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f3d44ae977d70ccf80938b371d5ec60b6adedf60800b9e8dd1223bb69f4cbc"
+checksum = "9784b325c3b85562ac6d7f81c8348c42af1f137d98dd4fc6631860e4e68bb655"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "indexmap 2.14.0",
+ "log",
+ "object",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.236.1",
+ "wasmparser 0.236.1",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
+]
+
+[[package]]
+name = "wasmtime-internal-asm-macros"
+version = "36.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcaa9336cd5ba934ba734dfdfe35f5245c3c74b4e34f9af9e114fad892d81b3d"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
-name = "wasmtime-cache"
-version = "31.0.0"
+name = "wasmtime-internal-cache"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e209505770c7f38725513dba37246265fa6f724c30969de1e9d2a9e6c8f55099"
+checksum = "e297746bc001fd919f8f9bb3d28ed1a01fb1ff10a5ccd9720e649b5807bf2b68"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
+ "base64",
  "directories-next",
  "log",
  "postcard",
- "rustix 0.38.44",
+ "rustix",
  "serde",
  "serde_derive",
  "sha2 0.10.9",
  "toml 0.8.23",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "zstd",
 ]
 
 [[package]]
-name = "wasmtime-component-macro"
-version = "31.0.0"
+name = "wasmtime-internal-component-macro"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397e68ee29eb072d8d8741c9d2c971a284cd1bc960ebf2c1f6a33ea6ba16d6e1"
+checksum = "91aba228ec4f646cb9514be55538c842822cb96f2c306f75d664eea6b6f2e9eb"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "wasmtime-component-util",
- "wasmtime-wit-bindgen",
- "wit-parser 0.226.0",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser 0.236.1",
 ]
 
 [[package]]
-name = "wasmtime-component-util"
-version = "31.0.0"
+name = "wasmtime-internal-component-util"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f292ef5eb2cf3d414c2bde59c7fa0feeba799c8db9a8c5a656ad1d1a1d05e10b"
+checksum = "c68f4a2387b0aea544aa2317e295583be54fed852e0d1a31c0070984bfd6a507"
 
 [[package]]
-name = "wasmtime-cranelift"
-version = "31.0.0"
+name = "wasmtime-internal-cranelift"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fc12eb8ea695a30007a4849a5fd56209dd86a15579e92e0c27c27122818505"
+checksum = "e7d938ae501275f44e7e5532ae4bb720542b429357014d33842e128c46fb9b54"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4405,104 +4381,92 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
- "object 0.36.7",
+ "object",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
- "thiserror 1.0.69",
- "wasmparser 0.226.0",
+ "thiserror 2.0.18",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
- "wasmtime-versioned-export-macros",
+ "wasmtime-internal-math",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
-name = "wasmtime-environ"
-version = "31.0.0"
+name = "wasmtime-internal-fiber"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6b4bf08e371edf262cccb62de10e214bd4aaafaa069f1cd49c9c1c3a5ae8e4"
-dependencies = [
- "anyhow",
- "cpp_demangle",
- "cranelift-bitset",
- "cranelift-entity",
- "gimli",
- "indexmap 2.14.0",
- "log",
- "object 0.36.7",
- "postcard",
- "rustc-demangle",
- "semver",
- "serde",
- "serde_derive",
- "smallvec",
- "target-lexicon",
- "wasm-encoder 0.226.0",
- "wasmparser 0.226.0",
- "wasmprinter",
- "wasmtime-component-util",
-]
-
-[[package]]
-name = "wasmtime-fiber"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8828d7d8fbe90d087a9edea9223315caf7eb434848896667e5d27889f1173"
+checksum = "c1443b0914ff848ee7920e0f232368168e2819b739c54f3c352f0559b6164343"
 dependencies = [
  "anyhow",
  "cc",
  "cfg-if",
- "rustix 0.38.44",
- "wasmtime-asm-macros",
- "wasmtime-versioned-export-macros",
- "windows-sys 0.59.0",
+ "libc",
+ "rustix",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
-name = "wasmtime-jit-debug"
-version = "31.0.0"
+name = "wasmtime-internal-jit-debug"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9eff86dedd48b023199de2d266f5d3e37bc7c5bafdc1e3e3057214649ecf5a"
+checksum = "861d6f2a1652e95ca10b02552934b3bd460d7416b285fe10d7ca8c0a2b90dc3e"
 dependencies = [
  "cc",
- "object 0.36.7",
- "rustix 0.38.44",
- "wasmtime-versioned-export-macros",
+ "object",
+ "rustix",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
-name = "wasmtime-jit-icache-coherence"
-version = "31.0.0"
+name = "wasmtime-internal-jit-icache-coherence"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54f6c6c7e9d7eeee32dfcc10db7f29d505ee7dd28d00593ea241d5f70698e64"
+checksum = "b1caeb3140c46319fecf09d93dc38a373eb535fd478e401a9fb2ac2da30fe5f6"
 dependencies = [
  "anyhow",
  "cfg-if",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
-name = "wasmtime-math"
-version = "31.0.0"
+name = "wasmtime-internal-math"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1108aad2e6965698f9207ea79b80eda2b3dcc57dcb69f4258296d4664ae32cd"
+checksum = "7c631615929951a4076aae64da7d6cad88668d292f19672606392c24ae9c5a00"
 dependencies = [
  "libm",
 ]
 
 [[package]]
-name = "wasmtime-slab"
-version = "31.0.0"
+name = "wasmtime-internal-slab"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d6a321317281b721c5530ef733e8596ecc6065035f286ccd155b3fa8e0ab2f"
+checksum = "7b28104d57b5bdb5d8facb3a8418463ec6c2cb40bb4adf9833b727ebf6a254eb"
 
 [[package]]
-name = "wasmtime-versioned-export-macros"
-version = "31.0.0"
+name = "wasmtime-internal-unwinder"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5732a5c86efce7bca121a61d8c07875f6b85c1607aa86753b40f7f8bd9d3a780"
+checksum = "0dd89f2db7377869aeaf66b71f56def8df54b9482e4f4e5533ccec2505f5c691"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "36.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9cdb9c2e3965ee15629d067203cb800e9822664d04335dadc6fe1788d4fc335"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4510,32 +4474,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-winch"
-version = "31.0.0"
+name = "wasmtime-internal-winch"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aa4741ee66a52e2f0ec5f79040017123ba47d2dff9d994b35879cc2b7f468d4"
+checksum = "53f693c8db710f20b927bcee025acd345acf599d055b63f122613d52f5553a5f"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
  "gimli",
- "object 0.36.7",
+ "object",
  "target-lexicon",
- "wasmparser 0.226.0",
- "wasmtime-cranelift",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
+ "wasmtime-internal-cranelift",
  "winch-codegen",
 ]
 
 [[package]]
-name = "wasmtime-wit-bindgen"
-version = "31.0.0"
+name = "wasmtime-internal-wit-bindgen"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505c13fa0cac6c43e805347acf1e916c8de54e3790f2c22873c5692964b09b62"
+checksum = "c6c97d4e849494d290e05573298bd372e12be86b2074502dc5e02f4ef7628002"
 dependencies = [
  "anyhow",
+ "bitflags 2.11.1",
  "heck 0.5.0",
  "indexmap 2.14.0",
- "wit-parser 0.226.0",
+ "wit-parser 0.236.1",
 ]
 
 [[package]]
@@ -4609,20 +4574,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "31.0.0"
+version = "36.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f05457f74ec3c94d5c5caac06b84fd8d9d4d7fa21419189845ed245a53477"
+checksum = "4332c8656af179fb8fc3ae5114c738c29399ee97b638d431725201c17f99294e"
 dependencies = [
  "anyhow",
+ "cranelift-assembler-x64",
  "cranelift-codegen",
  "gimli",
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "thiserror 1.0.69",
- "wasmparser 0.226.0",
- "wasmtime-cranelift",
+ "thiserror 2.0.18",
+ "wasmparser 0.236.1",
  "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-math",
 ]
 
 [[package]]
@@ -4686,9 +4653,9 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets",
 ]
@@ -4704,10 +4671,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -4720,51 +4688,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -4880,9 +4848,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.226.0"
+version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33f007722bfd43a2978c5b8b90f02c927dddf0f11c5f5b50929816b3358718cd"
+checksum = "16e4833a20cd6e85d6abfea0e63a399472d6f88c6262957c17f546879a80ba15"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -4893,7 +4861,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.226.0",
+ "wasmparser 0.236.1",
 ]
 
 [[package]]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -21,6 +21,7 @@ noirc_frontend = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-
 # The rest of the dependencies
 ark-bn254.workspace = true
 ark-ff.workspace = true
+bimap = { version = "0.6" }
 bincode = { version = "1.3" }
 cargo_metadata = { version = "0.23.1" }
 clap = { version = "4.5.17", features = ["unstable-v5", "derive"] }
@@ -37,7 +38,7 @@ thiserror.workspace = true
 tracing.workspace = true
 tracing-forest.workspace = true
 tracing-subscriber.workspace = true
-wasmtime = { version = "31" }
+wasmtime = { version = "36" }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/compiler/src/compiler/analysis/symbolic_executor.rs
+++ b/compiler/src/compiler/analysis/symbolic_executor.rs
@@ -12,11 +12,25 @@ use crate::compiler::{
     ssa::{
         BlockId, FunctionId, Instruction, Terminator, ValueId,
         hlssa::{
-            BinaryArithOpKind, CastTarget, CmpKind, Endianness, HLSSA, LookupTarget, OpCode, Radix,
-            RefCountOp, SequenceTargetType, SliceOpDir, Type, TypeExpr,
+            BinaryArithOpKind, CastTarget, CmpKind, ConstValue, Endianness, HLSSA, LookupTarget,
+            OpCode, Radix, RefCountOp, SequenceTargetType, SliceOpDir, Type, TypeExpr,
         },
     },
 };
+
+/// Build the value-typed representation of a single `ConstValue`, used to pre-seed `scope` with
+/// every entry in `ssa.const_storage()` before symbolic execution starts.
+fn materialise_const<V, Ctx>(value: &ConstValue, ctx: &mut Ctx) -> V
+where
+    V: Value<Ctx>,
+{
+    match value {
+        ConstValue::U(size, val) => V::of_u(*size, *val, ctx),
+        ConstValue::I(size, val) => V::of_i(*size, *val, ctx),
+        ConstValue::Field(val) => V::of_field(*val, ctx),
+        ConstValue::FnPtr(_) => todo!("FnPtrConst in symbolic executor"),
+    }
+}
 
 pub trait Value<Context>
 where
@@ -154,7 +168,21 @@ impl SymbolicExecutor {
     {
         let mut globals: Vec<Option<V>> = vec![None; ssa.num_globals()];
 
-        self.run_fn(ssa, type_info, entry_point, params, &mut globals, context);
+        let const_values: HashMap<ValueId, V> = ssa
+            .const_storage()
+            .iter()
+            .map(|(id, cv)| (*id, materialise_const::<V, Ctx>(cv, context)))
+            .collect();
+
+        self.run_fn(
+            ssa,
+            type_info,
+            entry_point,
+            params,
+            &mut globals,
+            &const_values,
+            context,
+        );
     }
 
     #[instrument(skip_all, name="SymbolicExecutor::run_fn", level = Level::TRACE, fields(function = %ssa.get_function(fn_id).get_name()))]
@@ -165,6 +193,7 @@ impl SymbolicExecutor {
         fn_id: FunctionId,
         mut inputs: Vec<V>,
         globals: &mut Vec<Option<V>>,
+        const_values: &HashMap<ValueId, V>,
         ctx: &mut Ctx,
     ) -> Vec<V>
     where
@@ -174,7 +203,7 @@ impl SymbolicExecutor {
         let fn_body = ssa.get_function(fn_id);
         let fn_type_info = type_info.get_function(fn_id);
         let entry = fn_body.get_entry();
-        let mut scope: HashMap<ValueId, V> = HashMap::new();
+        let mut scope: HashMap<ValueId, V> = const_values.clone();
 
         let call_result = ctx.on_call(
             fn_id,
@@ -345,7 +374,15 @@ impl SymbolicExecutor {
                             .expect("ICE: on_call must return Some for unconstrained calls")
                         } else {
                             // For constrained calls, run_fn handles on_call internally
-                            self.run_fn(ssa, type_info, *function_id, params, globals, ctx)
+                            self.run_fn(
+                                ssa,
+                                type_info,
+                                *function_id,
+                                params,
+                                globals,
+                                const_values,
+                                ctx,
+                            )
                         };
                         for (i, val) in returns.iter().enumerate() {
                             scope.insert(*val, outputs[i].clone());
@@ -627,20 +664,6 @@ impl SymbolicExecutor {
                         let val = scope[value].clone();
                         scope.insert(*result, val.value_of(ctx));
                     }
-                    crate::compiler::ssa::hlssa::OpCode::Const { result, value } => match value {
-                        crate::compiler::ssa::hlssa::ConstValue::U(size, val) => {
-                            scope.insert(*result, V::of_u(*size, *val, ctx));
-                        }
-                        crate::compiler::ssa::hlssa::ConstValue::I(size, val) => {
-                            scope.insert(*result, V::of_i(*size, *val, ctx));
-                        }
-                        crate::compiler::ssa::hlssa::ConstValue::Field(val) => {
-                            scope.insert(*result, V::of_field(*val, ctx));
-                        }
-                        crate::compiler::ssa::hlssa::ConstValue::FnPtr(_) => {
-                            todo!("FnPtrConst in symbolic executor");
-                        }
-                    },
                     crate::compiler::ssa::hlssa::OpCode::Guard { condition, inner } => {
                         let condition_val = &scope[condition];
                         let inputs: Vec<&V> = inner.get_inputs().map(|id| &scope[id]).collect();

--- a/compiler/src/compiler/analysis/symbolic_executor.rs
+++ b/compiler/src/compiler/analysis/symbolic_executor.rs
@@ -18,8 +18,6 @@ use crate::compiler::{
     },
 };
 
-/// Build the value-typed representation of a single `ConstValue`, used to pre-seed `scope` with
-/// every entry in `ssa.const_storage()` before symbolic execution starts.
 fn materialise_const<V, Ctx>(value: &ConstValue, ctx: &mut Ctx) -> V
 where
     V: Value<Ctx>,

--- a/compiler/src/compiler/analysis/types.rs
+++ b/compiler/src/compiler/analysis/types.rs
@@ -68,9 +68,11 @@ impl Types {
             .map(|(id, func)| (*id, (func.get_param_types(), func.get_returns())))
             .collect::<HashMap<_, _>>();
 
+        let const_types = const_type_seed(ssa);
+
         for (function_id, function) in ssa.iter_functions() {
             let cfg = cfg.get_function_cfg(*function_id);
-            let function_info = self.run_function(function, &function_types, cfg);
+            let function_info = self.run_function(function, &function_types, &const_types, cfg);
             type_info.functions.insert(*function_id, function_info);
         }
         type_info
@@ -144,10 +146,11 @@ impl Types {
         &self,
         function: &HLFunction,
         function_types: &HashMap<FunctionId, (Vec<Type>, &[Type])>,
+        const_types: &HashMap<ValueId, Type>,
         cfg: &CFG,
     ) -> FunctionTypeInfo {
         let mut function_info = FunctionTypeInfo {
-            values: HashMap::new(),
+            values: const_types.clone(),
         };
 
         for block_id in cfg.get_domination_pre_order() {
@@ -666,16 +669,6 @@ impl Types {
                 value: _,
             } => Ok(()),
             OpCode::DropGlobal { global: _ } => Ok(()),
-            OpCode::Const { result, value } => {
-                let ty = match value {
-                    ConstValue::U(size, _) => Type::u(*size),
-                    ConstValue::I(size, _) => Type::i(*size),
-                    ConstValue::Field(_) => Type::field(),
-                    ConstValue::FnPtr(_) => Type::function(),
-                };
-                function_info.values.insert(*result, ty);
-                Ok(())
-            }
             OpCode::Spread { result, value, .. } => {
                 let value_type = function_info
                     .values
@@ -703,6 +696,23 @@ impl Types {
             OpCode::Guard { inner, .. } => self.run_opcode(inner, function_info, function_types),
         }
     }
+}
+
+/// Build a `ValueId -> Type` map covering every constant in the SSA's side-table, ready to be
+/// cloned into each function's local type-info to seed constant references.
+pub fn const_type_seed(ssa: &HLSSA) -> HashMap<ValueId, Type> {
+    ssa.const_storage()
+        .iter()
+        .map(|(id, cv)| {
+            let ty = match cv {
+                ConstValue::U(size, _) => Type::u(*size),
+                ConstValue::I(size, _) => Type::i(*size),
+                ConstValue::Field(_) => Type::field(),
+                ConstValue::FnPtr(_) => Type::function(),
+            };
+            (*id, ty)
+        })
+        .collect()
 }
 
 use crate::compiler::pass_manager::{Analysis, AnalysisId, AnalysisStore};

--- a/compiler/src/compiler/analysis/types.rs
+++ b/compiler/src/compiler/analysis/types.rs
@@ -68,11 +68,9 @@ impl Types {
             .map(|(id, func)| (*id, (func.get_param_types(), func.get_returns())))
             .collect::<HashMap<_, _>>();
 
-        let const_types = const_type_seed(ssa);
-
         for (function_id, function) in ssa.iter_functions() {
             let cfg = cfg.get_function_cfg(*function_id);
-            let function_info = self.run_function(function, &function_types, &const_types, cfg);
+            let function_info = self.run_function(function, &function_types, ssa, cfg);
             type_info.functions.insert(*function_id, function_info);
         }
         type_info
@@ -146,11 +144,11 @@ impl Types {
         &self,
         function: &HLFunction,
         function_types: &HashMap<FunctionId, (Vec<Type>, &[Type])>,
-        const_types: &HashMap<ValueId, Type>,
+        ssa: &HLSSA,
         cfg: &CFG,
     ) -> FunctionTypeInfo {
         let mut function_info = FunctionTypeInfo {
-            values: const_types.clone(),
+            values: const_type_seed(ssa),
         };
 
         for block_id in cfg.get_domination_pre_order() {
@@ -698,9 +696,7 @@ impl Types {
     }
 }
 
-/// Build a `ValueId -> Type` map covering every constant in the SSA's side-table, ready to be
-/// cloned into each function's local type-info to seed constant references.
-pub fn const_type_seed(ssa: &HLSSA) -> HashMap<ValueId, Type> {
+fn const_type_seed(ssa: &HLSSA) -> HashMap<ValueId, Type> {
     ssa.const_storage()
         .iter()
         .map(|(id, cv)| {

--- a/compiler/src/compiler/analysis/value_definitions.rs
+++ b/compiler/src/compiler/analysis/value_definitions.rs
@@ -8,12 +8,13 @@ use std::collections::HashMap;
 
 use crate::compiler::ssa::{
     BlockId, FunctionId, Instruction, ValueId,
-    hlssa::{HLFunction, HLSSA, OpCode, Type},
+    hlssa::{ConstValue, Constants, HLFunction, HLSSA, OpCode, Type},
 };
 
 pub enum ValueDefinition {
     Param(BlockId, usize, Type),
     Instruction(BlockId, usize, OpCode),
+    Const(ConstValue),
 }
 
 pub struct FunctionValueDefinitions {
@@ -35,8 +36,12 @@ impl FunctionValueDefinitions {
         self.definitions.insert(value_id, definition);
     }
 
-    pub fn from_ssa(ssa: &HLFunction) -> Self {
+    pub fn from_ssa(ssa: &HLFunction, constants: &Constants) -> Self {
         let mut definitions = Self::new();
+
+        for (id, cv) in constants.iter() {
+            definitions.insert(*id, ValueDefinition::Const(cv.clone()));
+        }
 
         for (block_id, block) in ssa.get_blocks() {
             for (i, (val, typ)) in block.get_parameters().enumerate() {
@@ -70,11 +75,13 @@ impl ValueDefinitions {
 
     pub fn from_ssa(ssa: &HLSSA) -> Self {
         let mut definitions = Self::new();
+        let constants = ssa.const_storage();
 
         for (function_id, function) in ssa.iter_functions() {
-            definitions
-                .functions
-                .insert(*function_id, FunctionValueDefinitions::from_ssa(function));
+            definitions.functions.insert(
+                *function_id,
+                FunctionValueDefinitions::from_ssa(function, constants),
+            );
         }
 
         definitions

--- a/compiler/src/compiler/analysis/value_range_analysis.rs
+++ b/compiler/src/compiler/analysis/value_range_analysis.rs
@@ -369,6 +369,20 @@ fn field_to_bigint(f: &Field) -> BigInt {
     BigInt::from_bytes_le(Sign::Plus, &bytes_le)
 }
 
+/// Map a `ConstValue` to the tightest interval that captures its numeric value (or `top` for
+/// function pointers, which carry no numeric meaning). Used to seed range analysis for every
+/// constant ValueId in the SSA before per-function transfer kicks in.
+fn compute_const_value_interval(value: &ConstValue) -> IntInterval {
+    match value {
+        ConstValue::U(_, v) => IntInterval::singleton(*v),
+        ConstValue::I(bits, encoded) => {
+            IntInterval::singleton(signed_const_to_bigint(*bits, *encoded))
+        }
+        ConstValue::Field(f) => IntInterval::singleton(field_to_bigint(f)),
+        ConstValue::FnPtr(_) => IntInterval::top(),
+    }
+}
+
 pub struct FunctionValueRanges {
     values: HashMap<ValueId, IntInterval>,
 }
@@ -415,10 +429,15 @@ impl ValueRangeAnalysis {
         let mut result = ValueRanges {
             functions: HashMap::new(),
         };
+        let const_ranges: HashMap<ValueId, IntInterval> = ssa
+            .const_storage()
+            .iter()
+            .map(|(id, cv)| (*id, compute_const_value_interval(cv)))
+            .collect();
         for (function_id, function) in ssa.iter_functions() {
             let func_cfg = cfg.get_function_cfg(*function_id);
             let func_types = types.get_function(*function_id);
-            let function_ranges = self.run_function(function, func_cfg, func_types);
+            let function_ranges = self.run_function(function, func_cfg, func_types, &const_ranges);
             result.functions.insert(*function_id, function_ranges);
         }
         result
@@ -430,8 +449,9 @@ impl ValueRangeAnalysis {
         function: &HLFunction,
         cfg: &CFG,
         types: &FunctionTypeInfo,
+        const_ranges: &HashMap<ValueId, IntInterval>,
     ) -> FunctionValueRanges {
-        let mut bounds: HashMap<ValueId, IntInterval> = HashMap::new();
+        let mut bounds: HashMap<ValueId, IntInterval> = const_ranges.clone();
 
         // Initial state: every value's bound is its declared type's full range.
         // Iteration only narrows from there.
@@ -525,18 +545,6 @@ impl ValueRangeAnalysis {
         };
 
         match instr {
-            OpCode::Const { result, value } => {
-                let r = match value {
-                    ConstValue::U(_, v) => IntInterval::singleton(*v),
-                    ConstValue::I(bits, encoded) => {
-                        IntInterval::singleton(signed_const_to_bigint(*bits, *encoded))
-                    }
-                    ConstValue::Field(f) => IntInterval::singleton(field_to_bigint(f)),
-                    ConstValue::FnPtr(_) => IntInterval::top(),
-                };
-                Self::overwrite(bounds, *result, cap_to_type(*result, r), changed);
-            }
-
             OpCode::Cast {
                 result,
                 value,

--- a/compiler/src/compiler/analysis/witness_type_inference.rs
+++ b/compiler/src/compiler/analysis/witness_type_inference.rs
@@ -293,8 +293,12 @@ impl WitnessTypeInference {
         let entry_id = func.get_entry_id();
         let block_queue: Vec<BlockId> = cfg.get_blocks_bfs().collect();
 
-        // Inner state
-        let mut value_wt: HashMap<ValueId, WitnessShape> = HashMap::new();
+        // Inner state — seed with the SSA's constants table; every constant is `Pure`.
+        let mut value_wt: HashMap<ValueId, WitnessShape> = ssa
+            .const_storage()
+            .iter()
+            .map(|(id, _)| (*id, WitnessShape::Scalar(WitnessType::Pure)))
+            .collect();
         let mut block_cfg: HashMap<BlockId, WitnessType> = HashMap::new();
         let mut alloc_inner: HashMap<ValueId, WitnessShape> = HashMap::new();
 
@@ -841,9 +845,6 @@ impl WitnessTypeInference {
                 | OpCode::Todo { .. }
                 | OpCode::ValueOf { .. } => {
                     panic!("Should not be present at this stage {:?}", instruction);
-                }
-                OpCode::Const { result, .. } => {
-                    value_wt.insert(*result, WitnessShape::Scalar(WitnessType::Pure));
                 }
                 OpCode::Guard { .. } => {
                     panic!("ICE: Guard should not be present during witness type inference");

--- a/compiler/src/compiler/codegen/bytecode/mod.rs
+++ b/compiler/src/compiler/codegen/bytecode/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         },
         codegen::bytecode::layout::{FrameLayouter, GlobalFrameLayouter, StructLayoutInterner},
         ssa::{
-            BlockId, FunctionId, Terminator,
+            BlockId, FunctionId, Terminator, ValueId,
             hlssa::{
                 self, BinaryArithOpKind, CmpKind, DMatrix, Endianness, HLBlock, HLFunction, HLSSA,
                 LookupTarget, Radix, RefCountOp, Type, TypeExpr,
@@ -36,6 +36,7 @@ impl CodeGen {
     pub fn run(&self, ssa: &HLSSA, cfg: &FlowAnalysis, type_info: &TypeInfo) -> bytecode::Program {
         let global_layouter = GlobalFrameLayouter::new(ssa);
         let mut struct_interner = StructLayoutInterner::new();
+        let constants = ssa.const_storage();
 
         let function = ssa.get_main();
         let function = self.run_function(
@@ -44,6 +45,7 @@ impl CodeGen {
             type_info.get_function(ssa.get_main_id()),
             &global_layouter,
             &mut struct_interner,
+            constants,
         );
 
         let mut functions = vec![function];
@@ -63,6 +65,7 @@ impl CodeGen {
                 type_info.get_function(*function_id),
                 &global_layouter,
                 &mut struct_interner,
+                constants,
             );
             function_ids.insert(*function_id, cur_fn_begin);
             cur_fn_begin += function.code.len();
@@ -103,6 +106,7 @@ impl CodeGen {
         type_info: &FunctionTypeInfo,
         global_layouter: &GlobalFrameLayouter,
         struct_interner: &mut StructLayoutInterner,
+        constants: &hlssa::Constants,
     ) -> bytecode::Function {
         let mut layouter = FrameLayouter::new();
         let entry = function.get_entry();
@@ -112,6 +116,11 @@ impl CodeGen {
         for (param, tp) in entry.get_parameters() {
             layouter.alloc_value(*param, tp);
         }
+
+        // Pre-emit MovConst for every HL constant referenced by this function. Constants now
+        // live in `ssa.const_storage()` rather than as `OpCode::Const` instructions, so the
+        // backend must materialise their frame slots up-front.
+        emit_function_constants(function, constants, type_info, &mut layouter, &mut emitter);
 
         self.run_block_body(
             function,
@@ -1160,26 +1169,6 @@ impl CodeGen {
                         size: global_layouter.get_size(global_idx),
                     });
                 }
-                hlssa::OpCode::Const { result, value } => match value {
-                    hlssa::ConstValue::U(size, val) | hlssa::ConstValue::I(size, val) => {
-                        emitter.push_op(bytecode::OpCode::MovConst {
-                            res: layouter.alloc_u64(*result, *size),
-                            val: *val as u64,
-                        });
-                    }
-                    hlssa::ConstValue::Field(val) => {
-                        let start = layouter.alloc_field(*result);
-                        for i in 0..bytecode::FELT_LIMBS {
-                            emitter.push_op(bytecode::OpCode::MovConst {
-                                res: start.offset(i as isize),
-                                val: val.0.0[i],
-                            })
-                        }
-                    }
-                    hlssa::ConstValue::FnPtr(_) => {
-                        panic!("FnPtr constants not supported in codegen");
-                    }
-                },
                 hlssa::OpCode::Alloc { result, elem_type } => {
                     let res = layouter.alloc_ptr(*result);
                     let elem_size = layouter.type_size(elem_type);
@@ -1248,6 +1237,78 @@ impl CodeGen {
                     offset += size as isize;
                 }
                 emitter.push_op(bytecode::OpCode::Ret {});
+            }
+        }
+    }
+}
+
+/// Pre-emit `MovConst` bytecode for every HL constant referenced by `function`, allocating its
+/// frame slot via `layouter` so subsequent instructions can look up the slot through `get_value`.
+fn emit_function_constants(
+    function: &HLFunction,
+    constants: &hlssa::Constants,
+    type_info: &FunctionTypeInfo,
+    layouter: &mut FrameLayouter,
+    emitter: &mut EmitterState,
+) {
+    use crate::compiler::ssa::Instruction;
+
+    let mut used: std::collections::BTreeSet<ValueId> = std::collections::BTreeSet::new();
+    for (_, block) in function.get_blocks() {
+        for instr in block.get_instructions() {
+            for input in instr.get_inputs() {
+                if constants.contains_left(input) {
+                    used.insert(*input);
+                }
+            }
+        }
+        match block.get_terminator() {
+            Some(Terminator::Jmp(_, args)) => {
+                for v in args {
+                    if constants.contains_left(v) {
+                        used.insert(*v);
+                    }
+                }
+            }
+            Some(Terminator::JmpIf(cond, _, _)) => {
+                if constants.contains_left(cond) {
+                    used.insert(*cond);
+                }
+            }
+            Some(Terminator::Return(vals)) => {
+                for v in vals {
+                    if constants.contains_left(v) {
+                        used.insert(*v);
+                    }
+                }
+            }
+            None => {}
+        }
+    }
+
+    for id in used {
+        let cv = constants.get_by_left(&id).expect("constant present");
+        match cv {
+            hlssa::ConstValue::U(size, val) | hlssa::ConstValue::I(size, val) => {
+                // `type_info` covers every value defined inside the function, plus the seed
+                // entries we added for constants. Either source gives the same size.
+                let _ = type_info; // explicit no-op: layout is determined by `*size` alone here.
+                emitter.push_op(bytecode::OpCode::MovConst {
+                    res: layouter.alloc_u64(id, *size),
+                    val: *val as u64,
+                });
+            }
+            hlssa::ConstValue::Field(val) => {
+                let start = layouter.alloc_field(id);
+                for i in 0..bytecode::FELT_LIMBS {
+                    emitter.push_op(bytecode::OpCode::MovConst {
+                        res: start.offset(i as isize),
+                        val: val.0.0[i],
+                    });
+                }
+            }
+            hlssa::ConstValue::FnPtr(_) => {
+                panic!("FnPtr constants not supported in codegen");
             }
         }
     }

--- a/compiler/src/compiler/codegen/bytecode/mod.rs
+++ b/compiler/src/compiler/codegen/bytecode/mod.rs
@@ -120,7 +120,7 @@ impl CodeGen {
         // Pre-emit MovConst for every HL constant referenced by this function. Constants now
         // live in `ssa.const_storage()` rather than as `OpCode::Const` instructions, so the
         // backend must materialise their frame slots up-front.
-        emit_function_constants(function, constants, type_info, &mut layouter, &mut emitter);
+        emit_function_constants(function, constants, &mut layouter, &mut emitter);
 
         self.run_block_body(
             function,
@@ -1247,7 +1247,6 @@ impl CodeGen {
 fn emit_function_constants(
     function: &HLFunction,
     constants: &hlssa::Constants,
-    type_info: &FunctionTypeInfo,
     layouter: &mut FrameLayouter,
     emitter: &mut EmitterState,
 ) {
@@ -1290,9 +1289,6 @@ fn emit_function_constants(
         let cv = constants.get_by_left(&id).expect("constant present");
         match cv {
             hlssa::ConstValue::U(size, val) | hlssa::ConstValue::I(size, val) => {
-                // `type_info` covers every value defined inside the function, plus the seed
-                // entries we added for constants. Either source gives the same size.
-                let _ = type_info; // explicit no-op: layout is determined by `*size` alone here.
                 emitter.push_op(bytecode::OpCode::MovConst {
                     res: layouter.alloc_u64(id, *size),
                     val: *val as u64,

--- a/compiler/src/compiler/lowering/expression_converter.rs
+++ b/compiler/src/compiler/lowering/expression_converter.rs
@@ -11,7 +11,7 @@ use noirc_frontend::monomorphization::ast::{
 use crate::compiler::ssa::{
     BlockId, FunctionId, ValueId,
     hlssa::{
-        CastTarget, ConstValue, Endianness, OpCode, Radix, SequenceTargetType, Type,
+        CastTarget, ConstValue, Endianness, Radix, SequenceTargetType, Type,
         builder::{HLEmitter, HLFunctionBuilder},
     },
 };
@@ -61,8 +61,6 @@ pub struct ExpressionConverter<'a> {
     in_unconstrained: bool,
     /// Maps GlobalId to global slot index
     global_slots: &'a HashMap<GlobalId, usize>,
-    /// Dedup cache for constants
-    const_cache: HashMap<ConstValue, ValueId>,
     /// Maps LowLevel function name to its replacement
     lowlevel_replacements: &'a HashMap<String, LowLevelReplacement>,
     /// Current block being emitted into
@@ -88,7 +86,6 @@ impl<'a> ExpressionConverter<'a> {
             in_unconstrained,
             global_slots,
             lowlevel_replacements,
-            const_cache: HashMap::new(),
             current_block: entry_block,
         }
     }
@@ -98,17 +95,7 @@ impl<'a> ExpressionConverter<'a> {
     }
 
     fn get_or_create_const(&mut self, b: &mut HLFunctionBuilder<'_>, cv: ConstValue) -> ValueId {
-        if let Some(&vid) = self.const_cache.get(&cv) {
-            return vid;
-        }
-        let vid = b.fresh_value();
-        let entry = b.function().get_entry_id();
-        b.block(entry).emit(OpCode::Const {
-            result: vid,
-            value: cv.clone(),
-        });
-        self.const_cache.insert(cv, vid);
-        vid
+        b.ssa.intern_const(cv)
     }
 
     /// Bind an immutable local variable to a value

--- a/compiler/src/compiler/pass_manager.rs
+++ b/compiler/src/compiler/pass_manager.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::compiler::ssa::{
-    DefaultSSAAnnotator, Instruction, SSA, SSAType,
+    ConstantsDisplay, DefaultSSAAnnotator, Instruction, SSA, SSAType,
     hlssa::{Constants, OpCode, Type},
 };
 
@@ -229,7 +229,9 @@ pub struct PassManager<
     phase_label: String,
 }
 
-impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + 'static> PassManager<Op, Ty, C> {
+impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + ConstantsDisplay + 'static>
+    PassManager<Op, Ty, C>
+{
     pub fn new(phase_label: String, draw_cfg: bool, passes: Vec<Box<dyn Pass<Op, Ty, C>>>) -> Self {
         Self {
             passes,

--- a/compiler/src/compiler/passes/common_subexpression_elimination.rs
+++ b/compiler/src/compiler/passes/common_subexpression_elimination.rs
@@ -406,9 +406,33 @@ impl CSE {
     }
 
     pub fn do_run(&self, ssa: &mut HLSSA, cfg: &FlowAnalysis) {
+        // Constants live SSA-globally; build the per-ValueId Expr seed once and reuse across
+        // functions. Each function-level `gather_expressions` clones this into its local table.
+        let const_exprs: HashMap<ValueId, Expr> = ssa
+            .const_storage()
+            .iter()
+            .filter_map(|(id, cv)| match cv {
+                ConstValue::U(size, val) => Some((
+                    *id,
+                    Expr::UConst {
+                        bits: *size,
+                        value: *val,
+                    },
+                )),
+                ConstValue::I(size, val) => Some((
+                    *id,
+                    Expr::IConst {
+                        bits: *size,
+                        value: *val,
+                    },
+                )),
+                ConstValue::Field(val) => Some((*id, Expr::fconst(*val))),
+                ConstValue::FnPtr(_) => None,
+            })
+            .collect();
         for (function_id, function) in ssa.iter_functions_mut() {
             let cfg = cfg.get_function_cfg(*function_id);
-            let (exprs, assertions) = self.gather_expressions(function, cfg);
+            let (exprs, assertions) = self.gather_expressions(function, cfg, &const_exprs);
             let mut value_replacements = ValueReplacements::new();
             for (_, occurrences) in exprs {
                 if occurrences.len() <= 1 {
@@ -540,13 +564,14 @@ impl CSE {
         &self,
         ssa: &HLFunction,
         cfg: &CFG,
+        const_exprs: &HashMap<ValueId, Expr>,
     ) -> (
         HashMap<Expr, Vec<(BlockId, usize, ValueId)>>,
         HashMap<Assertion, Vec<(BlockId, usize)>>,
     ) {
         let mut result: HashMap<Expr, Vec<(BlockId, usize, ValueId)>> = HashMap::new();
         let mut assertions: HashMap<Assertion, Vec<(BlockId, usize)>> = HashMap::new();
-        let mut exprs = HashMap::<ValueId, Expr>::new();
+        let mut exprs = const_exprs.clone();
 
         fn get_expr(exprs: &HashMap<ValueId, Expr>, value_id: &ValueId) -> Expr {
             exprs
@@ -1017,42 +1042,6 @@ impl CSE {
                             *r,
                         ));
                     }
-                    OpCode::Const {
-                        result: r,
-                        value: cv,
-                    } => match cv {
-                        ConstValue::U(size, val) => {
-                            let expr = Expr::UConst {
-                                bits: *size,
-                                value: *val,
-                            };
-                            exprs.insert(*r, expr.clone());
-                            result
-                                .entry(expr)
-                                .or_default()
-                                .push((block_id, instruction_idx, *r));
-                        }
-                        ConstValue::I(size, val) => {
-                            let expr = Expr::IConst {
-                                bits: *size,
-                                value: *val,
-                            };
-                            exprs.insert(*r, expr.clone());
-                            result
-                                .entry(expr)
-                                .or_default()
-                                .push((block_id, instruction_idx, *r));
-                        }
-                        ConstValue::Field(val) => {
-                            let expr = Expr::fconst(*val);
-                            exprs.insert(*r, expr.clone());
-                            result
-                                .entry(expr)
-                                .or_default()
-                                .push((block_id, instruction_idx, *r));
-                        }
-                        ConstValue::FnPtr(_) => {}
-                    },
                     OpCode::Guard { .. } => {
                         // Guards are opaque to CSE
                     }

--- a/compiler/src/compiler/passes/condition_propagation.rs
+++ b/compiler/src/compiler/passes/condition_propagation.rs
@@ -6,7 +6,7 @@ use crate::compiler::{
     passes::fix_double_jumps::ValueReplacements,
     ssa::{
         BlockId, Terminator, ValueId,
-        hlssa::{ConstValue, HLSSA, OpCode, builder::HLSSABuilder},
+        hlssa::{ConstValue, HLSSA, builder::HLSSABuilder},
     },
 };
 
@@ -56,24 +56,19 @@ impl ConditionPropagation {
                         .iter()
                         .filter(|(cond_block, _, _)| func_cfg.dominates(*cond_block, block_id));
 
-                    let mut const_opcodes = Vec::new();
                     for (_, vid, value) in dominated {
-                        let const_id = fb.ssa.fresh_value();
-                        const_opcodes.push(OpCode::Const {
-                            result: const_id,
-                            value: ConstValue::U(1, if *value { 1 } else { 0 }),
-                        });
+                        let const_id = fb
+                            .ssa
+                            .intern_const(ConstValue::U(1, if *value { 1 } else { 0 }));
                         replacements.insert(*vid, const_id);
                     }
 
                     let block = fb.function.get_block_mut(block_id);
-                    let instructions = block.take_instructions();
-                    let mut new_instructions = const_opcodes;
-                    new_instructions.extend(instructions.iter().cloned());
-                    for instruction in new_instructions.iter_mut() {
+                    let mut instructions = block.take_instructions();
+                    for instruction in instructions.iter_mut() {
                         replacements.replace_inputs(instruction);
                     }
-                    block.put_instructions(new_instructions);
+                    block.put_instructions(instructions);
                     replacements.replace_terminator(block.get_terminator_mut());
                 }
             });

--- a/compiler/src/compiler/passes/dead_code_elimination.rs
+++ b/compiler/src/compiler/passes/dead_code_elimination.rs
@@ -125,7 +125,6 @@ impl DCE {
             | OpCode::ReadGlobal { .. }
             | OpCode::MkTuple { .. }
             | OpCode::ValueOf { .. }
-            | OpCode::Const { .. }
             | OpCode::Spread { .. }
             | OpCode::Unspread { .. } => false,
             OpCode::Guard { inner, .. } => self.is_initially_live(inner.as_ref()),

--- a/compiler/src/compiler/passes/defunctionalize.rs
+++ b/compiler/src/compiler/passes/defunctionalize.rs
@@ -14,7 +14,7 @@ use std::collections::{HashMap, HashSet};
 use crate::compiler::{
     pass_manager::{AnalysisStore, Pass},
     ssa::{
-        BlockId, FunctionId, Terminator, ValueId,
+        BlockId, FunctionId, Instruction, Terminator, ValueId,
         hlssa::{
             CallTarget, ConstValue, HLSSA, OpCode, Type, TypeExpr,
             builder::{HLEmitter, HLSSABuilder},
@@ -47,23 +47,9 @@ type ReachingFns = HashMap<(FunctionId, ValueId), HashSet<FunctionId>>;
 fn run_defunctionalize(ssa: &mut HLSSA) {
     // Check if there are any FnPtrs at all
     let has_fn_ptrs = ssa
-        .get_function_ids()
-        .collect::<Vec<_>>()
+        .const_storage()
         .iter()
-        .any(|fid| {
-            let func = ssa.get_function(*fid);
-            func.get_blocks().any(|(_, block)| {
-                block.get_instructions().any(|i| {
-                    matches!(
-                        i,
-                        OpCode::Const {
-                            value: ConstValue::FnPtr(_),
-                            ..
-                        }
-                    )
-                })
-            })
-        });
+        .any(|(_, cv)| matches!(cv, ConstValue::FnPtr(_)));
     if !has_fn_ptrs {
         return;
     }
@@ -126,21 +112,57 @@ fn run_defunctionalize(ssa: &mut HLSSA) {
 
     // Phase 3: Transformation
 
-    // 3a. Replace FnPtrConst → UConst(32, ...) in all functions
-    let func_ids: Vec<FunctionId> = ssa.get_function_ids().collect();
-    for fid in &func_ids {
-        let func = ssa.get_function_mut(*fid);
-        for (_, block) in func.get_blocks_mut() {
-            for instruction in block.get_instructions_mut() {
-                if let OpCode::Const {
-                    result,
-                    value: ConstValue::FnPtr(fn_id),
-                } = instruction
-                {
-                    *instruction = OpCode::Const {
-                        result: *result,
-                        value: ConstValue::U(32, fn_id.0 as u128),
+    // 3a. Replace each `FnPtr(fn_id)` constant with `U(32, fn_id.0)`. The constant ValueId for
+    // the `U32` form may already exist (or may be freshly allocated by intern_const), so build a
+    // remap from old FnPtr ValueIds to the new U32 ValueIds and apply it to every operand.
+    let fn_ptr_consts: Vec<(ValueId, FunctionId)> = ssa
+        .const_storage()
+        .iter()
+        .filter_map(|(id, cv)| match cv {
+            ConstValue::FnPtr(fn_id) => Some((*id, *fn_id)),
+            _ => None,
+        })
+        .collect();
+    let mut const_remap: HashMap<ValueId, ValueId> = HashMap::new();
+    for (old_id, fn_id) in fn_ptr_consts.iter().copied() {
+        // Remove the FnPtr entry so the new U32 entry can claim a fresh ValueId (or alias an
+        // existing one) without violating the bimap's bijection invariant.
+        ssa.const_storage_mut().remove_by_left(&old_id);
+        let new_id = ssa.intern_const(ConstValue::U(32, fn_id.0 as u128));
+        if new_id != old_id {
+            const_remap.insert(old_id, new_id);
+        }
+    }
+    if !const_remap.is_empty() {
+        let func_ids: Vec<FunctionId> = ssa.get_function_ids().collect();
+        for fid in &func_ids {
+            let func = ssa.get_function_mut(*fid);
+            for (_, block) in func.get_blocks_mut() {
+                for instruction in block.get_instructions_mut() {
+                    for input in instruction.get_inputs_mut() {
+                        if let Some(new) = const_remap.get(input) {
+                            *input = *new;
+                        }
+                    }
+                }
+                if let Some(term) = block.get_terminator().cloned() {
+                    let new_term = match term {
+                        Terminator::Jmp(b, args) => Terminator::Jmp(
+                            b,
+                            args.into_iter()
+                                .map(|v| const_remap.get(&v).copied().unwrap_or(v))
+                                .collect(),
+                        ),
+                        Terminator::JmpIf(c, t, f) => {
+                            Terminator::JmpIf(const_remap.get(&c).copied().unwrap_or(c), t, f)
+                        }
+                        Terminator::Return(vals) => Terminator::Return(
+                            vals.into_iter()
+                                .map(|v| const_remap.get(&v).copied().unwrap_or(v))
+                                .collect(),
+                        ),
                     };
+                    block.set_terminator(new_term);
                 }
             }
         }
@@ -291,19 +313,19 @@ fn compute_reaching_fn_ptrs(ssa: &HLSSA) -> ReachingFns {
         }
     }
 
-    // Seed from FnPtr consts
+    // Seed from FnPtr consts. Constants live SSA-globally now, so seed every (fid, value_id)
+    // pair — over-seeding is harmless (unused entries never propagate).
+    let fn_ptr_consts: Vec<(ValueId, FunctionId)> = ssa
+        .const_storage()
+        .iter()
+        .filter_map(|(id, cv)| match cv {
+            ConstValue::FnPtr(fn_id) => Some((*id, *fn_id)),
+            _ => None,
+        })
+        .collect();
     for &fid in &func_ids {
-        let func = ssa.get_function(fid);
-        for (_, block) in func.get_blocks() {
-            for instruction in block.get_instructions() {
-                if let OpCode::Const {
-                    result,
-                    value: ConstValue::FnPtr(fn_id),
-                } = instruction
-                {
-                    reaching.entry((fid, *result)).or_default().insert(*fn_id);
-                }
-            }
+        for (value_id, fn_id) in &fn_ptr_consts {
+            reaching.entry((fid, *value_id)).or_default().insert(*fn_id);
         }
     }
 

--- a/compiler/src/compiler/passes/defunctionalize.rs
+++ b/compiler/src/compiler/passes/defunctionalize.rs
@@ -13,8 +13,9 @@ use std::collections::{HashMap, HashSet};
 
 use crate::compiler::{
     pass_manager::{AnalysisStore, Pass},
+    passes::fix_double_jumps::ValueReplacements,
     ssa::{
-        BlockId, FunctionId, Instruction, Terminator, ValueId,
+        BlockId, FunctionId, Terminator, ValueId,
         hlssa::{
             CallTarget, ConstValue, HLSSA, OpCode, Type, TypeExpr,
             builder::{HLEmitter, HLSSABuilder},
@@ -123,7 +124,7 @@ fn run_defunctionalize(ssa: &mut HLSSA) {
             _ => None,
         })
         .collect();
-    let mut const_remap: HashMap<ValueId, ValueId> = HashMap::new();
+    let mut const_remap = ValueReplacements::new();
     for (old_id, fn_id) in fn_ptr_consts.iter().copied() {
         // Remove the FnPtr entry so the new U32 entry can claim a fresh ValueId (or alias an
         // existing one) without violating the bimap's bijection invariant.
@@ -133,38 +134,14 @@ fn run_defunctionalize(ssa: &mut HLSSA) {
             const_remap.insert(old_id, new_id);
         }
     }
-    if !const_remap.is_empty() {
-        let func_ids: Vec<FunctionId> = ssa.get_function_ids().collect();
-        for fid in &func_ids {
-            let func = ssa.get_function_mut(*fid);
-            for (_, block) in func.get_blocks_mut() {
-                for instruction in block.get_instructions_mut() {
-                    for input in instruction.get_inputs_mut() {
-                        if let Some(new) = const_remap.get(input) {
-                            *input = *new;
-                        }
-                    }
-                }
-                if let Some(term) = block.get_terminator().cloned() {
-                    let new_term = match term {
-                        Terminator::Jmp(b, args) => Terminator::Jmp(
-                            b,
-                            args.into_iter()
-                                .map(|v| const_remap.get(&v).copied().unwrap_or(v))
-                                .collect(),
-                        ),
-                        Terminator::JmpIf(c, t, f) => {
-                            Terminator::JmpIf(const_remap.get(&c).copied().unwrap_or(c), t, f)
-                        }
-                        Terminator::Return(vals) => Terminator::Return(
-                            vals.into_iter()
-                                .map(|v| const_remap.get(&v).copied().unwrap_or(v))
-                                .collect(),
-                        ),
-                    };
-                    block.set_terminator(new_term);
-                }
+    let func_ids: Vec<FunctionId> = ssa.get_function_ids().collect();
+    for fid in &func_ids {
+        let func = ssa.get_function_mut(*fid);
+        for (_, block) in func.get_blocks_mut() {
+            for instruction in block.get_instructions_mut() {
+                const_remap.replace_inputs(instruction);
             }
+            const_remap.replace_terminator(block.get_terminator_mut());
         }
     }
 

--- a/compiler/src/compiler/passes/explicit_witness.rs
+++ b/compiler/src/compiler/passes/explicit_witness.rs
@@ -958,10 +958,7 @@ impl ExplicitWitness {
                 assert!(!tuple_taint);
                 b.push(instruction);
             }
-            OpCode::InitGlobal { .. }
-            | OpCode::DropGlobal { .. }
-            | OpCode::ValueOf { .. }
-            | OpCode::Const { .. } => {
+            OpCode::InitGlobal { .. } | OpCode::DropGlobal { .. } | OpCode::ValueOf { .. } => {
                 b.push(instruction);
             }
             OpCode::Spread {
@@ -1381,7 +1378,6 @@ impl ExplicitWitness {
                 }
             }
             OpCode::Cast { .. }
-            | OpCode::Const { .. }
             | OpCode::MkSeq { .. }
             | OpCode::MkRepeated { .. }
             | OpCode::MkTuple { .. }

--- a/compiler/src/compiler/passes/lower_pure_guards.rs
+++ b/compiler/src/compiler/passes/lower_pure_guards.rs
@@ -261,8 +261,7 @@ impl LowerPureGuards {
             }
 
             // -- Pure computation, no constraints, can't fail → unwrap --
-            OpCode::Const { .. }
-            | OpCode::Cmp { .. }
+            OpCode::Cmp { .. }
             | OpCode::Not { .. }
             | OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::And | BinaryArithOpKind::Or | BinaryArithOpKind::Xor,

--- a/compiler/src/compiler/passes/prepare_entry_point.rs
+++ b/compiler/src/compiler/passes/prepare_entry_point.rs
@@ -166,18 +166,12 @@ impl PrepareEntryPoint {
 
             // witness[0] must be constant one, emitted by the program.
             let witness_one_value = fb.ssa.fresh_value();
-            let one_const_value = fb.ssa.fresh_value();
-            let mut write_witness_instructions = vec![
-                OpCode::Const {
-                    result: one_const_value,
-                    value: ConstValue::Field(ark_bn254::Fr::from(1u64)),
-                },
-                OpCode::WriteWitness {
-                    result: Some(witness_one_value),
-                    value: one_const_value,
-                    pinned: true,
-                },
-            ];
+            let one_const_value = fb.ssa.intern_const(ConstValue::Field(ark_bn254::Fr::from(1u64)));
+            let mut write_witness_instructions = vec![OpCode::WriteWitness {
+                result: Some(witness_one_value),
+                value: one_const_value,
+                pinned: true,
+            }];
 
             // Create pinned WriteWitness for each param and build replacements.
             // These must be pinned so they survive DCE even when their results become unused

--- a/compiler/src/compiler/passes/rc_insertion.rs
+++ b/compiler/src/compiler/passes/rc_insertion.rs
@@ -718,9 +718,6 @@ impl RCInsertion {
                     OpCode::ValueOf { .. } => {
                         panic!("ICE: ValueOf should not appear at this stage");
                     }
-                    OpCode::Const { .. } => {
-                        new_instructions.push(instruction);
-                    }
                     OpCode::Guard { .. } => {
                         panic!("ICE: Guard should be lowered before RC insertion");
                     }

--- a/compiler/src/compiler/passes/simplifier.rs
+++ b/compiler/src/compiler/passes/simplifier.rs
@@ -8,7 +8,7 @@ use num_traits::{One, Zero};
 use crate::compiler::{
     analysis::{
         flow_analysis::FlowAnalysis,
-        types::{FunctionTypeInfo, Types, const_type_seed},
+        types::{FunctionTypeInfo, Types},
         value_definitions::{FunctionValueDefinitions, ValueDefinition},
     },
     pass_manager::{AnalysisId, AnalysisStore, Pass},
@@ -81,13 +81,7 @@ impl Simplifier {
             let cfg = flow.get_function_cfg(function_id);
             sb.modify_function(function_id, |fb| {
                 for _ in 0..self.max_iterations {
-                    // `materialize_const` may intern fresh constants into `fb.ssa`, so refresh the
-                    // seed every iteration; otherwise newly-interned ValueIds would be absent from
-                    // the type map and `Types::run_function` would panic on the next instruction
-                    // that uses them.
-                    let const_types = const_type_seed(fb.ssa);
-                    let fti =
-                        Types::new().run_function(fb.function, &function_types, &const_types, cfg);
+                    let fti = Types::new().run_function(fb.function, &function_types, fb.ssa, cfg);
                     if !self.run_function(fb, &fti) {
                         break;
                     }

--- a/compiler/src/compiler/passes/simplifier.rs
+++ b/compiler/src/compiler/passes/simplifier.rs
@@ -8,7 +8,7 @@ use num_traits::{One, Zero};
 use crate::compiler::{
     analysis::{
         flow_analysis::FlowAnalysis,
-        types::{FunctionTypeInfo, Types},
+        types::{FunctionTypeInfo, Types, const_type_seed},
         value_definitions::{FunctionValueDefinitions, ValueDefinition},
     },
     pass_manager::{AnalysisId, AnalysisStore, Pass},
@@ -81,9 +81,13 @@ impl Simplifier {
             let cfg = flow.get_function_cfg(function_id);
             sb.modify_function(function_id, |fb| {
                 for _ in 0..self.max_iterations {
-                    // Recompute locally so newly emitted opcodes (the Const+Cast
-                    // pair from `materialize_const`) appear with the right types.
-                    let fti = Types::new().run_function(fb.function, &function_types, cfg);
+                    // `materialize_const` may intern fresh constants into `fb.ssa`, so refresh the
+                    // seed every iteration; otherwise newly-interned ValueIds would be absent from
+                    // the type map and `Types::run_function` would panic on the next instruction
+                    // that uses them.
+                    let const_types = const_type_seed(fb.ssa);
+                    let fti =
+                        Types::new().run_function(fb.function, &function_types, &const_types, cfg);
                     if !self.run_function(fb, &fti) {
                         break;
                     }
@@ -98,7 +102,9 @@ impl Simplifier {
         fb: &mut HLFunctionBuilder<'_>,
         function_type_info: &FunctionTypeInfo,
     ) -> bool {
-        let definitions = FunctionValueDefinitions::from_ssa(fb.function);
+        let mut definitions =
+            FunctionValueDefinitions::from_ssa(fb.function, fb.ssa.const_storage());
+        let mut consts_len = fb.ssa.const_storage().len();
         let mut aliases = ValueReplacements::new();
         let mut changed = false;
 
@@ -113,6 +119,20 @@ impl Simplifier {
 
                 let rewrite =
                     self.try_algebraic(&instruction, &definitions, function_type_info, fb);
+
+                // `materialize_const` may have just interned a fresh constant into `fb.ssa`. If
+                // we don't refresh `definitions`, a later `get_definition` lookup of an operand
+                // that the alias map redirected to that new constant will panic. We patch the
+                // new entries into `definitions` directly — rebuilding via `from_ssa` here
+                // would lose Param/Instruction entries, since `take_blocks` (above) has already
+                // detached every block from `fb.function`.
+                let new_consts_len = fb.ssa.const_storage().len();
+                if new_consts_len > consts_len {
+                    for (id, cv) in fb.ssa.const_storage().iter() {
+                        definitions.insert(*id, ValueDefinition::Const(cv.clone()));
+                    }
+                    consts_len = new_consts_len;
+                }
 
                 match rewrite {
                     Some(Rewrite::Alias { result, target }) => {
@@ -446,18 +466,18 @@ fn materialize_const(
     let ty = types.get_value_type(result).clone();
     let inner = ty.strip_witness();
     let value = pure_value(&inner.expr)?;
+    let const_id = fb.ssa.intern_const(value);
     if ty.is_witness_of() {
-        let tmp = fb.fresh_value();
-        Some(Rewrite::Replace(vec![
-            OpCode::Const { result: tmp, value },
-            OpCode::Cast {
-                result,
-                value: tmp,
-                target: CastTarget::WitnessOf,
-            },
-        ]))
+        Some(Rewrite::Replace(vec![OpCode::Cast {
+            result,
+            value: const_id,
+            target: CastTarget::WitnessOf,
+        }]))
     } else {
-        Some(Rewrite::Replace(vec![OpCode::Const { result, value }]))
+        Some(Rewrite::Alias {
+            result,
+            target: const_id,
+        })
     }
 }
 
@@ -488,8 +508,7 @@ fn materialize_one(
 }
 
 fn is_zero(defs: &FunctionValueDefinitions, v: ValueId) -> bool {
-    let def = defs.get_definition(v);
-    if let ValueDefinition::Instruction(_, _, OpCode::Const { value, .. }) = def {
+    if let ValueDefinition::Const(value) = defs.get_definition(v) {
         match value {
             ConstValue::U(_, 0) | ConstValue::I(_, 0) => true,
             ConstValue::Field(f) => f.is_zero(),
@@ -501,8 +520,7 @@ fn is_zero(defs: &FunctionValueDefinitions, v: ValueId) -> bool {
 }
 
 fn is_one(defs: &FunctionValueDefinitions, v: ValueId) -> bool {
-    let def = defs.get_definition(v);
-    if let ValueDefinition::Instruction(_, _, OpCode::Const { value, .. }) = def {
+    if let ValueDefinition::Const(value) = defs.get_definition(v) {
         match value {
             ConstValue::U(_, 1) | ConstValue::I(_, 1) => true,
             ConstValue::Field(f) => f.is_one(),

--- a/compiler/src/compiler/passes/specializer.rs
+++ b/compiler/src/compiler/passes/specializer.rs
@@ -21,8 +21,8 @@ use crate::compiler::{
     ssa::{
         FunctionId, ValueId,
         hlssa::{
-            BinaryArithOpKind, CastTarget, CmpKind, Endianness, HLFunction, HLSSA, OpCode, Radix,
-            RefCountOp, SequenceTargetType, Type,
+            BinaryArithOpKind, CastTarget, CmpKind, ConstValue, Constants, Endianness, HLFunction,
+            HLSSA, OpCode, Radix, RefCountOp, SequenceTargetType, Type,
             builder::{HLEmitter, HLFunctionBuilder},
         },
     },
@@ -47,11 +47,29 @@ enum ConstVal {
 struct Val(ValueId);
 
 struct SpecializationState {
+    /// The function being specialized.
     function: HLFunction,
-    /// Transient counter for `ValueId`s allocated during specialization. Starts at the SSA's
-    /// `value_num_bound` and is reconciled back into the SSA only if specialization is accepted.
+
+    /// Transient counter for `ValueId`s allocated during specialization.
+    ///
+    /// This starts at the SSA's `value_num_bound` and is reconciled back into the SSA _only_ if
+    /// specialization is accepted.
     transient_counter: u64,
+
+    /// Storage for known constant values for use in constant folding.
     const_vals: HashMap<ValueId, ConstVal>,
+
+    /// Snapshot of the main SSA's constants table, used to dedup against constants that already
+    /// exist before specialization began.
+    ///
+    /// Cloned because `SymbolicExecutor::run` only gives us `&HLSSA`, ruling out a live borrow into
+    /// the main table.
+    main_constants_snapshot: Constants,
+
+    /// Constants newly created during specialization.
+    ///
+    /// Merged back into the main SSA _only_ if the specialization is accepted.
+    transient_constants: Constants,
 }
 
 impl SpecializationState {
@@ -73,6 +91,18 @@ impl HLEmitter for SpecializationState {
     fn emit(&mut self, op: OpCode) {
         let entry = self.function.get_entry_id();
         self.function.get_block_mut(entry).push_instruction(op);
+    }
+
+    fn intern_const(&mut self, value: ConstValue) -> ValueId {
+        if let Some(&id) = self.main_constants_snapshot.get_by_right(&value) {
+            return id;
+        }
+        if let Some(&id) = self.transient_constants.get_by_right(&value) {
+            return id;
+        }
+        let id = self.fresh_value();
+        self.transient_constants.insert(id, value);
+        id
     }
 }
 
@@ -820,6 +850,8 @@ impl Specializer {
             function: HLFunction::empty(name),
             transient_counter: ssa.value_num_bound() as u64,
             const_vals: HashMap::new(),
+            main_constants_snapshot: ssa.const_storage().clone(),
+            transient_constants: Constants::default(),
         };
 
         let mut call_params: Vec<Val> = vec![];
@@ -887,6 +919,12 @@ impl Specializer {
         if savings_to_code_ratio > self.savings_to_code_ratio {
             info!(message = %"Specialization accepted", code_bloat = code_bloat,  savings_to_code_ratio = savings_to_code_ratio, threshold_ratio = self.savings_to_code_ratio);
             ssa.reserve_values_up_to(state.transient_counter);
+            // Merge transient constants into the main SSA. Each entry was deduped against the
+            // pre-specialization snapshot, so its ConstValue is unique relative to main; just
+            // insert under the transient ValueId.
+            for (id, cv) in state.transient_constants.iter() {
+                ssa.const_storage_mut().insert(*id, cv.clone());
+            }
             let original_fn = ssa.take_function(signature.get_fun_id());
             let new_fn_id = ssa.add_function("".to_string());
             let new_original_id = ssa.add_function("".to_string()); // Temporary

--- a/compiler/src/compiler/passes/strip_witness_of.rs
+++ b/compiler/src/compiler/passes/strip_witness_of.rs
@@ -142,7 +142,6 @@ impl StripWitnessOf {
             | OpCode::TupleProj { .. }
             | OpCode::InitGlobal { .. }
             | OpCode::DropGlobal { .. }
-            | OpCode::Const { .. }
             | OpCode::Spread { .. }
             | OpCode::Unspread { .. } => {}
             OpCode::Guard { .. } => {

--- a/compiler/src/compiler/passes/witness_lowering.rs
+++ b/compiler/src/compiler/passes/witness_lowering.rs
@@ -445,7 +445,6 @@ impl WitnessLowering {
                         | OpCode::TupleProj { .. }
                         | OpCode::Todo { .. }
                         | OpCode::ValueOf { .. }
-                        | OpCode::Const { .. }
                         | OpCode::Spread { .. }
                         | OpCode::Unspread { .. } => {
                             emitter.emit(instruction);

--- a/compiler/src/compiler/passes/witness_write_to_fresh.rs
+++ b/compiler/src/compiler/passes/witness_write_to_fresh.rs
@@ -93,7 +93,6 @@ impl WitnessWriteToFresh {
                         | OpCode::TupleProj { .. }
                         | OpCode::MkTuple { .. }
                         | OpCode::ValueOf { .. }
-                        | OpCode::Const { .. }
                         | OpCode::Spread { .. }
                         | OpCode::Unspread { .. }
                         | OpCode::Guard { .. } => instruction.clone(),

--- a/compiler/src/compiler/ssa/hlssa/builder.rs
+++ b/compiler/src/compiler/ssa/hlssa/builder.rs
@@ -15,6 +15,10 @@ pub trait HLEmitter {
     fn fresh_value(&mut self) -> ValueId;
     fn emit(&mut self, op: OpCode);
 
+    /// Return the canonical `ValueId` for `value`, allocating + recording it in the SSA's
+    /// constants table if not already present.
+    fn intern_const(&mut self, value: ConstValue) -> ValueId;
+
     // -- Arithmetic --
 
     fn add(&mut self, lhs: ValueId, rhs: ValueId) -> ValueId {
@@ -233,30 +237,15 @@ pub trait HLEmitter {
     // -- Constants --
 
     fn field_const(&mut self, value: ark_bn254::Fr) -> ValueId {
-        let r = self.fresh_value();
-        self.emit(OpCode::Const {
-            result: r,
-            value: ConstValue::Field(value),
-        });
-        r
+        self.intern_const(ConstValue::Field(value))
     }
 
     fn u_const(&mut self, bits: usize, value: u128) -> ValueId {
-        let r = self.fresh_value();
-        self.emit(OpCode::Const {
-            result: r,
-            value: ConstValue::U(bits, value),
-        });
-        r
+        self.intern_const(ConstValue::U(bits, value))
     }
 
     fn i_const(&mut self, bits: usize, value: u128) -> ValueId {
-        let r = self.fresh_value();
-        self.emit(OpCode::Const {
-            result: r,
-            value: ConstValue::I(bits, value),
-        });
-        r
+        self.intern_const(ConstValue::I(bits, value))
     }
 
     // -- Witness --
@@ -638,6 +627,10 @@ impl HLEmitter for HLInstrBuilder<'_> {
     fn emit(&mut self, op: OpCode) {
         self.instructions.push(op);
     }
+
+    fn intern_const(&mut self, value: ConstValue) -> ValueId {
+        self.ssa.intern_const(value)
+    }
 }
 
 impl HLEmitter for HLBlockEmitter<'_> {
@@ -647,6 +640,10 @@ impl HLEmitter for HLBlockEmitter<'_> {
 
     fn emit(&mut self, op: OpCode) {
         self.block.push_instruction(op);
+    }
+
+    fn intern_const(&mut self, value: ConstValue) -> ValueId {
+        self.ssa.intern_const(value)
     }
 }
 

--- a/compiler/src/compiler/ssa/hlssa/mod.rs
+++ b/compiler/src/compiler/ssa/hlssa/mod.rs
@@ -4,10 +4,13 @@ pub mod builder;
 pub mod type_system;
 
 use itertools::Itertools;
+use std::collections::HashMap;
 use std::fmt::Display;
 
-use crate::compiler::ssa::{
-    Block, ConstantsDisplay, Function, FunctionId, Instruction, SSA, ValueId,
+use crate::compiler::{
+    analysis::flow_analysis::FlowAnalysis,
+    passes::fix_double_jumps::ValueReplacements,
+    ssa::{Block, ConstantsDisplay, Function, FunctionId, Instruction, SSA, ValueId},
 };
 pub use type_system::{Type, TypeExpr};
 
@@ -36,6 +39,167 @@ impl HLSSA {
     /// Look up a constant by `ValueId`. Returns `None` if `id` is not a constant.
     pub fn get_const(&self, id: ValueId) -> Option<&ConstValue> {
         self.const_storage().get_by_left(&id)
+    }
+
+    /// Folds `other` into `self`, allocating fresh identifiers as it goes and re-interning
+    /// constants so duplicates collapse.
+    ///
+    /// Returns the source-to-destination `FunctionId` map so callers can locate the merged-in
+    /// functions; constant- and value-ID remappings stay internal.
+    ///
+    /// Unreachable blocks in `other` (not visited by a dominator-order walk from each function's
+    /// entry block) are dropped. Run dead-code elimination on `other` first if they must be
+    /// preserved.
+    pub fn merge(&mut self, other: HLSSA) -> HashMap<FunctionId, FunctionId> {
+        let global_offset = self.num_globals();
+        if global_offset > 0 || !other.get_global_types().is_empty() {
+            let mut combined = self.get_global_types().to_vec();
+            combined.extend(other.get_global_types().iter().cloned());
+            self.set_global_types(combined);
+        }
+        if self.get_globals_init_fn().is_some() && other.get_globals_init_fn().is_some() {
+            panic!("ICE: HLSSA::merge cannot compose two globals_init_fns");
+        }
+        if self.get_globals_deinit_fn().is_some() && other.get_globals_deinit_fn().is_some() {
+            panic!("ICE: HLSSA::merge cannot compose two globals_deinit_fns");
+        }
+
+        let mut fn_map: HashMap<FunctionId, FunctionId> = HashMap::new();
+        let src_fn_ids: Vec<FunctionId> = other
+            .iter_functions()
+            .map(|(id, _)| *id)
+            .sorted_by_key(|id| id.0)
+            .collect();
+        for src_fn_id in &src_fn_ids {
+            let name = other.get_function(*src_fn_id).get_name().to_string();
+            let dst_fn_id = self.add_function(name);
+            fn_map.insert(*src_fn_id, dst_fn_id);
+        }
+
+        // The re-interned constants are used to seed a value replacements table for downstream
+        // replacement in the function.
+        let mut replacements = ValueReplacements::new();
+        let mut const_entries: Vec<(ValueId, ConstValue)> = other
+            .const_storage()
+            .iter()
+            .map(|(id, cv)| (*id, cv.clone()))
+            .collect();
+        const_entries.sort_by_key(|(id, _)| id.0);
+        for (src_id, cv) in const_entries {
+            let rewritten = match cv {
+                ConstValue::FnPtr(fid) => ConstValue::FnPtr(fn_map[&fid]),
+                other_cv => other_cv,
+            };
+            let new_id = self.intern_const(rewritten);
+            replacements.insert(src_id, new_id);
+        }
+
+        // The functions are walked in dominator order to ensure that we can do replacements in a
+        // single pass, rather than two.
+        let other_flow = FlowAnalysis::run(&other);
+        let mut other = other;
+        for src_fn_id in &src_fn_ids {
+            let cfg = other_flow.get_function_cfg(*src_fn_id);
+            let src_fn = other.take_function(*src_fn_id);
+            let (mut new_fn, mut src_blocks, returns) = src_fn.prepare_rebuild();
+            for ret in returns {
+                new_fn.add_return_type(ret);
+            }
+
+            for block_id in cfg.get_domination_pre_order() {
+                let Some(mut block) = src_blocks.remove(&block_id) else {
+                    continue;
+                };
+
+                let old_params = block.take_parameters();
+                let mut new_params = Vec::with_capacity(old_params.len());
+                for (old_param, ty) in old_params {
+                    let new_param = self.fresh_value();
+                    replacements.insert(old_param, new_param);
+                    new_params.push((new_param, ty));
+                }
+                block.put_parameters(new_params);
+
+                let old_instructions = block.take_instructions();
+                let mut new_instructions = Vec::with_capacity(old_instructions.len());
+                for mut instr in old_instructions {
+                    // Allocate fresh IDs for every result so `replace_instruction` finds them.
+                    let old_results: Vec<ValueId> = instr.get_results().copied().collect();
+                    for old in old_results {
+                        let new = self.fresh_value();
+                        replacements.insert(old, new);
+                    }
+                    // Lookup/DLookup are strange, so we have to handle these manually.
+                    match &instr {
+                        OpCode::Lookup { results, .. } | OpCode::DLookup { results, .. } => {
+                            for old in results.clone() {
+                                let new = self.fresh_value();
+                                replacements.insert(old, new);
+                            }
+                        }
+                        _ => {}
+                    }
+
+                    replacements.replace_instruction(&mut instr);
+                    remap_static_calls(&mut instr, &fn_map);
+                    if global_offset > 0 {
+                        shift_globals(&mut instr, global_offset);
+                    }
+
+                    new_instructions.push(instr);
+                }
+                block.put_instructions(new_instructions);
+
+                if let Some(mut term) = block.take_terminator() {
+                    replacements.replace_terminator(&mut term);
+                    block.set_terminator(term);
+                }
+
+                new_fn.put_block(block_id, block);
+            }
+
+            self.put_function(fn_map[src_fn_id], new_fn);
+        }
+
+        if self.get_globals_init_fn().is_none() {
+            if let Some(fid) = other.get_globals_init_fn() {
+                self.set_globals_init_fn(fn_map[&fid]);
+            }
+        }
+        if self.get_globals_deinit_fn().is_none() {
+            if let Some(fid) = other.get_globals_deinit_fn() {
+                self.set_globals_deinit_fn(fn_map[&fid]);
+            }
+        }
+
+        fn_map
+    }
+}
+
+/// Rewrites `FunctionId`s embedded in static `Call` targets (and inside `Guard`'s inner op)
+/// using `fn_map`. `ValueReplacements` only rewrites `ValueId`s, so this complements it.
+fn remap_static_calls(instr: &mut OpCode, fn_map: &HashMap<FunctionId, FunctionId>) {
+    match instr {
+        OpCode::Call {
+            function: CallTarget::Static(fid),
+            ..
+        } => {
+            *fid = fn_map[fid];
+        }
+        OpCode::Guard { inner, .. } => remap_static_calls(inner, fn_map),
+        _ => {}
+    }
+}
+
+/// Shifts global indices in `ReadGlobal`/`InitGlobal`/`DropGlobal` (and inside `Guard`) so that
+/// `other`'s globals land in the appended section of `self`'s globals table.
+fn shift_globals(instr: &mut OpCode, offset: usize) {
+    match instr {
+        OpCode::ReadGlobal { offset: o, .. } => *o += offset as u64,
+        OpCode::InitGlobal { global, .. } => *global += offset,
+        OpCode::DropGlobal { global } => *global += offset,
+        OpCode::Guard { inner, .. } => shift_globals(inner, offset),
+        _ => {}
     }
 }
 
@@ -1779,4 +1943,149 @@ pub enum LookupTarget<V> {
 pub enum Radix<V> {
     Bytes,
     Dyn(V),
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compiler::ssa::Terminator;
+
+    /// Builds a tiny HLSSA with a configurable constant and a Call site for testing merge.
+    /// Returns: (ssa, main_id, callee_id, the U(32, _) constant ValueId, the FnPtr constant ValueId).
+    fn build_fixture(
+        callee_name: &str,
+        const_val: u128,
+    ) -> (HLSSA, FunctionId, FunctionId, ValueId, ValueId) {
+        let mut ssa = HLSSA::new();
+        let main_id = ssa.get_main_id();
+        let callee_id = ssa.add_function(callee_name.to_string());
+
+        let u_const = ssa.intern_const(ConstValue::U(32, const_val));
+        let fn_ptr = ssa.intern_const(ConstValue::FnPtr(callee_id));
+
+        // main: entry block does `r = u_const + u_const`, then calls callee, then returns r.
+        let r = ssa.fresh_value();
+        let call_result = ssa.fresh_value();
+        let main = ssa.get_function_mut(main_id);
+        let entry = main.get_entry_mut();
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: r,
+            lhs: u_const,
+            rhs: u_const,
+        });
+        entry.push_instruction(OpCode::Call {
+            results: vec![call_result],
+            function: CallTarget::Static(callee_id),
+            args: vec![r],
+            unconstrained: false,
+        });
+        entry.set_terminator(Terminator::Return(vec![r]));
+
+        // callee: returns its single parameter unchanged.
+        let p = ssa.fresh_value();
+        let callee = ssa.get_function_mut(callee_id);
+        callee.add_return_type(Type::u(32));
+        let entry = callee.get_entry_mut();
+        entry.push_parameter(p, Type::u(32));
+        entry.set_terminator(Terminator::Return(vec![p]));
+
+        (ssa, main_id, callee_id, u_const, fn_ptr)
+    }
+
+    #[test]
+    fn merge_returns_function_map_for_every_source_function() {
+        let (target, _, _, _, _) = build_fixture("callee_a", 7);
+        let (source, src_main, src_callee, _, _) = build_fixture("callee_b", 7);
+        let mut target = target;
+        let fn_map = target.merge(source);
+
+        assert!(fn_map.contains_key(&src_main));
+        assert!(fn_map.contains_key(&src_callee));
+        assert_eq!(fn_map.len(), 2);
+        // The destination IDs must not collide with anything already in target.
+        for (src_id, dst_id) in &fn_map {
+            assert_ne!(src_id, dst_id);
+            assert_ne!(target.get_main_id(), *dst_id);
+        }
+    }
+
+    #[test]
+    fn merge_deduplicates_shared_constants() {
+        // Both fixtures intern U(32, 7); after merge target should still have exactly 3 constants:
+        // U(32, 7), FnPtr(target_callee), FnPtr(source_callee) — the U is shared, the FnPtrs differ
+        // because they reference different functions.
+        let (mut target, _, _, _, _) = build_fixture("callee_a", 7);
+        let (source, _, _, _, _) = build_fixture("callee_b", 7);
+        let before = target.const_storage().len();
+        let _ = target.merge(source);
+        assert_eq!(before, 2); // U(32,7) + FnPtr(target_callee)
+        assert_eq!(target.const_storage().len(), 3);
+
+        // Both FnPtr constants must point at distinct destination functions.
+        let fn_ptrs: Vec<FunctionId> = target
+            .const_storage()
+            .iter()
+            .filter_map(|(_, cv)| match cv {
+                ConstValue::FnPtr(fid) => Some(*fid),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(fn_ptrs.len(), 2);
+        assert_ne!(fn_ptrs[0], fn_ptrs[1]);
+    }
+
+    #[test]
+    fn merge_remaps_static_call_target() {
+        let (mut target, _, _, _, _) = build_fixture("callee_a", 7);
+        let (source, src_main, src_callee, _, _) = build_fixture("callee_b", 11);
+        let fn_map = target.merge(source);
+        let merged_main = target.get_function(fn_map[&src_main]);
+        let call_target = merged_main
+            .get_entry()
+            .get_instructions()
+            .find_map(|instr| match instr {
+                OpCode::Call {
+                    function: CallTarget::Static(fid),
+                    ..
+                } => Some(*fid),
+                _ => None,
+            })
+            .expect("merged main should contain a static Call");
+        assert_eq!(call_target, fn_map[&src_callee]);
+    }
+
+    #[test]
+    fn merge_allocates_fresh_value_ids() {
+        let (mut target, _, _, _, _) = build_fixture("callee_a", 7);
+        let value_bound_before = target.value_num_bound();
+
+        let (source, src_main, _, _, _) = build_fixture("callee_b", 11);
+        let fn_map = target.merge(source);
+
+        // Every operand in the merged main must reference a value either already in target
+        // (a constant — bound < before) or one freshly allocated by merge (>= before).
+        // What must hold strictly: none of the operands point at a ValueId that didn't exist
+        // before merge but isn't a constant in the new table.
+        let merged_main = target.get_function(fn_map[&src_main]);
+        for instr in merged_main.get_entry().get_instructions() {
+            for v in instr.get_inputs().chain(instr.get_results()) {
+                assert!(
+                    (v.0 as usize) < target.value_num_bound(),
+                    "ValueId {} out of bounds",
+                    v.0
+                );
+                let is_constant = target.get_const(*v).is_some();
+                let is_fresh = (v.0 as usize) >= value_bound_before;
+                assert!(
+                    is_constant || is_fresh,
+                    "v{} is neither a constant nor a freshly-allocated id",
+                    v.0
+                );
+            }
+        }
+    }
 }

--- a/compiler/src/compiler/ssa/hlssa/mod.rs
+++ b/compiler/src/compiler/ssa/hlssa/mod.rs
@@ -6,7 +6,9 @@ pub mod type_system;
 use itertools::Itertools;
 use std::fmt::Display;
 
-use crate::compiler::ssa::{Block, Function, FunctionId, Instruction, SSA, ValueId};
+use crate::compiler::ssa::{
+    Block, ConstantsDisplay, Function, FunctionId, Instruction, SSA, ValueId,
+};
 pub use type_system::{Type, TypeExpr};
 
 // HLSSA
@@ -17,16 +19,59 @@ pub type HLSSA = SSA<OpCode, Type, Constants>;
 
 impl HLSSA {
     pub fn new() -> Self {
-        Self::with_main("main".to_string(), ())
+        Self::with_main("main".to_string(), Constants::default())
+    }
+
+    /// Returns the canonical `ValueId` for `value`, allocating a fresh one and recording it in the
+    /// constants table if `value` has not been interned yet. Otherwise returns the existing id.
+    pub fn intern_const(&mut self, value: ConstValue) -> ValueId {
+        if let Some(&id) = self.const_storage().get_by_right(&value) {
+            return id;
+        }
+        let id = self.fresh_value();
+        self.const_storage_mut().insert(id, value);
+        id
+    }
+
+    /// Look up a constant by `ValueId`. Returns `None` if `id` is not a constant.
+    pub fn get_const(&self, id: ValueId) -> Option<&ConstValue> {
+        self.const_storage().get_by_left(&id)
     }
 }
 
 // CONSTANT STORAGE
 // ================================================================================================
 
-/// Constant storage for the high-level SSA. Currently a placeholder while constants still live
-/// inline as `OpCode::Const` instructions.
-pub type Constants = ();
+/// Constant storage for the high-level SSA: a bidirectional map between `ValueId` and `ConstValue`,
+/// enforcing one canonical `ValueId` per distinct constant value.
+pub type Constants = bimap::BiHashMap<ValueId, ConstValue>;
+
+/// Render a single `ConstValue` as the right-hand-side of a constants-table entry, matching the
+/// syntax previously used for the `OpCode::Const` instruction.
+pub fn display_const(value: &ConstValue, func_name: &dyn Fn(FunctionId) -> String) -> String {
+    match value {
+        ConstValue::U(size, val) => format!("u_const({}, {})", size, val),
+        ConstValue::I(size, val) => format!("i_const({}, {})", size, val),
+        ConstValue::Field(val) => format!("field_const({})", val),
+        ConstValue::FnPtr(fn_id) => {
+            format!("fn_ptr_const({}@{})", func_name(*fn_id), fn_id.0)
+        }
+    }
+}
+
+impl ConstantsDisplay for Constants {
+    fn display_constants(&self, func_name: &dyn Fn(FunctionId) -> String) -> String {
+        if self.is_empty() {
+            return String::new();
+        }
+        let entries = self
+            .iter()
+            .sorted_by_key(|(id, _)| id.0)
+            .map(|(id, cv)| format!("  v{} = {}", id.0, display_const(cv, func_name)))
+            .join("\n");
+        format!("constants:\n{}", entries)
+    }
+}
 
 // HLSSA OPCODES
 // ================================================================================================
@@ -228,10 +273,6 @@ pub enum OpCode {
     },
     DropGlobal {
         global: usize,
-    },
-    Const {
-        result: ValueId,
-        value: ConstValue,
     },
     Spread {
         result: ValueId,
@@ -724,43 +765,6 @@ impl Instruction for OpCode {
             OpCode::DropGlobal { global } => {
                 format!("drop_global({})", global)
             }
-            OpCode::Const { result, value } => match value {
-                ConstValue::U(size, val) => {
-                    format!(
-                        "v{}{} = u_const({}, {})",
-                        result.0,
-                        annotate_value(*result),
-                        size,
-                        val
-                    )
-                }
-                ConstValue::I(size, val) => {
-                    format!(
-                        "v{}{} = i_const({}, {})",
-                        result.0,
-                        annotate_value(*result),
-                        size,
-                        val
-                    )
-                }
-                ConstValue::Field(val) => {
-                    format!(
-                        "v{}{} = field_const({})",
-                        result.0,
-                        annotate_value(*result),
-                        val
-                    )
-                }
-                ConstValue::FnPtr(fn_id) => {
-                    format!(
-                        "v{}{} = fn_ptr_const({}@{})",
-                        result.0,
-                        annotate_value(*result),
-                        func_name(*fn_id),
-                        fn_id.0
-                    )
-                }
-            },
             OpCode::Spread {
                 result,
                 value,
@@ -808,8 +812,7 @@ impl Instruction for OpCode {
                 result: _,
                 result_type: _,
             }
-            | Self::NextDCoeff { result: _ }
-            | Self::Const { .. } => vec![].into_iter(),
+            | Self::NextDCoeff { result: _ } => vec![].into_iter(),
             Self::Cmp {
                 kind: _,
                 result: _,
@@ -1027,7 +1030,6 @@ impl Instruction for OpCode {
         match self {
             Self::Alloc { result: r, .. }
             | Self::FreshWitness { result: r, .. }
-            | Self::Const { result: r, .. }
             | Self::Cmp { result: r, .. }
             | Self::BinaryArithOp { result: r, .. }
             | Self::ArrayGet { result: r, .. }
@@ -1084,7 +1086,6 @@ impl Instruction for OpCode {
         match self {
             Self::Alloc { result: r, .. }
             | Self::FreshWitness { result: r, .. }
-            | Self::Const { result: r, .. }
             | Self::Cmp { result: r, .. }
             | Self::BinaryArithOp { result: r, .. }
             | Self::ArrayGet { result: r, .. }
@@ -1147,8 +1148,7 @@ impl Instruction for OpCode {
                 result: _,
                 result_type: _,
             }
-            | Self::NextDCoeff { result: _ }
-            | Self::Const { .. } => vec![].into_iter(),
+            | Self::NextDCoeff { result: _ } => vec![].into_iter(),
             Self::Cmp {
                 kind: _,
                 result: _,
@@ -1374,8 +1374,7 @@ impl Instruction for OpCode {
                 result: r,
                 result_type: _,
             }
-            | Self::NextDCoeff { result: r }
-            | Self::Const { result: r, .. } => vec![r].into_iter(),
+            | Self::NextDCoeff { result: r } => vec![r].into_iter(),
             Self::Cmp {
                 kind: _,
                 result: a,

--- a/compiler/src/compiler/ssa/hlssa_to_llssa.rs
+++ b/compiler/src/compiler/ssa/hlssa_to_llssa.rs
@@ -1,4 +1,4 @@
-//! HLSSA -> LLSSA lowering pass
+//! HLSSA -> LLSSA lowering passhlssa_to
 //!
 //! Translates the high-level SSA (with abstract Field/U types and a separate
 //! constant map) into low-level SSA (explicit integer widths, field-as-struct,
@@ -21,8 +21,8 @@ use crate::compiler::analysis::{
 use super::{
     BlockId, FunctionId, Terminator, ValueId,
     hlssa::{
-        BinaryArithOpKind, CmpKind, DMatrix, HLFunction, HLSSA, Type as HLType,
-        TypeExpr as HLTypeExpr,
+        BinaryArithOpKind, CmpKind, ConstValue, Constants, DMatrix, HLFunction, HLSSA,
+        Type as HLType, TypeExpr as HLTypeExpr,
     },
     llssa::{
         FieldArithOp, IntArithOp, IntCmpOp, LLFieldType, LLFunction, LLOp, LLSSA, LLStruct,
@@ -461,6 +461,7 @@ fn lower_inner(
             &mut ad_fns,
             &mut lookup_fns,
             &hlssa_global_types,
+            hlssa.const_storage(),
         );
 
         let _old = llssa.take_function(ll_fn_id);
@@ -502,6 +503,7 @@ fn lower_function(
     ad_fns: &mut AdFunctions,
     lookup_fns: &mut LookupFunctions,
     hlssa_global_types: &[HLType],
+    hl_constants: &Constants,
 ) -> LLFunction {
     let mut ll_func = LLFunction::empty(function.get_name().to_string());
     let mut val_map: HashMap<ValueId, ValueId> = HashMap::new();
@@ -538,6 +540,22 @@ fn lower_function(
             val_map.insert(*param_id, ll_param_id);
         }
     }
+
+    // Pre-emit every HL constant the function references into its entry block, so they dominate
+    // every later use. Constants are sourced from the SSA-level constants table — no per-instr
+    // lowering of `OpCode::Const` is needed because that opcode no longer exists.
+    //
+    // This is very much a temporary hack brought on by this commit being a step on the way to the
+    // new constant infrastructure. It should no longer be needed once we have properly constant
+    // constants, but that is coming later in this chain of work.
+    emit_function_constants(
+        function,
+        hl_constants,
+        &mut ll_func,
+        llssa,
+        ll_entry_id,
+        &mut val_map,
+    );
 
     // Lower instructions and terminators in domination order
     for block_id in cfg.get_domination_pre_order() {
@@ -591,6 +609,81 @@ fn add_vm_parameter(func: &mut LLFunction, llssa: &mut LLSSA) -> ValueId {
     id
 }
 
+/// Pre-emit every HL constant *referenced* by `function` into `entry_block` of `ll_func`, and
+/// register the HL→LL ValueId mapping in `val_map`. Only constants used by the function are
+/// emitted, to avoid spamming each LL function with unrelated SSA-global constants.
+fn emit_function_constants(
+    function: &HLFunction,
+    hl_constants: &Constants,
+    ll_func: &mut LLFunction,
+    llssa: &mut LLSSA,
+    entry_block: BlockId,
+    val_map: &mut HashMap<ValueId, ValueId>,
+) {
+    use crate::compiler::ssa::Instruction;
+
+    // Discover which constant ValueIds are referenced by this function.
+    let mut used: std::collections::BTreeSet<ValueId> = std::collections::BTreeSet::new();
+    for (_, block) in function.get_blocks() {
+        for instr in block.get_instructions() {
+            for input in instr.get_inputs() {
+                if hl_constants.contains_left(input) {
+                    used.insert(*input);
+                }
+            }
+        }
+        match block.get_terminator() {
+            Some(Terminator::Jmp(_, args)) => {
+                for v in args {
+                    if hl_constants.contains_left(v) {
+                        used.insert(*v);
+                    }
+                }
+            }
+            Some(Terminator::JmpIf(cond, _, _)) => {
+                if hl_constants.contains_left(cond) {
+                    used.insert(*cond);
+                }
+            }
+            Some(Terminator::Return(vals)) => {
+                for v in vals {
+                    if hl_constants.contains_left(v) {
+                        used.insert(*v);
+                    }
+                }
+            }
+            None => {}
+        }
+    }
+
+    if used.is_empty() {
+        return;
+    }
+
+    let mut emitter = LLBlockEmitter::new(ll_func, llssa, entry_block);
+    for hl_id in used {
+        let cv = hl_constants.get_by_left(&hl_id).expect("constant present");
+        let ll_id = match cv {
+            ConstValue::U(bits, val) | ConstValue::I(bits, val) => {
+                emitter.int_const(*bits as u32, *val as u64)
+            }
+            ConstValue::Field(fr) => {
+                let field_struct = LLStruct::field_elem();
+                let limbs = fr.0.0;
+                let l0 = emitter.int_const(64, limbs[0]);
+                let l1 = emitter.int_const(64, limbs[1]);
+                let l2 = emitter.int_const(64, limbs[2]);
+                let l3 = emitter.int_const(64, limbs[3]);
+                emitter.mk_struct(field_struct, vec![l0, l1, l2, l3])
+            }
+            ConstValue::FnPtr(_) => {
+                panic!("FnPtr constants not supported in HLSSA->LLSSA lowering");
+            }
+        };
+        val_map.insert(hl_id, ll_id);
+    }
+}
+
 // =============================================================================
 // Instruction lowering
 // =============================================================================
@@ -609,7 +702,7 @@ fn lower_instruction(
     hlssa_global_types: &[HLType],
 ) {
     use crate::compiler::ssa::hlssa::{
-        CallTarget, CastTarget, ConstValue, OpCode, Radix, RefCountOp, SequenceTargetType,
+        CallTarget, CastTarget, OpCode, Radix, RefCountOp, SequenceTargetType,
     };
 
     match instruction {
@@ -760,26 +853,6 @@ fn lower_instruction(
             let ll_result = e.select(ll_cond, ll_if_t, ll_if_f);
             val_map.insert(*result, ll_result);
         }
-
-        OpCode::Const { result, value } => match value {
-            ConstValue::U(bits, val) | ConstValue::I(bits, val) => {
-                let ll_val = e.int_const(*bits as u32, *val as u64);
-                val_map.insert(*result, ll_val);
-            }
-            ConstValue::Field(fr) => {
-                let field_struct = LLStruct::field_elem();
-                let limbs = fr.0.0;
-                let l0 = e.int_const(64, limbs[0]);
-                let l1 = e.int_const(64, limbs[1]);
-                let l2 = e.int_const(64, limbs[2]);
-                let l3 = e.int_const(64, limbs[3]);
-                let mk = e.mk_struct(field_struct, vec![l0, l1, l2, l3]);
-                val_map.insert(*result, mk);
-            }
-            ConstValue::FnPtr(_) => {
-                panic!("FnPtr constants not supported in HLSSA->LLSSA lowering");
-            }
-        },
 
         // -- Array operations --
         OpCode::MkSeq {

--- a/compiler/src/compiler/ssa/id.rs
+++ b/compiler/src/compiler/ssa/id.rs
@@ -1,10 +1,10 @@
 //! Contains the basic identifier types for the SSA.
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub struct ValueId(pub u64);
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub struct BlockId(pub u64);
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub struct FunctionId(pub u64);

--- a/compiler/src/compiler/ssa/mod.rs
+++ b/compiler/src/compiler/ssa/mod.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use std::{collections::HashMap, fmt::Debug, vec};
 
 pub use id::{BlockId, FunctionId, ValueId};
-pub use traits::{Instruction, SSAAnotator, SSAType};
+pub use traits::{ConstantsDisplay, Instruction, SSAAnotator, SSAType};
 
 // SSA
 // ================================================================================================
@@ -221,14 +221,21 @@ impl<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSA<Op, Ty, Cn> {
     }
 }
 
-impl<Op: Instruction, Ty: SSAType, C: Clone + Debug> SSA<Op, Ty, C> {
+impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + ConstantsDisplay> SSA<Op, Ty, C> {
     pub fn to_string(&self, value_annotator: &dyn SSAAnotator) -> String {
         let func_name = |id: FunctionId| self.get_function(id).get_name().to_string();
-        self.functions
+        let consts = self.constants.display_constants(&func_name);
+        let functions = self
+            .functions
             .iter()
             .sorted_by_key(|(fn_id, _)| fn_id.0)
             .map(|(fn_id, func)| func.to_string(&func_name, *fn_id, value_annotator))
-            .join("\n\n")
+            .join("\n\n");
+        if consts.is_empty() {
+            functions
+        } else {
+            format!("{}\n\n{}", consts, functions)
+        }
     }
 }
 

--- a/compiler/src/compiler/ssa/traits.rs
+++ b/compiler/src/compiler/ssa/traits.rs
@@ -41,3 +41,16 @@ pub trait Instruction: Clone + Debug + 'static {
 
 /// The type of values in a given SSA.
 pub trait SSAType: Clone + Debug + Display + PartialEq + Eq + 'static {}
+
+/// Render the constant-storage side-table of an SSA as a string section, prepended to the SSA
+/// dump produced by `SSA::to_string`. Implementations should return the empty string when there
+/// are no constants (or when the IR has no constants concept).
+pub trait ConstantsDisplay {
+    fn display_constants(&self, func_name: &dyn Fn(FunctionId) -> String) -> String;
+}
+
+impl ConstantsDisplay for () {
+    fn display_constants(&self, _: &dyn Fn(FunctionId) -> String) -> String {
+        String::new()
+    }
+}

--- a/wasm-runtime/src/lib.rs
+++ b/wasm-runtime/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(target_arch = "wasm32")]
 //! Runtime Library for Mavros WASM
 //!
 //! Provides BN254 field arithmetic and heap allocation called by


### PR DESCRIPTION
This commit makes the swap from the old `OpCode::Const` to use the new SSA-level storage for `Constants`, ensuring de-duplication and also uniform handling of them as values.

Partial work for #184. 