### PR TITLE
Improve constant handling more betterer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ settings.local.json
 dist
 node_modules
 .cargo
+.claude/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
 name = "binary-merge"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +2205,7 @@ dependencies = [
  "anyhow",
  "ark-bn254",
  "ark-ff",
+ "bimap",
  "bincode",
  "cargo_metadata",
  "clap",

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -21,6 +21,7 @@ noirc_frontend = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-
 # The rest of the dependencies
 ark-bn254.workspace = true
 ark-ff.workspace = true
+bimap = { version = "0.6" }
 bincode = { version = "1.3" }
 cargo_metadata = { version = "0.23.1" }
 clap = { version = "4.5.17", features = ["unstable-v5", "derive"] }

--- a/compiler/src/compiler/analysis/flow_analysis.rs
+++ b/compiler/src/compiler/analysis/flow_analysis.rs
@@ -8,6 +8,7 @@ use petgraph::visit::{Bfs, DfsPostOrder, EdgeRef, Walker};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::fs;
+use std::hash::Hash;
 use std::path::PathBuf;
 
 use crate::compiler::ssa::{BlockId, FunctionId, Instruction, SSA, SSAType, Terminator};
@@ -399,7 +400,7 @@ impl CFG {
 }
 
 impl CFG {
-    pub fn generate_image<Op: Instruction, Ty: SSAType, C: Clone + Debug + 'static>(
+    pub fn generate_image<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash + 'static>(
         &self,
         output_path: PathBuf,
         ssa: &SSA<Op, Ty, C>,
@@ -567,7 +568,7 @@ impl CallGraph {
 }
 
 impl CallGraph {
-    pub fn generate_image<Op: Instruction, Ty: SSAType, C: Clone + Debug + 'static>(
+    pub fn generate_image<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash + 'static>(
         &self,
         output_path: PathBuf,
         ssa: &SSA<Op, Ty, C>,
@@ -634,7 +635,7 @@ pub struct FlowAnalysis {
 }
 
 impl FlowAnalysis {
-    pub fn run<Op: Instruction, Ty: SSAType, C: Clone + Debug + 'static>(
+    pub fn run<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash + 'static>(
         ssa: &SSA<Op, Ty, C>,
     ) -> Self {
         let mut call_graph = CallGraph::new();
@@ -691,7 +692,7 @@ impl FlowAnalysis {
         &self.function_cfgs[&function_id]
     }
 
-    pub fn generate_images<Op: Instruction, Ty: SSAType, C: Clone + Debug + 'static>(
+    pub fn generate_images<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash + 'static>(
         &self,
         debug_output_dir: PathBuf,
         ssa: &SSA<Op, Ty, C>,
@@ -736,10 +737,10 @@ impl FlowAnalysis {
     }
 }
 
-impl<Op: Instruction, Ty: SSAType, Cn: Clone + Debug + 'static> Analysis<Op, Ty, Cn>
+impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash + 'static> Analysis<Op, Ty, C>
     for FlowAnalysis
 {
-    fn compute(ssa: &SSA<Op, Ty, Cn>, _store: &AnalysisStore) -> Self {
+    fn compute(ssa: &SSA<Op, Ty, C>, _store: &AnalysisStore) -> Self {
         FlowAnalysis::run(ssa)
     }
 }

--- a/compiler/src/compiler/analysis/symbolic_executor.rs
+++ b/compiler/src/compiler/analysis/symbolic_executor.rs
@@ -12,8 +12,8 @@ use crate::compiler::{
     ssa::{
         BlockId, FunctionId, Instruction, Terminator, ValueId,
         hlssa::{
-            BinaryArithOpKind, CastTarget, CmpKind, Endianness, HLSSA, LookupTarget, OpCode, Radix,
-            RefCountOp, SequenceTargetType, SliceOpDir, Type, TypeExpr,
+            BinaryArithOpKind, CastTarget, CmpKind, Constant, Endianness, HLSSA, LookupTarget,
+            OpCode, Radix, RefCountOp, SequenceTargetType, SliceOpDir, Type, TypeExpr,
         },
     },
 };
@@ -154,7 +154,20 @@ impl SymbolicExecutor {
     {
         let mut globals: Vec<Option<V>> = vec![None; ssa.num_globals()];
 
-        self.run_fn(ssa, type_info, entry_point, params, &mut globals, context);
+        // Materialize the SSA constants into `V`s once, up front. Constant ids are global and stable
+        // across functions, so we build this map a single time and share it by reference with every
+        // `run_fn` instead of rebuilding it (via the emitting `of_*` path) on every function entry.
+        let consts = materialize_constants(ssa, context);
+
+        self.run_fn(
+            ssa,
+            type_info,
+            entry_point,
+            params,
+            &mut globals,
+            &consts,
+            context,
+        );
     }
 
     #[instrument(skip_all, name="SymbolicExecutor::run_fn", level = Level::TRACE, fields(function = %ssa.get_function(fn_id).get_name()))]
@@ -165,6 +178,7 @@ impl SymbolicExecutor {
         fn_id: FunctionId,
         mut inputs: Vec<V>,
         globals: &mut Vec<Option<V>>,
+        consts: &HashMap<ValueId, V>,
         ctx: &mut Ctx,
     ) -> Vec<V>
     where
@@ -174,7 +188,8 @@ impl SymbolicExecutor {
         let fn_body = ssa.get_function(fn_id);
         let fn_type_info = type_info.get_function(fn_id);
         let entry = fn_body.get_entry();
-        let mut scope: HashMap<ValueId, V> = HashMap::new();
+
+        let mut scope = Scope::new(consts);
 
         let call_result = ctx.on_call(
             fn_id,
@@ -345,7 +360,7 @@ impl SymbolicExecutor {
                             .expect("ICE: on_call must return Some for unconstrained calls")
                         } else {
                             // For constrained calls, run_fn handles on_call internally
-                            self.run_fn(ssa, type_info, *function_id, params, globals, ctx)
+                            self.run_fn(ssa, type_info, *function_id, params, globals, consts, ctx)
                         };
                         for (i, val) in returns.iter().enumerate() {
                             scope.insert(*val, outputs[i].clone());
@@ -609,20 +624,6 @@ impl SymbolicExecutor {
                         let val = scope[value].clone();
                         scope.insert(*result, val.value_of(ctx));
                     }
-                    crate::compiler::ssa::hlssa::OpCode::Const { result, value } => match value {
-                        crate::compiler::ssa::hlssa::ConstValue::U(size, val) => {
-                            scope.insert(*result, V::of_u(*size, *val, ctx));
-                        }
-                        crate::compiler::ssa::hlssa::ConstValue::I(size, val) => {
-                            scope.insert(*result, V::of_i(*size, *val, ctx));
-                        }
-                        crate::compiler::ssa::hlssa::ConstValue::Field(val) => {
-                            scope.insert(*result, V::of_field(*val, ctx));
-                        }
-                        crate::compiler::ssa::hlssa::ConstValue::FnPtr(_) => {
-                            todo!("FnPtrConst in symbolic executor");
-                        }
-                    },
                     crate::compiler::ssa::hlssa::OpCode::Guard { condition, inner } => {
                         let condition_val = &scope[condition];
                         let inputs: Vec<&V> = inner.get_inputs().map(|id| &scope[id]).collect();
@@ -681,4 +682,62 @@ impl SymbolicExecutor {
 
         panic!("ICE: Unreachable, function did not return");
     }
+}
+
+/// Per-function value environment, layered over the shared constant scope.
+///
+/// Locals (parameters and instruction results) are stored per call, constants are resolved on
+/// lookup miss relying on unique value IDs.
+struct Scope<'c, V> {
+    locals: HashMap<ValueId, V>,
+    consts: &'c HashMap<ValueId, V>,
+}
+
+impl<'c, V> Scope<'c, V> {
+    fn new(consts: &'c HashMap<ValueId, V>) -> Self {
+        Self {
+            locals: HashMap::new(),
+            consts,
+        }
+    }
+
+    fn insert(&mut self, id: ValueId, v: V) {
+        self.locals.insert(id, v);
+    }
+}
+
+impl<V> std::ops::Index<&ValueId> for Scope<'_, V> {
+    type Output = V;
+
+    fn index(&self, id: &ValueId) -> &V {
+        self.locals
+            .get(id)
+            .or_else(|| self.consts.get(id))
+            .expect("ICE: value id not in scope")
+    }
+}
+
+/// Build the constant scope: every interned SSA constant turned into a `V`, exactly once.
+///
+/// Sources from [`HLSSA::const_snapshot`], which releases the constants lock before returning,
+/// rather than [`HLSSA::for_each_const`], which holds the read lock across the walk. The `of_*`
+/// calls below may intern constants via `add_const` (which takes the constants write lock), so
+/// running them while the read lock is held would deadlock.
+fn materialize_constants<V, Ctx>(ssa: &HLSSA, ctx: &mut Ctx) -> HashMap<ValueId, V>
+where
+    V: Value<Ctx>,
+{
+    let mut consts = HashMap::new();
+    for (vid, cv) in ssa.const_snapshot() {
+        let v = match cv.as_ref() {
+            Constant::U(size, val) => V::of_u(*size, *val, ctx),
+            Constant::I(size, val) => V::of_i(*size, *val, ctx),
+            Constant::Field(val) => V::of_field(*val, ctx),
+            Constant::FnPtr(_) => {
+                todo!("FnPtrConst in symbolic executor");
+            }
+        };
+        consts.insert(vid, v);
+    }
+    consts
 }

--- a/compiler/src/compiler/analysis/types.rs
+++ b/compiler/src/compiler/analysis/types.rs
@@ -10,9 +10,18 @@ use crate::compiler::{
     analysis::flow_analysis::{CFG, FlowAnalysis},
     ssa::{
         FunctionId, ValueId,
-        hlssa::{CallTarget, CastTarget, ConstValue, HLFunction, HLSSA, OpCode, Type, TypeExpr},
+        hlssa::{CallTarget, CastTarget, Constant, HLFunction, HLSSA, OpCode, Type, TypeExpr},
     },
 };
+
+pub fn const_value_type(value: &Constant) -> Type {
+    match value {
+        Constant::U(size, _) => Type::u(*size),
+        Constant::I(size, _) => Type::i(*size),
+        Constant::Field(_) => Type::field(),
+        Constant::FnPtr(_) => Type::function(),
+    }
+}
 
 fn push_witness_of_to_leaves(t: Type) -> Type {
     match t.expr {
@@ -68,9 +77,17 @@ impl Types {
             .map(|(id, func)| (*id, (func.get_param_types(), func.get_returns())))
             .collect::<HashMap<_, _>>();
 
+        // The constants side-table is module-level; pre-compute types for every constant
+        // `ValueId` so `run_function` can seed `function_info` with them.
+        let constant_types: HashMap<ValueId, Type> = ssa
+            .const_snapshot()
+            .iter()
+            .map(|(vid, cv)| (*vid, const_value_type(cv)))
+            .collect();
+
         for (function_id, function) in ssa.iter_functions() {
             let cfg = cfg.get_function_cfg(*function_id);
-            let function_info = self.run_function(function, &function_types, cfg);
+            let function_info = self.run_function(function, &function_types, &constant_types, cfg);
             type_info.functions.insert(*function_id, function_info);
         }
         type_info
@@ -144,10 +161,11 @@ impl Types {
         &self,
         function: &HLFunction,
         function_types: &HashMap<FunctionId, (Vec<Type>, &[Type])>,
+        constant_types: &HashMap<ValueId, Type>,
         cfg: &CFG,
     ) -> FunctionTypeInfo {
         let mut function_info = FunctionTypeInfo {
-            values: HashMap::new(),
+            values: constant_types.clone(),
         };
 
         for block_id in cfg.get_domination_pre_order() {
@@ -673,16 +691,6 @@ impl Types {
                 value: _,
             } => Ok(()),
             OpCode::DropGlobal { global: _ } => Ok(()),
-            OpCode::Const { result, value } => {
-                let ty = match value {
-                    ConstValue::U(size, _) => Type::u(*size),
-                    ConstValue::I(size, _) => Type::i(*size),
-                    ConstValue::Field(_) => Type::field(),
-                    ConstValue::FnPtr(_) => Type::function(),
-                };
-                function_info.values.insert(*result, ty);
-                Ok(())
-            }
             OpCode::Spread { result, value, .. } => {
                 let value_type = function_info
                     .values

--- a/compiler/src/compiler/analysis/value_definitions.rs
+++ b/compiler/src/compiler/analysis/value_definitions.rs
@@ -3,12 +3,17 @@
 //!
 //! This is mainly consumed by the simplifier, avoiding the need to perform an `O(n)` scan of every
 //! block to find a value's defining instruction.
+//!
+//! Only *structural* definitions (block parameters and instruction results) are recorded here.
+//! Constants are deliberately excluded: they live in the SSA's interior-mutable constants pool,
+//! which is always up to date (including values minted mid-pass), so callers resolve them live via
+//! [`crate::compiler::ssa::SSA::get_const`] rather than from a stale snapshot.
 
 use std::collections::HashMap;
 
 use crate::compiler::ssa::{
-    BlockId, FunctionId, Instruction, ValueId,
-    hlssa::{HLFunction, HLSSA, OpCode, Type},
+    BlockId, Instruction, ValueId,
+    hlssa::{HLFunction, OpCode, Type},
 };
 
 pub enum ValueDefinition {
@@ -27,18 +32,20 @@ impl FunctionValueDefinitions {
         }
     }
 
-    pub fn get_definition(&self, value_id: ValueId) -> &ValueDefinition {
-        self.definitions.get(&value_id).unwrap()
+    /// Looks up the structural definition of a value, or `None` if it has none (e.g. a constant,
+    /// or a value minted after this snapshot was taken).
+    pub fn get_definition(&self, value_id: ValueId) -> Option<&ValueDefinition> {
+        self.definitions.get(&value_id)
     }
 
     pub fn insert(&mut self, value_id: ValueId, definition: ValueDefinition) {
         self.definitions.insert(value_id, definition);
     }
 
-    pub fn from_ssa(ssa: &HLFunction) -> Self {
+    pub fn from_function(function: &HLFunction) -> Self {
         let mut definitions = Self::new();
 
-        for (block_id, block) in ssa.get_blocks() {
+        for (block_id, block) in function.get_blocks() {
             for (i, (val, typ)) in block.get_parameters().enumerate() {
                 definitions.insert(*val, ValueDefinition::Param(*block_id, i, typ.clone()));
             }
@@ -54,41 +61,5 @@ impl FunctionValueDefinitions {
         }
 
         definitions
-    }
-}
-
-pub struct ValueDefinitions {
-    functions: HashMap<FunctionId, FunctionValueDefinitions>,
-}
-
-impl ValueDefinitions {
-    pub fn new() -> Self {
-        Self {
-            functions: HashMap::new(),
-        }
-    }
-
-    pub fn from_ssa(ssa: &HLSSA) -> Self {
-        let mut definitions = Self::new();
-
-        for (function_id, function) in ssa.iter_functions() {
-            definitions
-                .functions
-                .insert(*function_id, FunctionValueDefinitions::from_ssa(function));
-        }
-
-        definitions
-    }
-
-    pub fn get_function(&self, function_id: FunctionId) -> &FunctionValueDefinitions {
-        self.functions.get(&function_id).unwrap()
-    }
-}
-
-use crate::compiler::pass_manager::{Analysis, AnalysisStore};
-
-impl Analysis for ValueDefinitions {
-    fn compute(ssa: &HLSSA, _store: &AnalysisStore) -> Self {
-        ValueDefinitions::from_ssa(ssa)
     }
 }

--- a/compiler/src/compiler/analysis/value_range_analysis.rs
+++ b/compiler/src/compiler/analysis/value_range_analysis.rs
@@ -18,7 +18,7 @@ use crate::compiler::{
     ssa::{
         BlockId, FunctionId, Instruction, Terminator, ValueId,
         hlssa::{
-            BinaryArithOpKind, CastTarget, ConstValue, HLFunction, HLSSA, OpCode, Type, TypeExpr,
+            BinaryArithOpKind, CastTarget, Constant, HLFunction, HLSSA, OpCode, Type, TypeExpr,
         },
     },
 };
@@ -336,8 +336,8 @@ fn opt_mul(a: Option<&BigInt>, b: Option<&BigInt>) -> Option<BigInt> {
     }
 }
 
-/// Convert a `ConstValue::I(bits, encoded)` u128 bit pattern back to a
-/// signed `BigInt`. Two's-complement decode for any `bits ∈ [1, 128]`.
+/// Convert a `Constant::I(bits, encoded)` u128 bit pattern back to a signed
+/// `BigInt`. Two's-complement decode for any `bits ∈ [1, 128]`.
 fn signed_const_to_bigint(bits: usize, encoded: u128) -> BigInt {
     if bits == 0 {
         return BigInt::zero();
@@ -367,6 +367,26 @@ fn field_to_bigint(f: &Field) -> BigInt {
     let limbs = f.into_bigint().0; // [u64; 4]
     let bytes_le: Vec<u8> = limbs.iter().flat_map(|l| l.to_le_bytes()).collect();
     BigInt::from_bytes_le(Sign::Plus, &bytes_le)
+}
+
+/// Pre-compute the singleton interval for every constant in the SSA's constant
+/// storage. Constants are module-level singletons shared across functions, so
+/// this runs once before the per-function fixed-point.
+fn compute_constant_bounds(ssa: &HLSSA) -> HashMap<ValueId, IntInterval> {
+    ssa.const_snapshot()
+        .iter()
+        .map(|(vid, cv)| {
+            let r = match cv.as_ref() {
+                Constant::U(_, v) => IntInterval::singleton(*v),
+                Constant::I(bits, encoded) => {
+                    IntInterval::singleton(signed_const_to_bigint(*bits, *encoded))
+                }
+                Constant::Field(f) => IntInterval::singleton(field_to_bigint(f)),
+                Constant::FnPtr(_) => IntInterval::top(),
+            };
+            (*vid, r)
+        })
+        .collect()
 }
 
 pub struct FunctionValueRanges {
@@ -415,10 +435,15 @@ impl ValueRangeAnalysis {
         let mut result = ValueRanges {
             functions: HashMap::new(),
         };
+
+        // Constants are module-level singletons; pre-compute their bounds once.
+        let constant_bounds = compute_constant_bounds(ssa);
+
         for (function_id, function) in ssa.iter_functions() {
             let func_cfg = cfg.get_function_cfg(*function_id);
             let func_types = types.get_function(*function_id);
-            let function_ranges = self.run_function(function, func_cfg, func_types);
+            let function_ranges =
+                self.run_function(function, func_cfg, func_types, &constant_bounds);
             result.functions.insert(*function_id, function_ranges);
         }
         result
@@ -430,8 +455,9 @@ impl ValueRangeAnalysis {
         function: &HLFunction,
         cfg: &CFG,
         types: &FunctionTypeInfo,
+        constant_bounds: &HashMap<ValueId, IntInterval>,
     ) -> FunctionValueRanges {
-        let mut bounds: HashMap<ValueId, IntInterval> = HashMap::new();
+        let mut bounds: HashMap<ValueId, IntInterval> = constant_bounds.clone();
 
         // Initial state: every value's bound is its declared type's full range.
         // Iteration only narrows from there.
@@ -525,18 +551,6 @@ impl ValueRangeAnalysis {
         };
 
         match instr {
-            OpCode::Const { result, value } => {
-                let r = match value {
-                    ConstValue::U(_, v) => IntInterval::singleton(*v),
-                    ConstValue::I(bits, encoded) => {
-                        IntInterval::singleton(signed_const_to_bigint(*bits, *encoded))
-                    }
-                    ConstValue::Field(f) => IntInterval::singleton(field_to_bigint(f)),
-                    ConstValue::FnPtr(_) => IntInterval::top(),
-                };
-                Self::overwrite(bounds, *result, cap_to_type(*result, r), changed);
-            }
-
             OpCode::Cast {
                 result,
                 value,

--- a/compiler/src/compiler/analysis/witness_type_inference.rs
+++ b/compiler/src/compiler/analysis/witness_type_inference.rs
@@ -8,7 +8,7 @@ use crate::compiler::{
     analysis::flow_analysis::{self, FlowAnalysis},
     ssa::{
         BlockId, FunctionId, SSAAnotator, Terminator, ValueId,
-        hlssa::{CallTarget, HLBlock, HLFunction, HLSSA, OpCode, Type, TypeExpr},
+        hlssa::{CallTarget, Constant, HLBlock, HLFunction, HLSSA, OpCode, Type, TypeExpr},
     },
 };
 
@@ -108,8 +108,7 @@ impl WitnessTypeInference {
         };
 
         // Clone main function as specialized version, set as entry point
-        let main_specialized = ssa.get_function(main_id).clone();
-        let main_specialized_id = ssa.insert_function(main_specialized);
+        let main_specialized_id = ssa.duplicate_function(main_id);
         ssa.set_entry_point(main_specialized_id);
 
         let mut specializations: HashMap<SpecKey, SpecValue> = HashMap::new();
@@ -132,7 +131,8 @@ impl WitnessTypeInference {
         // 3. Global worklist loop
         while let Some(spec_key) = worklist.pop_front() {
             queued.remove(&spec_key);
-            let func = ssa.get_function(spec_key.original_func_id);
+            let specialized_func_id = specializations.get(&spec_key).unwrap().specialized_func_id;
+            let func = ssa.get_function(specialized_func_id);
             let cfg = flow_analysis.get_function_cfg(spec_key.original_func_id);
 
             let result = Self::propagate_function(
@@ -184,8 +184,7 @@ impl WitnessTypeInference {
                         .map(Self::construct_pure_witness_for_type)
                         .collect();
 
-                    let specialized_clone = callee_func.clone();
-                    let specialized_id = ssa.insert_function(specialized_clone);
+                    let specialized_id = ssa.duplicate_function(callee_key.original_func_id);
 
                     specializations.insert(
                         callee_key.clone(),
@@ -215,7 +214,7 @@ impl WitnessTypeInference {
 
         // 4. Update Call targets in specialized functions to point to specialized callees
         for (spec_key, spec_value) in &specializations {
-            let func = ssa.get_function(spec_key.original_func_id);
+            let func = ssa.get_function(spec_value.specialized_func_id);
             let cfg = flow_analysis.get_function_cfg(spec_key.original_func_id);
 
             // Re-propagate to get call sites with their correct mapping
@@ -228,6 +227,8 @@ impl WitnessTypeInference {
                 ssa,
             );
 
+            // Safe as we put the processed function back under the same ID and thus avoid any
+            // dangling references.
             let mut specialized_func = ssa.take_function(spec_value.specialized_func_id);
 
             // Build call site index: for each block, collect calls in order
@@ -297,6 +298,15 @@ impl WitnessTypeInference {
         let mut value_wt: HashMap<ValueId, WitnessShape> = HashMap::new();
         let mut block_cfg: HashMap<BlockId, WitnessType> = HashMap::new();
         let mut alloc_inner: HashMap<ValueId, WitnessShape> = HashMap::new();
+
+        ssa.for_each_const(|vid, val| {
+            let shape = match val.as_ref() {
+                Constant::U(_, _) | Constant::I(_, _) | Constant::Field(_) | Constant::FnPtr(_) => {
+                    WitnessShape::Scalar(WitnessType::Pure)
+                }
+            };
+            value_wt.insert(*vid, shape);
+        });
 
         // Initialize entry block params from arg_types
         let entry_params: Vec<(ValueId, Type)> =
@@ -841,9 +851,6 @@ impl WitnessTypeInference {
                 | OpCode::Todo { .. }
                 | OpCode::ValueOf { .. } => {
                     panic!("Should not be present at this stage {:?}", instruction);
-                }
-                OpCode::Const { result, .. } => {
-                    value_wt.insert(*result, WitnessShape::Scalar(WitnessType::Pure));
                 }
                 OpCode::Guard { .. } => {
                     panic!("ICE: Guard should not be present during witness type inference");

--- a/compiler/src/compiler/analysis/witness_type_inference.rs
+++ b/compiler/src/compiler/analysis/witness_type_inference.rs
@@ -227,8 +227,6 @@ impl WitnessTypeInference {
                 ssa,
             );
 
-            // Safe as we put the processed function back under the same ID and thus avoid any
-            // dangling references.
             let mut specialized_func = ssa.take_function(spec_value.specialized_func_id);
 
             // Build call site index: for each block, collect calls in order

--- a/compiler/src/compiler/codegen/bytecode/mod.rs
+++ b/compiler/src/compiler/codegen/bytecode/mod.rs
@@ -12,15 +12,82 @@ use crate::{
         },
         codegen::bytecode::layout::{FrameLayouter, GlobalFrameLayouter, StructLayoutInterner},
         ssa::{
-            BlockId, FunctionId, Terminator,
+            BlockId, FunctionId, Instruction, Terminator, ValueId,
             hlssa::{
                 self, BinaryArithOpKind, CmpKind, DMatrix, Endianness, HLBlock, HLFunction, HLSSA,
-                LookupTarget, Radix, RefCountOp, Type, TypeExpr,
+                HLSSAConstantsSnapshot, LookupTarget, Radix, RefCountOp, Type, TypeExpr,
             },
         },
     },
     vm::{self, bytecode},
 };
+
+/// Materialize every constant `ValueId` referenced by `function` into the function's frame at
+/// entry.
+///
+/// This can likely be improved in the future by handling constants specially in the VM, but for now
+/// this is the simplest solution that maintains semantic correctness.
+fn materialize_constants(
+    function: &HLFunction,
+    constants: &HLSSAConstantsSnapshot,
+    layouter: &mut FrameLayouter,
+    emitter: &mut EmitterState,
+) {
+    let mut referenced: std::collections::HashSet<ValueId> = std::collections::HashSet::new();
+    for (_, block) in function.get_blocks() {
+        for instr in block.get_instructions() {
+            for vid in instr.get_inputs() {
+                if constants.contains_key(vid) {
+                    referenced.insert(*vid);
+                }
+            }
+        }
+        if let Some(term) = block.get_terminator() {
+            match term {
+                Terminator::Jmp(_, args) | Terminator::Return(args) => {
+                    for vid in args {
+                        if constants.contains_key(vid) {
+                            referenced.insert(*vid);
+                        }
+                    }
+                }
+                Terminator::JmpIf(cond, _, _) => {
+                    if constants.contains_key(cond) {
+                        referenced.insert(*cond);
+                    }
+                }
+            }
+        }
+    }
+
+    // Sort for determinism: HashSet iteration order is non-deterministic but the emitted bytecode
+    // must be stable across runs.
+    let mut referenced: Vec<ValueId> = referenced.into_iter().collect();
+    referenced.sort_by_key(|v| v.0);
+
+    for vid in referenced {
+        match constants.get(&vid).expect("vid is in constants").as_ref() {
+            hlssa::Constant::U(size, val) | hlssa::Constant::I(size, val) => {
+                emitter.push_op(bytecode::OpCode::MovConst {
+                    res: layouter.alloc_u64(vid, *size),
+                    val: *val as u64,
+                });
+            }
+            hlssa::Constant::Field(val) => {
+                let start = layouter.alloc_field(vid);
+                for i in 0..bytecode::FELT_LIMBS {
+                    emitter.push_op(bytecode::OpCode::MovConst {
+                        res: start.offset(i as isize),
+                        val: val.0.0[i],
+                    });
+                }
+            }
+            hlssa::Constant::FnPtr(_) => {
+                panic!("FnPtr constants not supported in codegen");
+            }
+        }
+    }
+}
 
 // CODE GENERATOR
 // ================================================================================================
@@ -36,6 +103,7 @@ impl CodeGen {
     pub fn run(&self, ssa: &HLSSA, cfg: &FlowAnalysis, type_info: &TypeInfo) -> bytecode::Program {
         let global_layouter = GlobalFrameLayouter::new(ssa);
         let mut struct_interner = StructLayoutInterner::new();
+        let constants = ssa.const_snapshot();
 
         let function = ssa.get_main();
         let function = self.run_function(
@@ -44,6 +112,7 @@ impl CodeGen {
             type_info.get_function(ssa.get_main_id()),
             &global_layouter,
             &mut struct_interner,
+            &constants,
         );
 
         let mut functions = vec![function];
@@ -63,6 +132,7 @@ impl CodeGen {
                 type_info.get_function(*function_id),
                 &global_layouter,
                 &mut struct_interner,
+                &constants,
             );
             function_ids.insert(*function_id, cur_fn_begin);
             cur_fn_begin += function.code.len();
@@ -103,15 +173,20 @@ impl CodeGen {
         type_info: &FunctionTypeInfo,
         global_layouter: &GlobalFrameLayouter,
         struct_interner: &mut StructLayoutInterner,
+        constants: &HLSSAConstantsSnapshot,
     ) -> bytecode::Function {
         let mut layouter = FrameLayouter::new();
         let entry = function.get_entry();
         let mut emitter = EmitterState::new();
 
-        // Entry block params need to be allocated at the beginning of the frame (after return address and return data pointer)
+        // Entry block params need to be allocated at the beginning of the frame (after return
+        // address and return data pointer)
         for (param, tp) in entry.get_parameters() {
             layouter.alloc_value(*param, tp);
         }
+
+        // TODO: Deal with constants better in the bytecode (#201)
+        materialize_constants(function, constants, &mut layouter, &mut emitter);
 
         self.run_block_body(
             function,
@@ -1122,26 +1197,6 @@ impl CodeGen {
                         size: global_layouter.get_size(global_idx),
                     });
                 }
-                hlssa::OpCode::Const { result, value } => match value {
-                    hlssa::ConstValue::U(size, val) | hlssa::ConstValue::I(size, val) => {
-                        emitter.push_op(bytecode::OpCode::MovConst {
-                            res: layouter.alloc_u64(*result, *size),
-                            val: *val as u64,
-                        });
-                    }
-                    hlssa::ConstValue::Field(val) => {
-                        let start = layouter.alloc_field(*result);
-                        for i in 0..bytecode::FELT_LIMBS {
-                            emitter.push_op(bytecode::OpCode::MovConst {
-                                res: start.offset(i as isize),
-                                val: val.0.0[i],
-                            })
-                        }
-                    }
-                    hlssa::ConstValue::FnPtr(_) => {
-                        panic!("FnPtr constants not supported in codegen");
-                    }
-                },
                 hlssa::OpCode::Alloc { result, elem_type } => {
                     let res = layouter.alloc_ptr(*result);
                     let elem_size = layouter.type_size(elem_type);

--- a/compiler/src/compiler/lowering/expression_converter.rs
+++ b/compiler/src/compiler/lowering/expression_converter.rs
@@ -11,7 +11,7 @@ use noirc_frontend::monomorphization::ast::{
 use crate::compiler::ssa::{
     BlockId, FunctionId, ValueId,
     hlssa::{
-        CastTarget, ConstValue, Endianness, OpCode, Radix, SequenceTargetType, Type,
+        CastTarget, Constant, Endianness, Radix, SequenceTargetType, Type,
         builder::{HLEmitter, HLFunctionBuilder},
     },
 };
@@ -61,8 +61,6 @@ pub struct ExpressionConverter<'a> {
     in_unconstrained: bool,
     /// Maps GlobalId to global slot index
     global_slots: &'a HashMap<GlobalId, usize>,
-    /// Dedup cache for constants
-    const_cache: HashMap<ConstValue, ValueId>,
     /// Maps LowLevel function name to its replacement
     lowlevel_replacements: &'a HashMap<String, LowLevelReplacement>,
     /// Current block being emitted into
@@ -88,27 +86,12 @@ impl<'a> ExpressionConverter<'a> {
             in_unconstrained,
             global_slots,
             lowlevel_replacements,
-            const_cache: HashMap::new(),
             current_block: entry_block,
         }
     }
 
     pub fn current_block(&self) -> BlockId {
         self.current_block
-    }
-
-    fn get_or_create_const(&mut self, b: &mut HLFunctionBuilder<'_>, cv: ConstValue) -> ValueId {
-        if let Some(&vid) = self.const_cache.get(&cv) {
-            return vid;
-        }
-        let vid = b.fresh_value();
-        let entry = b.function().get_entry_id();
-        b.block(entry).emit(OpCode::Const {
-            result: vid,
-            value: cv.clone(),
-        });
-        self.const_cache.insert(cv, vid);
-        vid
     }
 
     /// Bind an immutable local variable to a value
@@ -190,7 +173,7 @@ impl<'a> ExpressionConverter<'a> {
                 let for_loop_index = ctx.for_loop_index;
                 if let Some((loop_index, index_bit_size)) = for_loop_index {
                     // For loop: increment index and jump back to header
-                    let one = self.get_or_create_const(b, ConstValue::U(index_bit_size, 1));
+                    let one = b.ssa.add_const(Constant::U(index_bit_size, 1));
                     let mut e = b.block(self.current_block);
                     let next_index = e.add(loop_index, one);
                     e.terminate_jmp(loop_header, vec![next_index]);
@@ -236,7 +219,7 @@ impl<'a> ExpressionConverter<'a> {
                     .get(func_id)
                     .unwrap_or_else(|| panic!("Undefined function: {:?}", func_id));
                 // Return a function pointer constant
-                let value_id = self.get_or_create_const(b, ConstValue::FnPtr(*ssa_func_id));
+                let value_id = b.ssa.add_const(Constant::FnPtr(*ssa_func_id));
                 Some(value_id)
             }
             Definition::Builtin(name) => {
@@ -527,7 +510,7 @@ impl<'a> ExpressionConverter<'a> {
 
         // if range is inclusive, bump by one
         let end = if for_expr.inclusive {
-            let one = self.get_or_create_const(b, ConstValue::U(index_type.get_bit_size(), 1));
+            let one = b.ssa.add_const(Constant::U(index_type.get_bit_size(), 1));
             b.block(self.current_block).add(end_raw, one)
         } else {
             end_raw
@@ -575,7 +558,7 @@ impl<'a> ExpressionConverter<'a> {
         // Increment the index and jump back to header
         // (only if current block is not already terminated by break/continue)
         if !b.block(self.current_block).is_terminated() {
-            let one = self.get_or_create_const(b, ConstValue::U(index_bit_size, 1));
+            let one = b.ssa.add_const(Constant::U(index_bit_size, 1));
             let mut body_end = b.block(self.current_block);
             let next_index = body_end.add(loop_index, one);
             body_end.terminate_jmp(loop_header, vec![next_index]);
@@ -818,14 +801,14 @@ impl<'a> ExpressionConverter<'a> {
                             Some(AstType::Integer(
                                 noirc_frontend::shared::Signedness::Signed,
                                 bit_size,
-                            )) => ConstValue::I(bit_size.bit_size() as usize, 0),
+                            )) => Constant::I(bit_size.bit_size() as usize, 0),
                             Some(AstType::Integer(
                                 noirc_frontend::shared::Signedness::Unsigned,
                                 bit_size,
-                            )) => ConstValue::U(bit_size.bit_size() as usize, 0),
-                            _ => ConstValue::Field(ark_bn254::Fr::from(0u64)),
+                            )) => Constant::U(bit_size.bit_size() as usize, 0),
+                            _ => Constant::Field(ark_bn254::Fr::from(0u64)),
                         };
-                        let zero = self.get_or_create_const(b, zero_const);
+                        let zero = b.ssa.add_const(zero_const);
                         b.block(self.current_block).sub(zero, value)
                     }
                     _ => unreachable!(),
@@ -944,7 +927,7 @@ impl<'a> ExpressionConverter<'a> {
         match lit {
             Literal::Bool(bv) => {
                 let value = if *bv { 1 } else { 0 };
-                Some(self.get_or_create_const(b, ConstValue::U(1, value)))
+                Some(b.ssa.add_const(Constant::U(1, value)))
             }
             Literal::Integer(signed_field, typ, _location) => {
                 use noirc_frontend::monomorphization::ast::Type as AstType;
@@ -954,7 +937,7 @@ impl<'a> ExpressionConverter<'a> {
                         // Convert SignedField to ark_bn254::Fr directly (both backed by same type)
                         let field_element = signed_field.to_field_element();
                         let field_val = field_element.into_repr();
-                        Some(self.get_or_create_const(b, ConstValue::Field(field_val)))
+                        Some(b.ssa.add_const(Constant::Field(field_val)))
                     }
                     AstType::Integer(signedness, bit_size) => {
                         use noirc_frontend::shared::Signedness;
@@ -962,16 +945,16 @@ impl<'a> ExpressionConverter<'a> {
                         if *signedness == Signedness::Signed {
                             let signed_val = signed_field.to_i128();
                             let twos_complement = (signed_val as u128) & ((1u128 << bits) - 1);
-                            Some(self.get_or_create_const(b, ConstValue::I(bits, twos_complement)))
+                            Some(b.ssa.add_const(Constant::I(bits, twos_complement)))
                         } else {
                             // Get the value as u128
                             let value = signed_field.to_u128();
-                            Some(self.get_or_create_const(b, ConstValue::U(bits, value)))
+                            Some(b.ssa.add_const(Constant::U(bits, value)))
                         }
                     }
                     AstType::Bool => {
                         let value = signed_field.to_u128();
-                        Some(self.get_or_create_const(b, ConstValue::U(1, value)))
+                        Some(b.ssa.add_const(Constant::U(1, value)))
                     }
                     _ => panic!("Unexpected type for integer literal: {:?}", typ),
                 }
@@ -1014,7 +997,7 @@ impl<'a> ExpressionConverter<'a> {
                 let len = s.len();
                 let elems: Vec<ValueId> = s
                     .bytes()
-                    .map(|byte| self.get_or_create_const(b, ConstValue::U(8, byte as u128)))
+                    .map(|byte| b.ssa.add_const(Constant::U(8, byte as u128)))
                     .collect();
                 let arr = b.block(self.current_block).mk_seq(
                     elems,
@@ -1035,7 +1018,7 @@ impl<'a> ExpressionConverter<'a> {
                         FmtStrFragment::Interpolation(name, _) => format!("{{{name}}}"),
                     };
                     for c in text.chars() {
-                        codepoints.push(self.get_or_create_const(b, ConstValue::U(32, c as u128)));
+                        codepoints.push(b.ssa.add_const(Constant::U(32, c as u128)));
                     }
                 }
                 let cp_len = codepoints.len();
@@ -1254,7 +1237,7 @@ impl<'a> ExpressionConverter<'a> {
                         // function call that emits constraints), then return the
                         // compile-time-known length.
                         self.convert_expression(&call.arguments[0], b);
-                        let value = self.get_or_create_const(b, ConstValue::U(32, *len as u128));
+                        let value = b.ssa.add_const(Constant::U(32, *len as u128));
                         Some(value)
                     }
                     noirc_frontend::monomorphization::ast::Type::Vector(_) => {
@@ -1318,10 +1301,9 @@ impl<'a> ExpressionConverter<'a> {
                 None
             }
             "is_unconstrained" => {
-                let value = self.get_or_create_const(
-                    b,
-                    ConstValue::U(1, if self.in_unconstrained { 1 } else { 0 }),
-                );
+                let value = b
+                    .ssa
+                    .add_const(Constant::U(1, if self.in_unconstrained { 1 } else { 0 }));
                 Some(value)
             }
             "as_witness" => {

--- a/compiler/src/compiler/lowering/expression_converter.rs
+++ b/compiler/src/compiler/lowering/expression_converter.rs
@@ -173,7 +173,7 @@ impl<'a> ExpressionConverter<'a> {
                 let for_loop_index = ctx.for_loop_index;
                 if let Some((loop_index, index_bit_size)) = for_loop_index {
                     // For loop: increment index and jump back to header
-                    let one = b.ssa.add_const(Constant::U(index_bit_size, 1));
+                    let one = b.emit_const(Constant::U(index_bit_size, 1));
                     let mut e = b.block(self.current_block);
                     let next_index = e.add(loop_index, one);
                     e.terminate_jmp(loop_header, vec![next_index]);
@@ -219,7 +219,7 @@ impl<'a> ExpressionConverter<'a> {
                     .get(func_id)
                     .unwrap_or_else(|| panic!("Undefined function: {:?}", func_id));
                 // Return a function pointer constant
-                let value_id = b.ssa.add_const(Constant::FnPtr(*ssa_func_id));
+                let value_id = b.emit_const(Constant::FnPtr(*ssa_func_id));
                 Some(value_id)
             }
             Definition::Builtin(name) => {
@@ -510,7 +510,7 @@ impl<'a> ExpressionConverter<'a> {
 
         // if range is inclusive, bump by one
         let end = if for_expr.inclusive {
-            let one = b.ssa.add_const(Constant::U(index_type.get_bit_size(), 1));
+            let one = b.emit_const(Constant::U(index_type.get_bit_size(), 1));
             b.block(self.current_block).add(end_raw, one)
         } else {
             end_raw
@@ -558,7 +558,7 @@ impl<'a> ExpressionConverter<'a> {
         // Increment the index and jump back to header
         // (only if current block is not already terminated by break/continue)
         if !b.block(self.current_block).is_terminated() {
-            let one = b.ssa.add_const(Constant::U(index_bit_size, 1));
+            let one = b.emit_const(Constant::U(index_bit_size, 1));
             let mut body_end = b.block(self.current_block);
             let next_index = body_end.add(loop_index, one);
             body_end.terminate_jmp(loop_header, vec![next_index]);
@@ -808,7 +808,7 @@ impl<'a> ExpressionConverter<'a> {
                             )) => Constant::U(bit_size.bit_size() as usize, 0),
                             _ => Constant::Field(ark_bn254::Fr::from(0u64)),
                         };
-                        let zero = b.ssa.add_const(zero_const);
+                        let zero = b.emit_const(zero_const);
                         b.block(self.current_block).sub(zero, value)
                     }
                     _ => unreachable!(),
@@ -927,7 +927,7 @@ impl<'a> ExpressionConverter<'a> {
         match lit {
             Literal::Bool(bv) => {
                 let value = if *bv { 1 } else { 0 };
-                Some(b.ssa.add_const(Constant::U(1, value)))
+                Some(b.emit_const(Constant::U(1, value)))
             }
             Literal::Integer(signed_field, typ, _location) => {
                 use noirc_frontend::monomorphization::ast::Type as AstType;
@@ -937,7 +937,7 @@ impl<'a> ExpressionConverter<'a> {
                         // Convert SignedField to ark_bn254::Fr directly (both backed by same type)
                         let field_element = signed_field.to_field_element();
                         let field_val = field_element.into_repr();
-                        Some(b.ssa.add_const(Constant::Field(field_val)))
+                        Some(b.emit_const(Constant::Field(field_val)))
                     }
                     AstType::Integer(signedness, bit_size) => {
                         use noirc_frontend::shared::Signedness;
@@ -945,16 +945,16 @@ impl<'a> ExpressionConverter<'a> {
                         if *signedness == Signedness::Signed {
                             let signed_val = signed_field.to_i128();
                             let twos_complement = (signed_val as u128) & ((1u128 << bits) - 1);
-                            Some(b.ssa.add_const(Constant::I(bits, twos_complement)))
+                            Some(b.emit_const(Constant::I(bits, twos_complement)))
                         } else {
                             // Get the value as u128
                             let value = signed_field.to_u128();
-                            Some(b.ssa.add_const(Constant::U(bits, value)))
+                            Some(b.emit_const(Constant::U(bits, value)))
                         }
                     }
                     AstType::Bool => {
                         let value = signed_field.to_u128();
-                        Some(b.ssa.add_const(Constant::U(1, value)))
+                        Some(b.emit_const(Constant::U(1, value)))
                     }
                     _ => panic!("Unexpected type for integer literal: {:?}", typ),
                 }
@@ -997,7 +997,7 @@ impl<'a> ExpressionConverter<'a> {
                 let len = s.len();
                 let elems: Vec<ValueId> = s
                     .bytes()
-                    .map(|byte| b.ssa.add_const(Constant::U(8, byte as u128)))
+                    .map(|byte| b.emit_const(Constant::U(8, byte as u128)))
                     .collect();
                 let arr = b.block(self.current_block).mk_seq(
                     elems,
@@ -1018,7 +1018,7 @@ impl<'a> ExpressionConverter<'a> {
                         FmtStrFragment::Interpolation(name, _) => format!("{{{name}}}"),
                     };
                     for c in text.chars() {
-                        codepoints.push(b.ssa.add_const(Constant::U(32, c as u128)));
+                        codepoints.push(b.emit_const(Constant::U(32, c as u128)));
                     }
                 }
                 let cp_len = codepoints.len();
@@ -1237,7 +1237,7 @@ impl<'a> ExpressionConverter<'a> {
                         // function call that emits constraints), then return the
                         // compile-time-known length.
                         self.convert_expression(&call.arguments[0], b);
-                        let value = b.ssa.add_const(Constant::U(32, *len as u128));
+                        let value = b.emit_const(Constant::U(32, *len as u128));
                         Some(value)
                     }
                     noirc_frontend::monomorphization::ast::Type::Vector(_) => {

--- a/compiler/src/compiler/lowering/mod.rs
+++ b/compiler/src/compiler/lowering/mod.rs
@@ -99,21 +99,18 @@ impl SSAConverter {
                 let ssa_func_id = *self.constrained_mapper.get(&ast_func.id).unwrap();
                 let converted =
                     self.convert_function(&mut ssa, ast_func, &self.unconstrained_mapper, true);
-                // Safe as we do an in-place replacement of a unique function by ID.
                 *ssa.get_function_mut(ssa_func_id) = converted;
             } else {
                 // Constrained version
                 let constrained_id = *self.constrained_mapper.get(&ast_func.id).unwrap();
                 let converted =
                     self.convert_function(&mut ssa, ast_func, &self.constrained_mapper, false);
-                // Safe as we do an in-place replacement of a unique function by ID.
                 *ssa.get_function_mut(constrained_id) = converted;
 
                 // Unconstrained variant (for calls from unconstrained context)
                 let unconstrained_id = *self.unconstrained_mapper.get(&ast_func.id).unwrap();
                 let converted =
                     self.convert_function(&mut ssa, ast_func, &self.unconstrained_mapper, true);
-                // Safe as we do an in-place replacement of a unique function by ID.
                 *ssa.get_function_mut(unconstrained_id) = converted;
             }
         }

--- a/compiler/src/compiler/lowering/mod.rs
+++ b/compiler/src/compiler/lowering/mod.rs
@@ -99,18 +99,21 @@ impl SSAConverter {
                 let ssa_func_id = *self.constrained_mapper.get(&ast_func.id).unwrap();
                 let converted =
                     self.convert_function(&mut ssa, ast_func, &self.unconstrained_mapper, true);
+                // Safe as we do an in-place replacement of a unique function by ID.
                 *ssa.get_function_mut(ssa_func_id) = converted;
             } else {
                 // Constrained version
                 let constrained_id = *self.constrained_mapper.get(&ast_func.id).unwrap();
                 let converted =
                     self.convert_function(&mut ssa, ast_func, &self.constrained_mapper, false);
+                // Safe as we do an in-place replacement of a unique function by ID.
                 *ssa.get_function_mut(constrained_id) = converted;
 
                 // Unconstrained variant (for calls from unconstrained context)
                 let unconstrained_id = *self.unconstrained_mapper.get(&ast_func.id).unwrap();
                 let converted =
                     self.convert_function(&mut ssa, ast_func, &self.unconstrained_mapper, true);
+                // Safe as we do an in-place replacement of a unique function by ID.
                 *ssa.get_function_mut(unconstrained_id) = converted;
             }
         }

--- a/compiler/src/compiler/pass_manager.rs
+++ b/compiler/src/compiler/pass_manager.rs
@@ -3,12 +3,13 @@ use std::{
     collections::HashMap,
     fmt::Debug,
     fs,
+    hash::Hash,
     path::PathBuf,
 };
 
 use crate::compiler::ssa::{
     DefaultSSAAnnotator, Instruction, SSA, SSAType,
-    hlssa::{Constants, OpCode, Type},
+    hlssa::{Constant, OpCode, Type},
 };
 
 // ---------------------------------------------------------------------------
@@ -24,8 +25,12 @@ pub struct AnalysisId {
 }
 
 impl AnalysisId {
-    pub fn of<A: Analysis<Op, Ty, C>, Op: Instruction, Ty: SSAType, C: Clone + Debug + 'static>()
-    -> Self {
+    pub fn of<
+        A: Analysis<Op, Ty, C>,
+        Op: Instruction,
+        Ty: SSAType,
+        C: Clone + Debug + Eq + Hash + 'static,
+    >() -> Self {
         Self {
             type_id: TypeId::of::<A>(),
             type_name: std::any::type_name::<A>(),
@@ -73,7 +78,7 @@ impl std::fmt::Debug for AnalysisId {
 pub trait Analysis<
     Op: Instruction = OpCode,
     Ty: SSAType = Type,
-    C: Clone + Debug + 'static = Constants,
+    C: Clone + Debug + Eq + Hash + 'static = Constant,
 >: Any + 'static
 {
     fn id() -> AnalysisId
@@ -172,7 +177,11 @@ impl AnalysisStore {
 // Pass trait — parametric
 // ---------------------------------------------------------------------------
 
-pub trait Pass<Op: Instruction = OpCode, Ty: SSAType = Type, C: Clone + Debug + 'static = Constants>
+pub trait Pass<
+    Op: Instruction = OpCode,
+    Ty: SSAType = Type,
+    C: Clone + Debug + Eq + Hash + 'static = Constant,
+>
 {
     fn name(&self) -> &'static str;
     fn needs(&self) -> Vec<AnalysisId> {
@@ -220,7 +229,7 @@ fn topo_sort(roots: Vec<AnalysisId>, store: &AnalysisStore) -> Vec<AnalysisId> {
 pub struct PassManager<
     Op: Instruction = OpCode,
     Ty: SSAType = Type,
-    C: Clone + Debug + 'static = Constants,
+    C: Clone + Debug + Eq + Hash + 'static = Constant,
 > {
     passes: Vec<Box<dyn Pass<Op, Ty, C>>>,
     analyses: AnalysisStore,
@@ -229,7 +238,7 @@ pub struct PassManager<
     phase_label: String,
 }
 
-impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + 'static> PassManager<Op, Ty, C> {
+impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash + 'static> PassManager<Op, Ty, C> {
     pub fn new(phase_label: String, draw_cfg: bool, passes: Vec<Box<dyn Pass<Op, Ty, C>>>) -> Self {
         Self {
             passes,

--- a/compiler/src/compiler/passes/common_subexpression_elimination.rs
+++ b/compiler/src/compiler/passes/common_subexpression_elimination.rs
@@ -8,9 +8,9 @@ use std::collections::{HashMap, HashSet};
 use crate::compiler::{
     analysis::flow_analysis::{CFG, FlowAnalysis},
     ssa::{
-        BlockId, ValueId,
+        BlockId, SSAConstantsSnapshot, ValueId,
         hlssa::{
-            BinaryArithOpKind, CastTarget, CmpKind, ConstValue, Endianness, HLFunction, HLSSA,
+            BinaryArithOpKind, CastTarget, CmpKind, Constant, Endianness, HLFunction, HLSSA,
             OpCode, Radix,
         },
     },
@@ -298,9 +298,11 @@ impl CSE {
     }
 
     pub fn do_run(&self, ssa: &mut HLSSA, cfg: &FlowAnalysis) {
+        let constants = ssa.const_snapshot();
+
         for (function_id, function) in ssa.iter_functions_mut() {
             let cfg = cfg.get_function_cfg(*function_id);
-            let (exprs, assertions) = self.gather_expressions(function, cfg);
+            let (exprs, assertions) = self.gather_expressions(function, cfg, &constants);
             let mut value_replacements = ValueReplacements::new();
             for (_, occurrences) in exprs {
                 if occurrences.len() <= 1 {
@@ -432,6 +434,7 @@ impl CSE {
         &self,
         ssa: &HLFunction,
         cfg: &CFG,
+        constants: &SSAConstantsSnapshot<Constant>,
     ) -> (
         HashMap<ExprId, Vec<(BlockId, usize, ValueId)>>,
         HashMap<Assertion, Vec<(BlockId, usize)>>,
@@ -439,7 +442,20 @@ impl CSE {
         let mut interner = ExprInterner::default();
         let mut result: HashMap<ExprId, Vec<(BlockId, usize, ValueId)>> = HashMap::new();
         let mut assertions: HashMap<Assertion, Vec<(BlockId, usize)>> = HashMap::new();
-        let mut exprs = HashMap::<ValueId, ExprId>::new();
+
+        // Seed the value->expr map with the SSA's constants so they can be referenced as operands.
+        // They are not recorded into `result`: the constant store already dedups them, so CSE must
+        // not try to dedup the constants themselves.
+        let mut exprs: HashMap<ValueId, ExprId> = HashMap::new();
+        for (vid, cv) in constants {
+            let id = match cv.as_ref() {
+                Constant::U(bits, value) => interner.uconst(*bits, *value),
+                Constant::I(bits, value) => interner.iconst(*bits, *value),
+                Constant::Field(value) => interner.fconst(*value),
+                Constant::FnPtr(_) => continue,
+            };
+            exprs.insert(*vid, id);
+        }
 
         fn get_expr(
             exprs: &HashMap<ValueId, ExprId>,
@@ -991,45 +1007,6 @@ impl CSE {
                             result_expr,
                         );
                     }
-                    OpCode::Const {
-                        result: r,
-                        value: cv,
-                    } => match cv {
-                        ConstValue::U(size, val) => {
-                            let expr = interner.uconst(*size, *val);
-                            record_expr(
-                                &mut exprs,
-                                &mut result,
-                                block_id,
-                                instruction_idx,
-                                *r,
-                                expr,
-                            );
-                        }
-                        ConstValue::I(size, val) => {
-                            let expr = interner.iconst(*size, *val);
-                            record_expr(
-                                &mut exprs,
-                                &mut result,
-                                block_id,
-                                instruction_idx,
-                                *r,
-                                expr,
-                            );
-                        }
-                        ConstValue::Field(val) => {
-                            let expr = interner.fconst(*val);
-                            record_expr(
-                                &mut exprs,
-                                &mut result,
-                                block_id,
-                                instruction_idx,
-                                *r,
-                                expr,
-                            );
-                        }
-                        ConstValue::FnPtr(_) => {}
-                    },
                     OpCode::Guard { .. } => {
                         // Guards are opaque to CSE
                     }

--- a/compiler/src/compiler/passes/condition_propagation.rs
+++ b/compiler/src/compiler/passes/condition_propagation.rs
@@ -6,7 +6,7 @@ use crate::compiler::{
     passes::fix_double_jumps::ValueReplacements,
     ssa::{
         BlockId, Terminator, ValueId,
-        hlssa::{ConstValue, HLSSA, OpCode, builder::HLSSABuilder},
+        hlssa::{Constant, HLSSA, builder::HLSSABuilder},
     },
 };
 
@@ -56,22 +56,18 @@ impl ConditionPropagation {
                         .iter()
                         .filter(|(cond_block, _, _)| func_cfg.dominates(*cond_block, block_id));
 
-                    let mut const_opcodes = Vec::new();
                     for (_, vid, value) in dominated {
-                        let const_id = fb.ssa.fresh_value();
-                        const_opcodes.push(OpCode::Const {
-                            result: const_id,
-                            value: ConstValue::U(1, if *value { 1 } else { 0 }),
-                        });
+                        let const_id = fb.ssa.add_const(Constant::U(1, if *value { 1 } else { 0 }));
                         replacements.insert(*vid, const_id);
                     }
 
                     let block = fb.function.get_block_mut(block_id);
                     let instructions = block.take_instructions();
-                    let mut new_instructions = const_opcodes;
-                    new_instructions.extend(instructions.iter().cloned());
-                    for instruction in new_instructions.iter_mut() {
-                        replacements.replace_inputs(instruction);
+                    let mut new_instructions = Vec::with_capacity(instructions.len());
+                    for instr in instructions {
+                        let mut instr = instr;
+                        replacements.replace_inputs(&mut instr);
+                        new_instructions.push(instr);
                     }
                     block.put_instructions(new_instructions);
                     replacements.replace_terminator(block.get_terminator_mut());

--- a/compiler/src/compiler/passes/dead_code_elimination.rs
+++ b/compiler/src/compiler/passes/dead_code_elimination.rs
@@ -125,7 +125,6 @@ impl DCE {
             | OpCode::ReadGlobal { .. }
             | OpCode::MkTuple { .. }
             | OpCode::ValueOf { .. }
-            | OpCode::Const { .. }
             | OpCode::Spread { .. }
             | OpCode::Unspread { .. } => false,
             OpCode::Guard { inner, .. } => self.is_initially_live(inner.as_ref()),
@@ -404,8 +403,20 @@ impl DCE {
             }
         }
 
+        // Sweep the module-level constant storage: a constant is live iff some live instruction
+        // (in any function) references its `ValueId`.
+        let all_live: HashSet<ValueId> = live_values
+            .values()
+            .flat_map(|set| set.iter().copied())
+            .collect();
+        // Safe to do as we ensure that all retained constants are live, and hence the dropped ones
+        // have no reachable references.
+        ssa.retain_constants(|vid, _| all_live.contains(vid));
+
         for function_id in function_ids {
             let function_cfg = cfg.get_function_cfg(function_id);
+            // Safe as a function is replaced under the same ID after processing, ensuring that
+            // there are no dangling references left.
             let mut function = ssa.take_function(function_id);
             let entry_id = function.get_entry_id();
 

--- a/compiler/src/compiler/passes/dead_code_elimination.rs
+++ b/compiler/src/compiler/passes/dead_code_elimination.rs
@@ -409,14 +409,10 @@ impl DCE {
             .values()
             .flat_map(|set| set.iter().copied())
             .collect();
-        // Safe to do as we ensure that all retained constants are live, and hence the dropped ones
-        // have no reachable references.
         ssa.retain_constants(|vid, _| all_live.contains(vid));
 
         for function_id in function_ids {
             let function_cfg = cfg.get_function_cfg(function_id);
-            // Safe as a function is replaced under the same ID after processing, ensuring that
-            // there are no dangling references left.
             let mut function = ssa.take_function(function_id);
             let entry_id = function.get_entry_id();
 

--- a/compiler/src/compiler/passes/defunctionalize.rs
+++ b/compiler/src/compiler/passes/defunctionalize.rs
@@ -13,10 +13,11 @@ use std::collections::{HashMap, HashSet};
 
 use crate::compiler::{
     pass_manager::{AnalysisStore, Pass},
+    passes::fix_double_jumps::ValueReplacements,
     ssa::{
         BlockId, FunctionId, Terminator, ValueId,
         hlssa::{
-            CallTarget, ConstValue, HLSSA, OpCode, Type, TypeExpr,
+            CallTarget, Constant, HLSSA, OpCode, Type, TypeExpr,
             builder::{HLEmitter, HLSSABuilder},
         },
     },
@@ -47,23 +48,9 @@ type ReachingFns = HashMap<(FunctionId, ValueId), HashSet<FunctionId>>;
 fn run_defunctionalize(ssa: &mut HLSSA) {
     // Check if there are any FnPtrs at all
     let has_fn_ptrs = ssa
-        .get_function_ids()
-        .collect::<Vec<_>>()
-        .iter()
-        .any(|fid| {
-            let func = ssa.get_function(*fid);
-            func.get_blocks().any(|(_, block)| {
-                block.get_instructions().any(|i| {
-                    matches!(
-                        i,
-                        OpCode::Const {
-                            value: ConstValue::FnPtr(_),
-                            ..
-                        }
-                    )
-                })
-            })
-        });
+        .const_snapshot()
+        .values()
+        .any(|cv| matches!(cv.as_ref(), Constant::FnPtr(_)));
     if !has_fn_ptrs {
         return;
     }
@@ -126,27 +113,27 @@ fn run_defunctionalize(ssa: &mut HLSSA) {
 
     // Phase 3: Transformation
 
-    // 3a. Replace FnPtrConst → UConst(32, ...) in all functions
-    let func_ids: Vec<FunctionId> = ssa.get_function_ids().collect();
-    for fid in &func_ids {
-        let func = ssa.get_function_mut(*fid);
-        for (_, block) in func.get_blocks_mut() {
-            for instruction in block.get_instructions_mut() {
-                if let OpCode::Const {
-                    result,
-                    value: ConstValue::FnPtr(fn_id),
-                } = instruction
-                {
-                    *instruction = OpCode::Const {
-                        result: *result,
-                        value: ConstValue::U(32, fn_id.0 as u128),
-                    };
-                }
-            }
-        }
+    // 3a. Intern a `U(32, fn_id)` constant for every FnPtr in storage, build a remap from each
+    // FnPtr `ValueId` to its canonical U-typed `ValueId`, and remove the FnPtr entries. The
+    // remap is applied globally in phase 3d below, after `Call::Dynamic` rewriting in 3b has
+    // run on the still-original operands.
+    let fnptr_entries: Vec<(ValueId, FunctionId)> = ssa
+        .const_snapshot()
+        .iter()
+        .filter_map(|(vid, cv)| match cv.as_ref() {
+            Constant::FnPtr(fn_id) => Some((*vid, *fn_id)),
+            _ => None,
+        })
+        .collect();
+    let mut fnptr_remap = ValueReplacements::new();
+    for (fnptr_vid, fn_id) in &fnptr_entries {
+        let canon = ssa.add_const(Constant::U(32, fn_id.0 as u128));
+        fnptr_remap.insert(*fnptr_vid, canon);
     }
 
-    // 3b. Replace CallTarget::Dynamic → CallTarget::Static(dispatch_fn)
+    // 3b. Replace CallTarget::Dynamic → CallTarget::Static(dispatch_fn). The lookup uses the
+    // original FnPtr vid (still present in the IR at this point); the emitted dispatcher Call
+    // carries `fn_ptr_val` as args[0], which is remapped to the canonical vid by phase 3d.
     let func_ids: Vec<FunctionId> = ssa.get_function_ids().collect();
     for fid in func_ids {
         let func = ssa.get_function(fid);
@@ -167,6 +154,8 @@ fn run_defunctionalize(ssa: &mut HLSSA) {
 
         let func = ssa.get_function(fid);
         let block_ids: Vec<BlockId> = func.get_blocks().map(|(bid, _)| *bid).collect();
+        // Safe as we only take and replace contents, and never duplicate them, ensuring the
+        // uniqueness of value identifiers.
         let func = ssa.get_function_mut(fid);
         for bid in block_ids {
             let block = func.get_block_mut(bid);
@@ -206,9 +195,22 @@ fn run_defunctionalize(ssa: &mut HLSSA) {
         }
     }
 
+    // 3d. Apply the FnPtr → U(32, ...) operand remap globally. This is the operand-rewriting
+    // step that used to be implicit when the FnPtr entry was rebound in place at the same vid.
+    for (_, func) in ssa.iter_functions_mut() {
+        for (_, block) in func.get_blocks_mut() {
+            for instr in block.get_instructions_mut() {
+                fnptr_remap.replace_inputs(instr);
+            }
+            fnptr_remap.replace_terminator(block.get_terminator_mut());
+        }
+    }
+
     // 3c. Replace TypeExpr::Function → TypeExpr::U(32) everywhere
     let func_ids: Vec<FunctionId> = ssa.get_function_ids().collect();
     for fid in func_ids {
+        // Safe as we only take and replace contents of the function and never duplicate them,
+        // ensuring the uniqueness of value identifiers.
         let func = ssa.get_function_mut(fid);
 
         let mut returns = func.take_returns();
@@ -291,19 +293,19 @@ fn compute_reaching_fn_ptrs(ssa: &HLSSA) -> ReachingFns {
         }
     }
 
-    // Seed from FnPtr consts
+    // Seed from FnPtr constants in storage. They are module-level — visible to every function
+    // that references them — so seed under each function id.
+    let fnptr_constants: Vec<(ValueId, FunctionId)> = ssa
+        .const_snapshot()
+        .iter()
+        .filter_map(|(vid, cv)| match cv.as_ref() {
+            Constant::FnPtr(fn_id) => Some((*vid, *fn_id)),
+            _ => None,
+        })
+        .collect();
     for &fid in &func_ids {
-        let func = ssa.get_function(fid);
-        for (_, block) in func.get_blocks() {
-            for instruction in block.get_instructions() {
-                if let OpCode::Const {
-                    result,
-                    value: ConstValue::FnPtr(fn_id),
-                } = instruction
-                {
-                    reaching.entry((fid, *result)).or_default().insert(*fn_id);
-                }
-            }
+        for (vid, target) in &fnptr_constants {
+            reaching.entry((fid, *vid)).or_default().insert(*target);
         }
     }
 

--- a/compiler/src/compiler/passes/defunctionalize.rs
+++ b/compiler/src/compiler/passes/defunctionalize.rs
@@ -154,8 +154,6 @@ fn run_defunctionalize(ssa: &mut HLSSA) {
 
         let func = ssa.get_function(fid);
         let block_ids: Vec<BlockId> = func.get_blocks().map(|(bid, _)| *bid).collect();
-        // Safe as we only take and replace contents, and never duplicate them, ensuring the
-        // uniqueness of value identifiers.
         let func = ssa.get_function_mut(fid);
         for bid in block_ids {
             let block = func.get_block_mut(bid);
@@ -209,8 +207,6 @@ fn run_defunctionalize(ssa: &mut HLSSA) {
     // 3c. Replace TypeExpr::Function → TypeExpr::U(32) everywhere
     let func_ids: Vec<FunctionId> = ssa.get_function_ids().collect();
     for fid in func_ids {
-        // Safe as we only take and replace contents of the function and never duplicate them,
-        // ensuring the uniqueness of value identifiers.
         let func = ssa.get_function_mut(fid);
 
         let mut returns = func.take_returns();

--- a/compiler/src/compiler/passes/explicit_witness.rs
+++ b/compiler/src/compiler/passes/explicit_witness.rs
@@ -765,10 +765,7 @@ impl ExplicitWitness {
                 assert!(!tuple_taint);
                 b.push(instruction);
             }
-            OpCode::InitGlobal { .. }
-            | OpCode::DropGlobal { .. }
-            | OpCode::ValueOf { .. }
-            | OpCode::Const { .. } => {
+            OpCode::InitGlobal { .. } | OpCode::DropGlobal { .. } | OpCode::ValueOf { .. } => {
                 b.push(instruction);
             }
             OpCode::Spread {
@@ -1051,7 +1048,6 @@ impl ExplicitWitness {
                 panic!("guarded BitRange should have been lowered by instruction_lowering");
             }
             OpCode::Cast { .. }
-            | OpCode::Const { .. }
             | OpCode::MkSeq { .. }
             | OpCode::MkRepeated { .. }
             | OpCode::MkTuple { .. }

--- a/compiler/src/compiler/passes/fix_double_jumps.rs
+++ b/compiler/src/compiler/passes/fix_double_jumps.rs
@@ -10,9 +10,17 @@ use crate::compiler::{
     pass_manager::{AnalysisId, AnalysisStore, Pass},
     ssa::{
         BlockId, Instruction, Terminator, ValueId,
-        hlssa::{HLSSA, OpCode},
+        hlssa::{HLFunction, HLSSA, OpCode},
     },
 };
+
+/// Selects which value references a [`ValueReplacements`] sweep rewrites.
+pub enum ReplaceScope {
+    /// Only instruction *inputs* (the values an instruction reads).
+    Inputs,
+    /// All instruction *operands*, both inputs and results.
+    Operands,
+}
 
 pub struct ValueReplacements {
     replacements: HashMap<ValueId, ValueId>,
@@ -68,6 +76,21 @@ impl ValueReplacements {
             }
         }
         panic!("ValueReplacements: cycle starting at {:?}", value)
+    }
+
+    /// Walks every instruction and terminator in `function`, applying the collected replacements.
+    ///
+    /// `scope` selects whether instruction results are rewritten alongside inputs.
+    pub fn apply_to_function(&self, function: &mut HLFunction, scope: ReplaceScope) {
+        for (_, block) in function.get_blocks_mut() {
+            for instr in block.get_instructions_mut() {
+                match scope {
+                    ReplaceScope::Inputs => self.replace_inputs(instr),
+                    ReplaceScope::Operands => self.replace_instruction(instr),
+                }
+            }
+            self.replace_terminator(block.get_terminator_mut());
+        }
     }
 }
 
@@ -125,14 +148,7 @@ impl FixDoubleJumps {
                 replacements.insert(target, source);
             }
 
-            for (_, block) in function.get_blocks_mut() {
-                for instruction in block.get_instructions_mut() {
-                    value_replacements.replace_instruction(instruction);
-                }
-                let mut terminator = block.take_terminator().unwrap();
-                value_replacements.replace_terminator(&mut terminator);
-                block.set_terminator(terminator);
-            }
+            value_replacements.apply_to_function(function, ReplaceScope::Operands);
         }
     }
 }

--- a/compiler/src/compiler/passes/instruction_lowering/pure_guards.rs
+++ b/compiler/src/compiler/passes/instruction_lowering/pure_guards.rs
@@ -212,8 +212,7 @@ impl LowerPureGuards {
             OpCode::ArraySet { .. } | OpCode::ArrayGet { .. } => false,
 
             // -- Pure computation, no constraints, can't fail → unwrap --
-            OpCode::Const { .. }
-            | OpCode::Cmp { .. }
+            OpCode::Cmp { .. }
             | OpCode::Not { .. }
             | OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::And | BinaryArithOpKind::Or | BinaryArithOpKind::Xor,

--- a/compiler/src/compiler/passes/prepare_entry_point.rs
+++ b/compiler/src/compiler/passes/prepare_entry_point.rs
@@ -24,7 +24,7 @@ use crate::compiler::{
     ssa::{
         BlockId, FunctionId, ValueId,
         hlssa::{
-            CallTarget, CastTarget, ConstValue, HLSSA, OpCode, SequenceTargetType, Type, TypeExpr,
+            CallTarget, CastTarget, Constant, HLSSA, OpCode, SequenceTargetType, Type, TypeExpr,
             builder::{HLBlockEmitter, HLEmitter, HLSSABuilder},
         },
     },
@@ -166,18 +166,12 @@ impl PrepareEntryPoint {
 
             // witness[0] must be constant one, emitted by the program.
             let witness_one_value = fb.ssa.fresh_value();
-            let one_const_value = fb.ssa.fresh_value();
-            let mut write_witness_instructions = vec![
-                OpCode::Const {
-                    result: one_const_value,
-                    value: ConstValue::Field(ark_bn254::Fr::from(1u64)),
-                },
-                OpCode::WriteWitness {
-                    result: Some(witness_one_value),
-                    value: one_const_value,
-                    pinned: true,
-                },
-            ];
+            let one_const_value = fb.ssa.add_const(Constant::Field(ark_bn254::Fr::from(1u64)));
+            let mut write_witness_instructions = vec![OpCode::WriteWitness {
+                result: Some(witness_one_value),
+                value: one_const_value,
+                pinned: true,
+            }];
 
             // Create pinned WriteWitness for each param and build replacements.
             // These must be pinned so they survive DCE even when their results become unused

--- a/compiler/src/compiler/passes/rc_insertion.rs
+++ b/compiler/src/compiler/passes/rc_insertion.rs
@@ -725,9 +725,6 @@ impl RCInsertion {
                     OpCode::ValueOf { .. } => {
                         panic!("ICE: ValueOf should not appear at this stage");
                     }
-                    OpCode::Const { .. } => {
-                        new_instructions.push(instruction);
-                    }
                     OpCode::Guard { .. } => {
                         panic!("ICE: Guard should be lowered before RC insertion");
                     }

--- a/compiler/src/compiler/passes/remove_unreachable_functions.rs
+++ b/compiler/src/compiler/passes/remove_unreachable_functions.rs
@@ -38,7 +38,9 @@ impl Pass for RemoveUnreachableFunctions {
         let all_function_ids: Vec<_> = ssa.get_function_ids().collect();
         for function_id in all_function_ids {
             if !reachable.contains(&function_id) {
-                ssa.take_function(function_id);
+                // If we get here then the function is not reachable so there will be no dangling
+                // references to it.
+                ssa.delete_function(function_id);
             }
         }
     }

--- a/compiler/src/compiler/passes/simplifier.rs
+++ b/compiler/src/compiler/passes/simplifier.rs
@@ -8,15 +8,15 @@ use num_traits::{One, Zero};
 use crate::compiler::{
     analysis::{
         flow_analysis::FlowAnalysis,
-        types::{FunctionTypeInfo, Types},
+        types::{FunctionTypeInfo, Types, const_value_type},
         value_definitions::{FunctionValueDefinitions, ValueDefinition},
     },
     pass_manager::{AnalysisId, AnalysisStore, Pass},
-    passes::fix_double_jumps::ValueReplacements,
+    passes::fix_double_jumps::{ReplaceScope, ValueReplacements},
     ssa::{
         FunctionId, ValueId,
         hlssa::{
-            BinaryArithOpKind, CastTarget, CmpKind, ConstValue, HLSSA, OpCode, Type, TypeExpr,
+            BinaryArithOpKind, CastTarget, CmpKind, Constant, HLSSA, OpCode, Type, TypeExpr,
             builder::{HLFunctionBuilder, HLSSABuilder},
         },
     },
@@ -83,7 +83,18 @@ impl Simplifier {
                 for _ in 0..self.max_iterations {
                     // Recompute locally so newly emitted opcodes (the Const+Cast
                     // pair from `materialize_const`) appear with the right types.
-                    let fti = Types::new().run_function(fb.function, &function_types, cfg);
+                    let constant_types: HashMap<ValueId, Type> = fb
+                        .ssa
+                        .const_snapshot()
+                        .iter()
+                        .map(|(vid, cv)| (*vid, const_value_type(cv)))
+                        .collect();
+                    let fti = Types::new().run_function(
+                        fb.function,
+                        &function_types,
+                        &constant_types,
+                        cfg,
+                    );
                     if !self.run_function(fb, &fti) {
                         break;
                     }
@@ -98,7 +109,7 @@ impl Simplifier {
         fb: &mut HLFunctionBuilder<'_>,
         function_type_info: &FunctionTypeInfo,
     ) -> bool {
-        let definitions = FunctionValueDefinitions::from_ssa(fb.function);
+        let definitions = FunctionValueDefinitions::from_function(fb.function);
         let mut aliases = ValueReplacements::new();
         let mut changed = false;
 
@@ -106,8 +117,8 @@ impl Simplifier {
         for (bid, mut block) in fb.function.take_blocks().into_iter() {
             let mut new_instructions = Vec::new();
             for instruction in block.take_instructions().into_iter() {
-                // Apply aliases collected so far in this iteration before
-                // pattern-matching, so we see up-to-date operand identities.
+                // Apply aliases collected so far in this iteration before pattern-matching, so we
+                // see up-to-date operands.
                 let mut instruction = instruction;
                 aliases.replace_inputs(&mut instruction);
 
@@ -133,15 +144,10 @@ impl Simplifier {
         }
         fb.function.put_blocks(new_blocks);
 
-        // Apply aliases globally. Block iteration order is non-deterministic,
-        // so a block processed before its predecessor sees stale operands;
-        // sweep here to fix references the in-walk substitution missed.
-        for (_, block) in fb.function.get_blocks_mut() {
-            for instr in block.get_instructions_mut() {
-                aliases.replace_inputs(instr);
-            }
-            aliases.replace_terminator(block.get_terminator_mut());
-        }
+        // Apply aliases globally. Block iteration order is non-deterministic, so a block processed
+        // before its predecessor sees stale operands; sweep here to fix references the in-walk
+        // substitution missed.
+        aliases.apply_to_function(fb.function, ReplaceScope::Inputs);
 
         changed
     }
@@ -163,13 +169,13 @@ impl Simplifier {
             } => {
                 match kind {
                     BinaryArithOpKind::Add => {
-                        if is_zero(defs, *lhs) {
+                        if is_zero(fb.ssa, *lhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *rhs,
                             });
                         }
-                        if is_zero(defs, *rhs) {
+                        if is_zero(fb.ssa, *rhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *lhs,
@@ -177,7 +183,7 @@ impl Simplifier {
                         }
                     }
                     BinaryArithOpKind::Sub => {
-                        if is_zero(defs, *rhs) {
+                        if is_zero(fb.ssa, *rhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *lhs,
@@ -188,25 +194,25 @@ impl Simplifier {
                         }
                     }
                     BinaryArithOpKind::Mul => {
-                        if is_zero(defs, *lhs) {
+                        if is_zero(fb.ssa, *lhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *lhs,
                             });
                         }
-                        if is_zero(defs, *rhs) {
+                        if is_zero(fb.ssa, *rhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *rhs,
                             });
                         }
-                        if is_one(defs, *lhs) {
+                        if is_one(fb.ssa, *lhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *rhs,
                             });
                         }
-                        if is_one(defs, *rhs) {
+                        if is_one(fb.ssa, *rhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *lhs,
@@ -214,7 +220,7 @@ impl Simplifier {
                         }
                     }
                     BinaryArithOpKind::Div => {
-                        if is_one(defs, *rhs) {
+                        if is_one(fb.ssa, *rhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *lhs,
@@ -222,13 +228,13 @@ impl Simplifier {
                         }
                     }
                     BinaryArithOpKind::And => {
-                        if is_zero(defs, *lhs) {
+                        if is_zero(fb.ssa, *lhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *lhs,
                             });
                         }
-                        if is_zero(defs, *rhs) {
+                        if is_zero(fb.ssa, *rhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *rhs,
@@ -240,13 +246,13 @@ impl Simplifier {
                                 target: *lhs,
                             });
                         }
-                        if is_all_ones(defs, *lhs) {
+                        if is_all_ones(fb.ssa, *lhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *rhs,
                             });
                         }
-                        if is_all_ones(defs, *rhs) {
+                        if is_all_ones(fb.ssa, *rhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *lhs,
@@ -254,13 +260,13 @@ impl Simplifier {
                         }
                     }
                     BinaryArithOpKind::Or => {
-                        if is_zero(defs, *lhs) {
+                        if is_zero(fb.ssa, *lhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *rhs,
                             });
                         }
-                        if is_zero(defs, *rhs) {
+                        if is_zero(fb.ssa, *rhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *lhs,
@@ -274,13 +280,13 @@ impl Simplifier {
                         }
                     }
                     BinaryArithOpKind::Xor => {
-                        if is_zero(defs, *lhs) {
+                        if is_zero(fb.ssa, *lhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *rhs,
                             });
                         }
-                        if is_zero(defs, *rhs) {
+                        if is_zero(fb.ssa, *rhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *lhs,
@@ -291,14 +297,14 @@ impl Simplifier {
                         }
                     }
                     BinaryArithOpKind::Shl | BinaryArithOpKind::Shr => {
-                        if is_zero(defs, *rhs) {
+                        if is_zero(fb.ssa, *rhs) {
                             return Some(Rewrite::Alias {
                                 result: *result,
                                 target: *lhs,
                             });
                         }
                         if matches!(kind, BinaryArithOpKind::Shr) {
-                            if let Some(offset) = const_as_usize(defs, *rhs) {
+                            if let Some(offset) = const_as_usize(fb.ssa, *rhs) {
                                 let lhs_type = types.get_value_type(*lhs);
                                 let lhs_inner = lhs_type.strip_witness();
                                 if let TypeExpr::U(bits) = lhs_inner.expr {
@@ -323,13 +329,13 @@ impl Simplifier {
                 const_val,
                 var,
             } => {
-                if is_zero(defs, *const_val) {
+                if is_zero(fb.ssa, *const_val) {
                     return Some(Rewrite::Alias {
                         result: *result,
                         target: *const_val,
                     });
                 }
-                if is_one(defs, *const_val) {
+                if is_one(fb.ssa, *const_val) {
                     return Some(Rewrite::Alias {
                         result: *result,
                         target: *var,
@@ -349,7 +355,7 @@ impl Simplifier {
                     });
                 }
                 // cast(cast(x, T), T) → cast(x, T)
-                if let ValueDefinition::Instruction(
+                if let Some(ValueDefinition::Instruction(
                     _,
                     _,
                     OpCode::Cast {
@@ -357,7 +363,7 @@ impl Simplifier {
                         value: _,
                         target: inner_target,
                     },
-                ) = defs.get_definition(*value)
+                )) = defs.get_definition(*value)
                 {
                     if inner_target == target {
                         return Some(Rewrite::Alias {
@@ -370,14 +376,14 @@ impl Simplifier {
             }
             OpCode::Not { result, value } => {
                 // ~~x → x
-                if let ValueDefinition::Instruction(
+                if let Some(ValueDefinition::Instruction(
                     _,
                     _,
                     OpCode::Not {
                         result: _,
                         value: inner,
                     },
-                ) = defs.get_definition(*value)
+                )) = defs.get_definition(*value)
                 {
                     return Some(Rewrite::Alias {
                         result: *result,
@@ -422,7 +428,7 @@ impl Simplifier {
             } if *lhs == *rhs => materialize_one(types, *result, fb),
             OpCode::ValueOf { result, value } => {
                 // ValueOf(ValueOf(x)) → ValueOf(x)
-                if let ValueDefinition::Instruction(_, _, OpCode::ValueOf { .. }) =
+                if let Some(ValueDefinition::Instruction(_, _, OpCode::ValueOf { .. })) =
                     defs.get_definition(*value)
                 {
                     return Some(Rewrite::Alias {
@@ -433,7 +439,7 @@ impl Simplifier {
                 // ValueOf(WriteWitness(_, hint, _)) → hint (the slot's hint
                 // value IS what ValueOf strips back to). Sound by witgen
                 // semantics.
-                if let ValueDefinition::Instruction(
+                if let Some(ValueDefinition::Instruction(
                     _,
                     _,
                     OpCode::WriteWitness {
@@ -441,7 +447,7 @@ impl Simplifier {
                         value: hint,
                         pinned: _,
                     },
-                ) = defs.get_definition(*value)
+                )) = defs.get_definition(*value)
                 {
                     return Some(Rewrite::Alias {
                         result: *result,
@@ -458,14 +464,14 @@ impl Simplifier {
                 // WriteWitness(ValueOf(x)) → x. The new slot's hint is x's
                 // value, so honest prover fills both identically; merging is
                 // equivalent to the always-true constraint new == x.
-                if let ValueDefinition::Instruction(
+                if let Some(ValueDefinition::Instruction(
                     _,
                     _,
                     OpCode::ValueOf {
                         result: _,
                         value: inner,
                     },
-                ) = defs.get_definition(*value)
+                )) = defs.get_definition(*value)
                 {
                     return Some(Rewrite::Alias {
                         result: *result,
@@ -483,23 +489,24 @@ fn materialize_const(
     types: &FunctionTypeInfo,
     result: ValueId,
     fb: &mut HLFunctionBuilder<'_>,
-    pure_value: impl Fn(&TypeExpr) -> Option<ConstValue>,
+    pure_value: impl Fn(&TypeExpr) -> Option<Constant>,
 ) -> Option<Rewrite> {
     let ty = types.get_value_type(result).clone();
     let inner = ty.strip_witness();
     let value = pure_value(&inner.expr)?;
     if ty.is_witness_of() {
-        let tmp = fb.fresh_value();
-        Some(Rewrite::Replace(vec![
-            OpCode::Const { result: tmp, value },
-            OpCode::Cast {
-                result,
-                value: tmp,
-                target: CastTarget::WitnessOf,
-            },
-        ]))
+        let tmp = fb.ssa.add_const(value);
+        Some(Rewrite::Replace(vec![OpCode::Cast {
+            result,
+            value: tmp,
+            target: CastTarget::WitnessOf,
+        }]))
     } else {
-        Some(Rewrite::Replace(vec![OpCode::Const { result, value }]))
+        let canon = fb.ssa.add_const(value);
+        Some(Rewrite::Alias {
+            result,
+            target: canon,
+        })
     }
 }
 
@@ -509,9 +516,9 @@ fn materialize_zero(
     fb: &mut HLFunctionBuilder<'_>,
 ) -> Option<Rewrite> {
     materialize_const(types, result, fb, |t| match t {
-        TypeExpr::U(s) => Some(ConstValue::U(*s, 0)),
-        TypeExpr::I(s) => Some(ConstValue::I(*s, 0)),
-        TypeExpr::Field => Some(ConstValue::Field(ark_bn254::Fr::zero())),
+        TypeExpr::U(s) => Some(Constant::U(*s, 0)),
+        TypeExpr::I(s) => Some(Constant::I(*s, 0)),
+        TypeExpr::Field => Some(Constant::Field(ark_bn254::Fr::zero())),
         _ => None,
     })
 }
@@ -522,48 +529,33 @@ fn materialize_one(
     fb: &mut HLFunctionBuilder<'_>,
 ) -> Option<Rewrite> {
     materialize_const(types, result, fb, |t| match t {
-        TypeExpr::U(s) => Some(ConstValue::U(*s, 1)),
-        TypeExpr::I(s) => Some(ConstValue::I(*s, 1)),
-        TypeExpr::Field => Some(ConstValue::Field(ark_bn254::Fr::one())),
+        TypeExpr::U(s) => Some(Constant::U(*s, 1)),
+        TypeExpr::I(s) => Some(Constant::I(*s, 1)),
+        TypeExpr::Field => Some(Constant::Field(ark_bn254::Fr::one())),
         _ => None,
     })
 }
 
-fn is_zero(defs: &FunctionValueDefinitions, v: ValueId) -> bool {
-    let def = defs.get_definition(v);
-    if let ValueDefinition::Instruction(_, _, OpCode::Const { value, .. }) = def {
-        match value {
-            ConstValue::U(_, 0) | ConstValue::I(_, 0) => true,
-            ConstValue::Field(f) => f.is_zero(),
-            _ => false,
-        }
-    } else {
-        false
+fn is_zero(ssa: &HLSSA, v: ValueId) -> bool {
+    match ssa.get_const(v).as_deref() {
+        Some(Constant::U(_, 0) | Constant::I(_, 0)) => true,
+        Some(Constant::Field(f)) => f.is_zero(),
+        _ => false,
     }
 }
 
-fn is_one(defs: &FunctionValueDefinitions, v: ValueId) -> bool {
-    let def = defs.get_definition(v);
-    if let ValueDefinition::Instruction(_, _, OpCode::Const { value, .. }) = def {
-        match value {
-            ConstValue::U(_, 1) | ConstValue::I(_, 1) => true,
-            ConstValue::Field(f) => f.is_one(),
-            _ => false,
-        }
-    } else {
-        false
+fn is_one(ssa: &HLSSA, v: ValueId) -> bool {
+    match ssa.get_const(v).as_deref() {
+        Some(Constant::U(_, 1) | Constant::I(_, 1)) => true,
+        Some(Constant::Field(f)) => f.is_one(),
+        _ => false,
     }
 }
 
-fn is_all_ones(defs: &FunctionValueDefinitions, v: ValueId) -> bool {
-    let def = defs.get_definition(v);
-    if let ValueDefinition::Instruction(_, _, OpCode::Const { value, .. }) = def {
-        match value {
-            ConstValue::U(bits, value) | ConstValue::I(bits, value) => *value == bit_mask(*bits),
-            ConstValue::Field(_) | ConstValue::FnPtr(_) => false,
-        }
-    } else {
-        false
+fn is_all_ones(ssa: &HLSSA, v: ValueId) -> bool {
+    match ssa.get_const(v).as_deref() {
+        Some(Constant::U(bits, value) | Constant::I(bits, value)) => *value == bit_mask(*bits),
+        _ => false,
     }
 }
 
@@ -577,14 +569,9 @@ fn bit_mask(bits: usize) -> u128 {
     }
 }
 
-fn const_as_usize(defs: &FunctionValueDefinitions, v: ValueId) -> Option<usize> {
-    let def = defs.get_definition(v);
-    if let ValueDefinition::Instruction(_, _, OpCode::Const { value, .. }) = def {
-        match value {
-            ConstValue::U(_, value) | ConstValue::I(_, value) => (*value).try_into().ok(),
-            ConstValue::Field(_) | ConstValue::FnPtr(_) => None,
-        }
-    } else {
-        None
+fn const_as_usize(ssa: &HLSSA, v: ValueId) -> Option<usize> {
+    match ssa.get_const(v).as_deref() {
+        Some(Constant::U(_, value) | Constant::I(_, value)) => (*value).try_into().ok(),
+        _ => None,
     }
 }

--- a/compiler/src/compiler/passes/specializer.rs
+++ b/compiler/src/compiler/passes/specializer.rs
@@ -863,9 +863,6 @@ impl Specializer {
 
         // Take the empty body out so the state can mutate it while the symbolic executor
         // holds a shared `&HLSSA`.
-        //
-        // Safe because it either a new function exists under the same ID that respects the calling
-        // contract, or the body is replaced.
         let mut body = ssa.take_function(candidate_id);
         for ret in &original_return_types {
             body.add_return_type(ret.clone());

--- a/compiler/src/compiler/passes/specializer.rs
+++ b/compiler/src/compiler/passes/specializer.rs
@@ -5,7 +5,7 @@
 //! in defunctionalization wherever needed. In some cases, we can call the specialized version
 //! directly instead.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use ark_ff::{AdditiveGroup, BigInteger, PrimeField};
 use tracing::{info, instrument};
@@ -19,10 +19,10 @@ use crate::compiler::{
     },
     pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
     ssa::{
-        FunctionId, ValueId,
+        BlockId, FunctionId, ValueId,
         hlssa::{
-            BinaryArithOpKind, CastTarget, CmpKind, Endianness, HLFunction, HLSSA, OpCode, Radix,
-            RefCountOp, SequenceTargetType, Type, TypeExpr,
+            BinaryArithOpKind, CastTarget, CmpKind, Constant, Endianness, HLFunction, HLSSA,
+            OpCode, Radix, RefCountOp, SequenceTargetType, Type, TypeExpr,
             builder::{HLEmitter, HLFunctionBuilder},
         },
     },
@@ -56,37 +56,36 @@ enum ConstVal {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 struct Val(ValueId);
 
-struct SpecializationState {
-    function: HLFunction,
-    /// Transient counter for `ValueId`s allocated during specialization. Starts at the SSA's
-    /// `value_num_bound` and is reconciled back into the SSA only if specialization is accepted.
-    transient_counter: u64,
+struct SpecializationState<'a> {
+    /// Shared reference to the SSA, used to mint fresh `ValueId`s via `fresh_value(&self)` while
+    /// the symbolic executor holds its own shared `&HLSSA` borrow.
+    ssa: &'a HLSSA,
+
+    /// The candidate function body, mutated in place during symbolic execution. The candidate's
+    /// `FunctionId` is owned by the caller. This is just the body slot, taken out of the SSA so it
+    /// can be modified while the executor holds the SSA shared.
+    body: HLFunction,
+
+    /// Constant values created during specialization, usually by constant folding.
     const_vals: HashMap<ValueId, ConstVal>,
 }
 
-impl SpecializationState {
-    fn add_entry_parameter(&mut self, ty: Type) -> ValueId {
-        let id = self.fresh_value();
-        let entry = self.function.get_entry_id();
-        self.function.get_block_mut(entry).push_parameter(id, ty);
-        id
-    }
-}
-
-impl HLEmitter for SpecializationState {
+impl HLEmitter for SpecializationState<'_> {
     fn fresh_value(&mut self) -> ValueId {
-        let id = ValueId(self.transient_counter);
-        self.transient_counter += 1;
-        id
+        self.ssa.fresh_value()
     }
 
     fn emit(&mut self, op: OpCode) {
-        let entry = self.function.get_entry_id();
-        self.function.get_block_mut(entry).push_instruction(op);
+        let entry = self.body.get_entry_id();
+        self.body.get_block_mut(entry).push_instruction(op);
+    }
+
+    fn emit_constant(&mut self, value: Constant) -> ValueId {
+        self.ssa.add_const(value)
     }
 }
 
-impl symbolic_executor::Value<SpecializationState> for Val {
+impl symbolic_executor::Value<SpecializationState<'_>> for Val {
     fn ult(&self, b: &Self, ctx: &mut SpecializationState) -> Self {
         let l_const = ctx.const_vals.get(&self.0).cloned();
         let r_const = ctx.const_vals.get(&b.0).cloned();
@@ -98,7 +97,7 @@ impl symbolic_executor::Value<SpecializationState> for Val {
                 Self(res)
             }
             (None, _) | (_, None) => {
-                let res = ctx.cmp(self.0, b.0, crate::compiler::ssa::hlssa::CmpKind::Lt);
+                let res = ctx.cmp(self.0, b.0, CmpKind::Lt);
                 Self(res)
             }
             _ => todo!(),
@@ -116,7 +115,7 @@ impl symbolic_executor::Value<SpecializationState> for Val {
                 Self(res)
             }
             (None, _) | (_, None) => {
-                let res = ctx.cmp(self.0, b.0, crate::compiler::ssa::hlssa::CmpKind::Lt);
+                let res = ctx.cmp(self.0, b.0, CmpKind::Lt);
                 Self(res)
             }
             _ => todo!(),
@@ -134,7 +133,7 @@ impl symbolic_executor::Value<SpecializationState> for Val {
                 Self(res)
             }
             (None, _) | (_, None) => {
-                let res = ctx.cmp(self.0, b.0, crate::compiler::ssa::hlssa::CmpKind::Eq);
+                let res = ctx.cmp(self.0, b.0, CmpKind::Eq);
                 Self(res)
             }
             _ => todo!(),
@@ -144,7 +143,7 @@ impl symbolic_executor::Value<SpecializationState> for Val {
     fn arith(
         &self,
         b: &Self,
-        binary_arith_op_kind: crate::compiler::ssa::hlssa::BinaryArithOpKind,
+        binary_arith_op_kind: BinaryArithOpKind,
         _out_type: &Type,
         ctx: &mut SpecializationState,
     ) -> Self {
@@ -433,7 +432,7 @@ impl symbolic_executor::Value<SpecializationState> for Val {
 
     fn cast(
         &self,
-        cast_target: &crate::compiler::ssa::hlssa::CastTarget,
+        cast_target: &CastTarget,
         _out_type: &Type,
         ctx: &mut SpecializationState,
     ) -> Self {
@@ -699,7 +698,7 @@ impl symbolic_executor::Value<SpecializationState> for Val {
     }
 }
 
-impl symbolic_executor::Context<Val> for SpecializationState {
+impl symbolic_executor::Context<Val> for SpecializationState<'_> {
     fn on_call(
         &mut self,
         func: FunctionId,
@@ -719,19 +718,13 @@ impl symbolic_executor::Context<Val> for SpecializationState {
     }
 
     fn on_return(&mut self, returns: &mut [Val], _return_types: &[Type]) {
-        self.function.terminate_block_with_return(
-            self.function.get_entry_id(),
+        self.body.terminate_block_with_return(
+            self.body.get_entry_id(),
             returns.iter().map(|v| v.0).collect(),
         );
     }
 
-    fn on_jmp(
-        &mut self,
-        _target: crate::compiler::ssa::BlockId,
-        _params: &mut [Val],
-        _param_types: &[&Type],
-    ) {
-    }
+    fn on_jmp(&mut self, _target: BlockId, _params: &mut [Val], _param_types: &[&Type]) {}
 
     fn todo(&mut self, payload: &str, _result_types: &[Type]) -> Vec<Val> {
         todo!("Todo opcode: {}", payload);
@@ -751,12 +744,13 @@ impl symbolic_executor::Context<Val> for SpecializationState {
 
     fn on_guard(
         &mut self,
-        inner: &crate::compiler::ssa::hlssa::OpCode,
+        inner: &OpCode,
         condition: &Val,
         inputs: Vec<&Val>,
         _result_types: Vec<&Type>,
     ) -> Vec<Val> {
         use crate::compiler::ssa::Instruction;
+
         // Build a mapping from old ValueIds to new ValueIds
         let orig_inputs: Vec<_> = inner.get_inputs().cloned().collect();
         let orig_results: Vec<_> = inner.get_results().cloned().collect();
@@ -796,11 +790,27 @@ impl Pass for Specializer {
 
     fn run(&self, ssa: &mut HLSSA, store: &AnalysisStore) {
         let summary = store.get::<Summary>();
+        let mut speculative_ids: HashSet<FunctionId> = HashSet::new();
+        let mut accepted_ids: HashSet<FunctionId> = HashSet::new();
+
         for (sig, summary) in summary.functions.iter() {
             if summary.specialization_total_savings > 0 {
-                self.try_spec(ssa, store.get::<TypeInfo>(), summary, sig.clone());
+                self.try_spec(
+                    ssa,
+                    store.get::<TypeInfo>(),
+                    summary,
+                    sig.clone(),
+                    &mut speculative_ids,
+                    &mut accepted_ids,
+                );
             }
         }
+
+        // Drop any speculative candidate (and its `#unspecialized` clone, if it had one)
+        // that wasn't accepted. Constants the rejected candidates left behind become
+        // unreferenced and are cleaned up by the DCE pass that runs immediately after the
+        // specializer.
+        ssa.retain_functions(|id, _| !speculative_ids.contains(&id) || accepted_ids.contains(&id));
     }
 }
 
@@ -818,6 +828,8 @@ impl Specializer {
         type_info: &TypeInfo,
         summary: &SpecializationSummary,
         signature: FunctionSignature,
+        speculative_ids: &mut HashSet<FunctionId>,
+        accepted_ids: &mut HashSet<FunctionId>,
     ) {
         let name = signature.pretty_print(ssa, true);
 
@@ -831,18 +843,40 @@ impl Specializer {
             return;
         }
 
-        let original_fn = ssa.get_function(signature.get_fun_id());
+        // Snapshot what we need from the original before any mutation: param types, return
+        // types, and its name (for the #specialized / #unspecialized derived names).
+        let original_param_types: Vec<Type>;
+        let original_return_types: Vec<Type>;
+        let original_name: String;
+        {
+            let original_fn = ssa.get_function(signature.get_fun_id());
+            original_param_types = original_fn.get_param_types();
+            original_return_types = original_fn.get_returns().to_vec();
+            original_name = original_fn.get_name().to_string();
+        }
 
-        let mut state = SpecializationState {
-            function: HLFunction::empty(name),
-            transient_counter: ssa.value_num_bound() as u64,
-            const_vals: HashMap::new(),
-        };
+        // Mint the candidate's FunctionId up-front. The empty body lives in the SSA at this
+        // id until we put the filled-in one back. Track it as speculative so the end-of-pass
+        // cleanup drops it if the specialization is ultimately rejected.
+        let candidate_id = ssa.add_function(name.clone());
+        speculative_ids.insert(candidate_id);
 
+        // Take the empty body out so the state can mutate it while the symbolic executor
+        // holds a shared `&HLSSA`.
+        //
+        // Safe because it either a new function exists under the same ID that respects the calling
+        // contract, or the body is replaced.
+        let mut body = ssa.take_function(candidate_id);
+        for ret in &original_return_types {
+            body.add_return_type(ret.clone());
+        }
+
+        // Build call params and the initial `const_vals` map. Routes through `add_const`
+        // (still `&mut ssa` here) so the constants for `Field`/`U`/`I` signature params are
+        // interned eagerly.
         let mut call_params: Vec<Val> = vec![];
-
-        for (param, sig) in original_fn
-            .get_param_types()
+        let mut const_vals: HashMap<ValueId, ConstVal> = HashMap::new();
+        for (param, sig) in original_param_types
             .iter()
             .zip(signature.get_params().iter())
         {
@@ -858,26 +892,24 @@ impl Specializer {
                 ValueSignature::Unknown(_)
                 | ValueSignature::UnknownSlice
                 | ValueSignature::WitnessOf(_) => {
-                    call_params.push(Val(state.add_entry_parameter(param.clone())));
+                    let id = ssa.fresh_value();
+                    body.get_entry_mut().push_parameter(id, param.clone());
+                    call_params.push(Val(id));
                 }
                 ValueSignature::Field(f) => {
-                    let val = state.field_const(*f);
+                    let val = ssa.add_const(Constant::Field(*f));
                     call_params.push(Val(val));
-                    state.const_vals.insert(val, ConstVal::Field(*f));
+                    const_vals.insert(val, ConstVal::Field(*f));
                 }
                 ValueSignature::U { bits_size, value } => {
-                    let val = state.u_const(*bits_size, *value);
+                    let val = ssa.add_const(Constant::U(*bits_size, *value));
                     call_params.push(Val(val));
-                    state
-                        .const_vals
-                        .insert(val, ConstVal::U(*bits_size, *value));
+                    const_vals.insert(val, ConstVal::U(*bits_size, *value));
                 }
                 ValueSignature::I { bits_size, value } => {
-                    let val = state.i_const(*bits_size, *value);
+                    let val = ssa.add_const(Constant::I(*bits_size, *value));
                     call_params.push(Val(val));
-                    state
-                        .const_vals
-                        .insert(val, ConstVal::I(*bits_size, *value));
+                    const_vals.insert(val, ConstVal::I(*bits_size, *value));
                 }
                 ValueSignature::Tuple(_) => {
                     info!("TODO: Aborting specialization on a tuple value");
@@ -886,45 +918,55 @@ impl Specializer {
             }
         }
 
-        for ret in original_fn.get_returns() {
-            state.function.add_return_type(ret.clone());
-        }
+        let body = {
+            let mut state = SpecializationState {
+                ssa: &*ssa,
+                body,
+                const_vals,
+            };
 
-        SymbolicExecutor::new().run(
-            ssa,
-            type_info,
-            signature.get_fun_id(),
-            call_params,
-            &mut state,
-        );
+            SymbolicExecutor::new().run(
+                &*ssa,
+                type_info,
+                signature.get_fun_id(),
+                call_params,
+                &mut state,
+            );
 
-        let code_bloat = state.function.code_size();
+            state.body
+        };
+
+        let code_bloat = body.code_size();
         let savings_to_code_ratio = summary.specialization_total_savings as f64 / code_bloat as f64;
+
+        // Put the body back unconditionally. On rejection it stays at `candidate_id` only
+        // until the end-of-pass `retain_functions` call drops it.
+        ssa.put_function(candidate_id, body);
 
         if savings_to_code_ratio > self.savings_to_code_ratio {
             info!(message = %"Specialization accepted", code_bloat = code_bloat,  savings_to_code_ratio = savings_to_code_ratio, threshold_ratio = self.savings_to_code_ratio);
-            ssa.reserve_values_up_to(state.transient_counter);
-            let original_fn = ssa.take_function(signature.get_fun_id());
-            let new_fn_id = ssa.add_function("".to_string());
-            let new_original_id = ssa.add_function("".to_string()); // Temporary
 
-            let original_params = original_fn.get_param_types();
-            let original_returns = original_fn.get_returns().to_vec();
+            // Clone the original via the SSA helper. The clone has fresh `ValueId`s and
+            // becomes the dispatcher's fallback target; the original's slot is then
+            // overwritten with the dispatcher itself.
+            let unspecialized_id = ssa.duplicate_function(signature.get_fun_id());
+            ssa.get_function_mut(unspecialized_id)
+                .set_name(format!("{}#unspecialized", original_name));
 
             let dispatcher = self.build_dispatcher_for(
                 ssa,
-                original_params,
-                original_returns,
+                original_param_types,
+                original_return_types,
                 &signature,
-                original_fn.get_name().to_string() + "#specialized",
-                new_fn_id,
-                new_original_id,
+                format!("{}#specialized", original_name),
+                candidate_id,
+                unspecialized_id,
             );
-            ssa.put_function(new_original_id, original_fn);
-            ssa.put_function(signature.get_fun_id(), dispatcher);
-            ssa.put_function(new_fn_id, state.function);
+            *ssa.get_function_mut(signature.get_fun_id()) = dispatcher;
+
+            accepted_ids.insert(candidate_id);
+            accepted_ids.insert(unspecialized_id);
         } else {
-            // TODO: run some passes to see if it decreases
             info!(message = %"Specialization rejected", code_bloat = code_bloat,  savings_to_code_ratio = savings_to_code_ratio, threshold_ratio = self.savings_to_code_ratio);
         }
     }

--- a/compiler/src/compiler/passes/strip_witness_of.rs
+++ b/compiler/src/compiler/passes/strip_witness_of.rs
@@ -142,7 +142,6 @@ impl StripWitnessOf {
             | OpCode::TupleProj { .. }
             | OpCode::InitGlobal { .. }
             | OpCode::DropGlobal { .. }
-            | OpCode::Const { .. }
             | OpCode::Spread { .. }
             | OpCode::Unspread { .. } => {}
             OpCode::Guard { .. } => {

--- a/compiler/src/compiler/passes/witness_lowering.rs
+++ b/compiler/src/compiler/passes/witness_lowering.rs
@@ -434,7 +434,6 @@ impl WitnessLowering {
                         | OpCode::TupleProj { .. }
                         | OpCode::Todo { .. }
                         | OpCode::ValueOf { .. }
-                        | OpCode::Const { .. }
                         | OpCode::Spread { .. }
                         | OpCode::Unspread { .. } => {
                             emitter.emit(instruction);

--- a/compiler/src/compiler/passes/witness_write_to_fresh.rs
+++ b/compiler/src/compiler/passes/witness_write_to_fresh.rs
@@ -93,7 +93,6 @@ impl WitnessWriteToFresh {
                         | OpCode::TupleProj { .. }
                         | OpCode::MkTuple { .. }
                         | OpCode::ValueOf { .. }
-                        | OpCode::Const { .. }
                         | OpCode::Spread { .. }
                         | OpCode::Unspread { .. }
                         | OpCode::Guard { .. } => instruction.clone(),

--- a/compiler/src/compiler/ssa/builder.rs
+++ b/compiler/src/compiler/ssa/builder.rs
@@ -59,6 +59,11 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash>
         self.ssa.fresh_value()
     }
 
+    /// Intern a constant into the SSA and return its `ValueId`.
+    pub fn emit_const(&mut self, value: C) -> ValueId {
+        self.ssa.add_const(value)
+    }
+
     /// Escape hatch for direct function access.
     pub fn function(&mut self) -> &mut Function<Op, Ty> {
         self.function

--- a/compiler/src/compiler/ssa/builder.rs
+++ b/compiler/src/compiler/ssa/builder.rs
@@ -345,8 +345,6 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSABuilder<
         fid: FunctionId,
         body: impl FnOnce(&mut FunctionBuilder<'_, Op, Ty, C>) -> R,
     ) -> R {
-        // Safe as we are guaranteed to replace the function under the same ID, so no references are
-        // left dangling.
         let mut function = self.ssa.take_function(fid);
         let result = {
             let mut fb = FunctionBuilder::new(&mut function, self.ssa);

--- a/compiler/src/compiler/ssa/builder.rs
+++ b/compiler/src/compiler/ssa/builder.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, hash::Hash};
 
 use crate::compiler::ssa::{
     Block, BlockId, Function, FunctionId, Instruction, SSA, SSAType, Terminator, ValueId,
@@ -8,16 +8,16 @@ use crate::compiler::ssa::{
 // InstrBuilder — lightweight instruction emitter
 // ---------------------------------------------------------------------------
 
-pub struct InstrBuilder<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> {
+pub struct InstrBuilder<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> {
     pub function: &'a mut Function<Op, Ty>,
-    pub ssa: &'a mut SSA<Op, Ty, Cn>,
+    pub ssa: &'a mut SSA<Op, Ty, C>,
     pub instructions: &'a mut Vec<Op>,
 }
 
-impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> InstrBuilder<'a, Op, Ty, Cn> {
+impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> InstrBuilder<'a, Op, Ty, C> {
     pub fn new(
         function: &'a mut Function<Op, Ty>,
-        ssa: &'a mut SSA<Op, Ty, Cn>,
+        ssa: &'a mut SSA<Op, Ty, C>,
         instructions: &'a mut Vec<Op>,
     ) -> Self {
         Self {
@@ -37,17 +37,19 @@ impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> InstrBuilder<'a, Op, T
 // FunctionBuilder — function-level coordinator (no current_block)
 // ---------------------------------------------------------------------------
 
-pub struct FunctionBuilder<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> {
+pub struct FunctionBuilder<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> {
     pub function: &'a mut Function<Op, Ty>,
-    pub ssa: &'a mut SSA<Op, Ty, Cn>,
+    pub ssa: &'a mut SSA<Op, Ty, C>,
 }
 
-impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> FunctionBuilder<'a, Op, Ty, Cn> {
-    pub fn new(function: &'a mut Function<Op, Ty>, ssa: &'a mut SSA<Op, Ty, Cn>) -> Self {
+impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash>
+    FunctionBuilder<'a, Op, Ty, C>
+{
+    pub fn new(function: &'a mut Function<Op, Ty>, ssa: &'a mut SSA<Op, Ty, C>) -> Self {
         Self { function, ssa }
     }
 
-    pub fn add_block(&mut self, f: impl FnOnce(&mut BlockEmitter<'_, Op, Ty, Cn>)) -> BlockId {
+    pub fn add_block(&mut self, f: impl FnOnce(&mut BlockEmitter<'_, Op, Ty, C>)) -> BlockId {
         let (id, mut emitter) = BlockEmitter::from_new_block(self.function, self.ssa);
         f(&mut emitter);
         id
@@ -63,12 +65,12 @@ impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> FunctionBuilder<'a, Op
     }
 
     /// Escape hatch for direct SSA access.
-    pub fn ssa(&mut self) -> &mut SSA<Op, Ty, Cn> {
+    pub fn ssa(&mut self) -> &mut SSA<Op, Ty, C> {
         self.ssa
     }
 
     /// Get a BlockEmitter for a specific block.
-    pub fn block(&mut self, id: BlockId) -> BlockEmitter<'_, Op, Ty, Cn> {
+    pub fn block(&mut self, id: BlockId) -> BlockEmitter<'_, Op, Ty, C> {
         BlockEmitter::new(self.function, self.ssa, id)
     }
 }
@@ -80,25 +82,27 @@ impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> FunctionBuilder<'a, Op
 /// Holds the current block *taken out* of the function, so `emit()` is a
 /// direct `Vec::push` with no HashMap lookup.  The block is put back into the
 /// function on `seal_and_switch` or `Drop`.
-pub struct BlockEmitter<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> {
+pub struct BlockEmitter<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> {
     pub function: &'a mut Function<Op, Ty>,
-    pub ssa: &'a mut SSA<Op, Ty, Cn>,
+    pub ssa: &'a mut SSA<Op, Ty, C>,
     pub(crate) block_id: BlockId,
     pub(crate) block: Block<Op, Ty>,
 }
 
-impl<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> Drop for BlockEmitter<'_, Op, Ty, Cn> {
+impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> Drop
+    for BlockEmitter<'_, Op, Ty, C>
+{
     fn drop(&mut self) {
         let block = std::mem::replace(&mut self.block, Block::empty());
         self.function.put_block(self.block_id, block);
     }
 }
 
-impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> BlockEmitter<'a, Op, Ty, Cn> {
+impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEmitter<'a, Op, Ty, C> {
     /// Create an emitter for an existing block (takes it out of the function).
     pub fn new(
         function: &'a mut Function<Op, Ty>,
-        ssa: &'a mut SSA<Op, Ty, Cn>,
+        ssa: &'a mut SSA<Op, Ty, C>,
         block_id: BlockId,
     ) -> Self {
         let block = function.take_block(block_id);
@@ -114,7 +118,7 @@ impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> BlockEmitter<'a, Op, T
     /// The block is inserted into the function on drop.
     pub(crate) fn from_new_block(
         function: &'a mut Function<Op, Ty>,
-        ssa: &'a mut SSA<Op, Ty, Cn>,
+        ssa: &'a mut SSA<Op, Ty, C>,
     ) -> (BlockId, Self) {
         let (block_id, block) = function.next_virtual_block();
         (
@@ -188,7 +192,7 @@ impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> BlockEmitter<'a, Op, T
     pub fn build_loop(
         &mut self,
         params: Vec<(ValueId, Ty)>,
-        header: impl FnOnce(&mut InstrBuilder<'_, Op, Ty, Cn>, &[ValueId]) -> ValueId,
+        header: impl FnOnce(&mut InstrBuilder<'_, Op, Ty, C>, &[ValueId]) -> ValueId,
         body: impl FnOnce(&mut Self, &[ValueId]) -> Vec<ValueId>,
     ) -> Vec<ValueId> {
         // Create blocks
@@ -304,12 +308,12 @@ impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> BlockEmitter<'a, Op, T
 //              function builders via closure-based scopes.
 // ---------------------------------------------------------------------------
 
-pub struct SSABuilder<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> {
-    ssa: &'a mut SSA<Op, Ty, Cn>,
+pub struct SSABuilder<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> {
+    ssa: &'a mut SSA<Op, Ty, C>,
 }
 
-impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSABuilder<'a, Op, Ty, Cn> {
-    pub fn new(ssa: &'a mut SSA<Op, Ty, Cn>) -> Self {
+impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSABuilder<'a, Op, Ty, C> {
+    pub fn new(ssa: &'a mut SSA<Op, Ty, C>) -> Self {
         Self { ssa }
     }
 
@@ -320,7 +324,7 @@ impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSABuilder<'a, Op, Ty,
     pub fn add_function<R>(
         &mut self,
         name: String,
-        body: impl FnOnce(&mut FunctionBuilder<'_, Op, Ty, Cn>) -> R,
+        body: impl FnOnce(&mut FunctionBuilder<'_, Op, Ty, C>) -> R,
     ) -> (FunctionId, R) {
         let mut function = Function::<Op, Ty>::empty(name);
         let result = {
@@ -339,8 +343,10 @@ impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSABuilder<'a, Op, Ty,
     pub fn modify_function<R>(
         &mut self,
         fid: FunctionId,
-        body: impl FnOnce(&mut FunctionBuilder<'_, Op, Ty, Cn>) -> R,
+        body: impl FnOnce(&mut FunctionBuilder<'_, Op, Ty, C>) -> R,
     ) -> R {
+        // Safe as we are guaranteed to replace the function under the same ID, so no references are
+        // left dangling.
         let mut function = self.ssa.take_function(fid);
         let result = {
             let mut fb = FunctionBuilder::new(&mut function, self.ssa);
@@ -362,21 +368,21 @@ impl<'a, Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSABuilder<'a, Op, Ty,
     }
 
     /// Escape hatch for direct SSA access.
-    pub fn ssa(&mut self) -> &mut SSA<Op, Ty, Cn> {
+    pub fn ssa(&mut self) -> &mut SSA<Op, Ty, C> {
         self.ssa
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::compiler::ssa::hlssa::HLSSA;
     use crate::compiler::ssa::hlssa::builder::HLSSABuilder;
-    use crate::compiler::ssa::hlssa::{Constants, HLSSA};
 
     /// `ValueId`s issued inside two different functions must not collide:
     /// the counter lives on the SSA, not the function.
     #[test]
     fn global_value_ids_are_unique_across_functions() {
-        let mut ssa = HLSSA::with_main("main".to_string(), Constants::default());
+        let mut ssa = HLSSA::with_main("main".to_string());
         let mut sb = HLSSABuilder::new(&mut ssa);
         let main_id = sb.ssa().get_main_id();
         let other_id = sb.ssa().add_function("other".to_string());
@@ -391,13 +397,13 @@ mod tests {
     /// rebuild continue from where the original counter left off.
     #[test]
     fn prepare_rebuild_preserves_value_counter() {
-        let mut ssa = HLSSA::with_main("main".to_string(), Constants::default());
+        let ssa = HLSSA::with_main("main".to_string());
         let _v0 = ssa.fresh_value();
         let _v1 = ssa.fresh_value();
         let _v2 = ssa.fresh_value();
         let bound_before = ssa.value_num_bound();
 
-        let (mut rebuilt, _functions, _globals) = ssa.prepare_rebuild();
+        let (rebuilt, _functions, _globals) = ssa.prepare_rebuild();
         assert_eq!(rebuilt.value_num_bound(), bound_before);
 
         let next = rebuilt.fresh_value();
@@ -409,7 +415,7 @@ mod tests {
     /// all preserved.
     #[test]
     fn modify_function_noop_roundtrip() {
-        let mut ssa = HLSSA::with_main("main".to_string(), Constants::default());
+        let mut ssa = HLSSA::with_main("main".to_string());
         let main_id = ssa.get_main_id();
         let _ = ssa.add_function("other".to_string());
 

--- a/compiler/src/compiler/ssa/hlssa/builder.rs
+++ b/compiler/src/compiler/ssa/hlssa/builder.rs
@@ -2,8 +2,8 @@ use crate::compiler::ssa::{
     ValueId,
     builder::{BlockEmitter, FunctionBuilder, InstrBuilder, SSABuilder},
     hlssa::{
-        BinaryArithOpKind, CallTarget, CastTarget, CmpKind, ConstValue, Constants, Endianness,
-        LookupTarget, OpCode, Radix, RefCountOp, SequenceTargetType, SliceOpDir, Type, TypeExpr,
+        BinaryArithOpKind, CallTarget, CastTarget, CmpKind, Constant, Endianness, LookupTarget,
+        OpCode, Radix, RefCountOp, SequenceTargetType, SliceOpDir, Type, TypeExpr,
     },
 };
 
@@ -14,6 +14,10 @@ use crate::compiler::ssa::{
 pub trait HLEmitter {
     fn fresh_value(&mut self) -> ValueId;
     fn emit(&mut self, op: OpCode);
+
+    /// Intern a constant value into the SSA's constants side-table, returning the `ValueId` that
+    /// names it. Identical `Constant`s collapse to the same `ValueId`.
+    fn emit_constant(&mut self, value: Constant) -> ValueId;
 
     // -- Arithmetic --
 
@@ -233,30 +237,15 @@ pub trait HLEmitter {
     // -- Constants --
 
     fn field_const(&mut self, value: ark_bn254::Fr) -> ValueId {
-        let r = self.fresh_value();
-        self.emit(OpCode::Const {
-            result: r,
-            value: ConstValue::Field(value),
-        });
-        r
+        self.emit_constant(Constant::Field(value))
     }
 
     fn u_const(&mut self, bits: usize, value: u128) -> ValueId {
-        let r = self.fresh_value();
-        self.emit(OpCode::Const {
-            result: r,
-            value: ConstValue::U(bits, value),
-        });
-        r
+        self.emit_constant(Constant::U(bits, value))
     }
 
     fn i_const(&mut self, bits: usize, value: u128) -> ValueId {
-        let r = self.fresh_value();
-        self.emit(OpCode::Const {
-            result: r,
-            value: ConstValue::I(bits, value),
-        });
-        r
+        self.emit_constant(Constant::I(bits, value))
     }
 
     // -- Witness --
@@ -617,10 +606,10 @@ pub trait HLEmitter {
 // Type aliases
 // ---------------------------------------------------------------------------
 
-pub type HLInstrBuilder<'a> = InstrBuilder<'a, OpCode, Type, Constants>;
-pub type HLFunctionBuilder<'a> = FunctionBuilder<'a, OpCode, Type, Constants>;
-pub type HLBlockEmitter<'a> = BlockEmitter<'a, OpCode, Type, Constants>;
-pub type HLSSABuilder<'a> = SSABuilder<'a, OpCode, Type, Constants>;
+pub type HLInstrBuilder<'a> = InstrBuilder<'a, OpCode, Type, Constant>;
+pub type HLFunctionBuilder<'a> = FunctionBuilder<'a, OpCode, Type, Constant>;
+pub type HLBlockEmitter<'a> = BlockEmitter<'a, OpCode, Type, Constant>;
+pub type HLSSABuilder<'a> = SSABuilder<'a, OpCode, Type, Constant>;
 
 // ---------------------------------------------------------------------------
 // HLEmitter impls
@@ -634,6 +623,10 @@ impl HLEmitter for HLInstrBuilder<'_> {
     fn emit(&mut self, op: OpCode) {
         self.instructions.push(op);
     }
+
+    fn emit_constant(&mut self, value: Constant) -> ValueId {
+        self.ssa.add_const(value)
+    }
 }
 
 impl HLEmitter for HLBlockEmitter<'_> {
@@ -643,6 +636,10 @@ impl HLEmitter for HLBlockEmitter<'_> {
 
     fn emit(&mut self, op: OpCode) {
         self.block.push_instruction(op);
+    }
+
+    fn emit_constant(&mut self, value: Constant) -> ValueId {
+        self.ssa.add_const(value)
     }
 }
 

--- a/compiler/src/compiler/ssa/hlssa/mod.rs
+++ b/compiler/src/compiler/ssa/hlssa/mod.rs
@@ -6,27 +6,32 @@ pub mod type_system;
 use itertools::Itertools;
 use std::fmt::Display;
 
-use crate::compiler::ssa::{Block, Function, FunctionId, Instruction, SSA, ValueId};
+use crate::compiler::ssa::{
+    Block, Function, FunctionId, Instruction, SSA, SSAConstants, SSAConstantsSnapshot, ValueId,
+};
 pub use type_system::{Type, TypeExpr};
 
 // HLSSA
 // ================================================================================================
 
 /// The high-level SSA is designed for domain-level analysis without concretizing runtime details.
-pub type HLSSA = SSA<OpCode, Type, Constants>;
+pub type HLSSA = SSA<OpCode, Type, Constant>;
 
 impl HLSSA {
     pub fn new() -> Self {
-        Self::with_main("main".to_string(), ())
+        Self::with_main("main".to_string())
     }
 }
 
 // CONSTANT STORAGE
 // ================================================================================================
 
-/// Constant storage for the high-level SSA. Currently a placeholder while constants still live
-/// inline as `OpCode::Const` instructions.
-pub type Constants = ();
+/// Concrete constants side-table type for the high-level SSA.
+pub type HLSSAConstants = SSAConstants<Constant>;
+
+/// Owned, lock-free snapshot of the high-level SSA's constants, as handed out by
+/// [`SSA::const_snapshot`](crate::compiler::ssa::SSA::const_snapshot).
+pub type HLSSAConstantsSnapshot = SSAConstantsSnapshot<Constant>;
 
 // HLSSA OPCODES
 // ================================================================================================
@@ -226,10 +231,6 @@ pub enum OpCode {
     },
     DropGlobal {
         global: usize,
-    },
-    Const {
-        result: ValueId,
-        value: ConstValue,
     },
     Spread {
         result: ValueId,
@@ -707,43 +708,6 @@ impl Instruction for OpCode {
             OpCode::DropGlobal { global } => {
                 format!("drop_global({})", global)
             }
-            OpCode::Const { result, value } => match value {
-                ConstValue::U(size, val) => {
-                    format!(
-                        "v{}{} = u_const({}, {})",
-                        result.0,
-                        annotate_value(*result),
-                        size,
-                        val
-                    )
-                }
-                ConstValue::I(size, val) => {
-                    format!(
-                        "v{}{} = i_const({}, {})",
-                        result.0,
-                        annotate_value(*result),
-                        size,
-                        val
-                    )
-                }
-                ConstValue::Field(val) => {
-                    format!(
-                        "v{}{} = field_const({})",
-                        result.0,
-                        annotate_value(*result),
-                        val
-                    )
-                }
-                ConstValue::FnPtr(fn_id) => {
-                    format!(
-                        "v{}{} = fn_ptr_const({}@{})",
-                        result.0,
-                        annotate_value(*result),
-                        func_name(*fn_id),
-                        fn_id.0
-                    )
-                }
-            },
             OpCode::Spread {
                 result,
                 value,
@@ -791,8 +755,7 @@ impl Instruction for OpCode {
                 result: _,
                 result_type: _,
             }
-            | Self::NextDCoeff { result: _ }
-            | Self::Const { .. } => vec![].into_iter(),
+            | Self::NextDCoeff { result: _ } => vec![].into_iter(),
             Self::Cmp {
                 kind: _,
                 result: _,
@@ -998,7 +961,6 @@ impl Instruction for OpCode {
         match self {
             Self::Alloc { result: r, .. }
             | Self::FreshWitness { result: r, .. }
-            | Self::Const { result: r, .. }
             | Self::Cmp { result: r, .. }
             | Self::BinaryArithOp { result: r, .. }
             | Self::ArrayGet { result: r, .. }
@@ -1055,7 +1017,6 @@ impl Instruction for OpCode {
         match self {
             Self::Alloc { result: r, .. }
             | Self::FreshWitness { result: r, .. }
-            | Self::Const { result: r, .. }
             | Self::Cmp { result: r, .. }
             | Self::BinaryArithOp { result: r, .. }
             | Self::ArrayGet { result: r, .. }
@@ -1118,8 +1079,7 @@ impl Instruction for OpCode {
                 result: _,
                 result_type: _,
             }
-            | Self::NextDCoeff { result: _ }
-            | Self::Const { .. } => vec![].into_iter(),
+            | Self::NextDCoeff { result: _ } => vec![].into_iter(),
             Self::Cmp {
                 kind: _,
                 result: _,
@@ -1333,8 +1293,7 @@ impl Instruction for OpCode {
                 result: r,
                 result_type: _,
             }
-            | Self::NextDCoeff { result: r }
-            | Self::Const { result: r, .. } => vec![r].into_iter(),
+            | Self::NextDCoeff { result: r } => vec![r].into_iter(),
             Self::Cmp {
                 kind: _,
                 result: a,
@@ -1676,11 +1635,12 @@ pub enum SliceOpDir {
     Back,
 }
 
-// CONST VALUES
+// CONSTANTS
 // ================================================================================================
 
+/// The value type stored in the high-level SSA's constants side-table.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum ConstValue {
+pub enum Constant {
     U(usize, u128),
     I(usize, u128),
     Field(ark_bn254::Fr),

--- a/compiler/src/compiler/ssa/hlssa_to_llssa.rs
+++ b/compiler/src/compiler/ssa/hlssa_to_llssa.rs
@@ -21,8 +21,8 @@ use crate::compiler::analysis::{
 use super::{
     BlockId, FunctionId, Terminator, ValueId,
     hlssa::{
-        BinaryArithOpKind, CmpKind, DMatrix, HLFunction, HLSSA, Type as HLType,
-        TypeExpr as HLTypeExpr,
+        BinaryArithOpKind, CmpKind, Constant, DMatrix, HLFunction, HLSSA, HLSSAConstantsSnapshot,
+        Type as HLType, TypeExpr as HLTypeExpr,
     },
     llssa::{
         FieldArithOp, IntArithOp, IntCmpOp, LLFieldType, LLFunction, LLOp, LLSSA, LLStruct,
@@ -423,7 +423,7 @@ fn lower_inner(
 ) -> LLSSA {
     let main_id = hlssa.get_main_id();
     let main_name = hlssa.get_main().get_name().to_string();
-    let mut llssa = LLSSA::with_main(main_name, ());
+    let mut llssa = LLSSA::with_main(main_name);
     let mut fn_map: HashMap<FunctionId, FunctionId> = HashMap::new();
     let mut drop_fns: Vec<DropFnEntry> = Vec::new();
     let mut ad_fns = AdFunctions::new();
@@ -445,7 +445,9 @@ fn lower_inner(
         fn_map.insert(*fn_id, ll_fn_id);
     }
 
-    // Second pass: lower each function body
+    // Second pass: lower each function body. Snapshot the constants once; every function lowering
+    // reads from the same lock-free view.
+    let constants = hlssa.const_snapshot();
     for (fn_id, function) in hlssa.iter_functions() {
         let ll_fn_id = fn_map[fn_id];
         let fn_type_info = type_info.get_function(*fn_id);
@@ -461,9 +463,9 @@ fn lower_inner(
             &mut ad_fns,
             &mut lookup_fns,
             &hlssa_global_types,
+            &constants,
         );
 
-        let _old = llssa.take_function(ll_fn_id);
         llssa.put_function(ll_fn_id, ll_func);
     }
 
@@ -491,6 +493,80 @@ fn lower_inner(
 // Per-function lowering
 // =============================================================================
 
+/// Materialize every HLSSA constant `ValueId` referenced by `function` into the LLSSA function's
+/// entry block.
+///
+/// This is mostly a temporary hack to keep LLSSA working as before while adjusting constant
+/// handling in HLSSA. It will be removed.
+fn materialize_constants_llssa(
+    function: &HLFunction,
+    constants: &HLSSAConstantsSnapshot,
+    ll_func: &mut LLFunction,
+    llssa: &mut LLSSA,
+    ll_entry_id: crate::compiler::ssa::BlockId,
+    val_map: &mut HashMap<ValueId, ValueId>,
+) {
+    use crate::compiler::ssa::Instruction;
+    use crate::compiler::ssa::llssa::builder::LLEmitter;
+
+    let mut referenced: std::collections::HashSet<ValueId> = std::collections::HashSet::new();
+    for (_, block) in function.get_blocks() {
+        for instr in block.get_instructions() {
+            for vid in instr.get_inputs() {
+                if constants.contains_key(vid) {
+                    referenced.insert(*vid);
+                }
+            }
+        }
+        if let Some(term) = block.get_terminator() {
+            match term {
+                crate::compiler::ssa::Terminator::Jmp(_, args)
+                | crate::compiler::ssa::Terminator::Return(args) => {
+                    for vid in args {
+                        if constants.contains_key(vid) {
+                            referenced.insert(*vid);
+                        }
+                    }
+                }
+                crate::compiler::ssa::Terminator::JmpIf(cond, _, _) => {
+                    if constants.contains_key(cond) {
+                        referenced.insert(*cond);
+                    }
+                }
+            }
+        }
+    }
+
+    if referenced.is_empty() {
+        return;
+    }
+
+    let mut referenced: Vec<ValueId> = referenced.into_iter().collect();
+    referenced.sort_by_key(|v| v.0);
+
+    let mut emitter = LLBlockEmitter::new(ll_func, llssa, ll_entry_id);
+    for vid in referenced {
+        let ll_val = match constants.get(&vid).expect("vid is in constants").as_ref() {
+            Constant::U(bits, val) | Constant::I(bits, val) => {
+                emitter.int_const(*bits as u32, *val as u64)
+            }
+            Constant::Field(fr) => {
+                let field_struct = LLStruct::field_elem();
+                let limbs = fr.0.0;
+                let l0 = emitter.int_const(64, limbs[0]);
+                let l1 = emitter.int_const(64, limbs[1]);
+                let l2 = emitter.int_const(64, limbs[2]);
+                let l3 = emitter.int_const(64, limbs[3]);
+                emitter.mk_struct(field_struct, vec![l0, l1, l2, l3])
+            }
+            Constant::FnPtr(_) => {
+                panic!("FnPtr constants not supported in HLSSA->LLSSA lowering");
+            }
+        };
+        val_map.insert(vid, ll_val);
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn lower_function(
     function: &HLFunction,
@@ -502,6 +578,7 @@ fn lower_function(
     ad_fns: &mut AdFunctions,
     lookup_fns: &mut LookupFunctions,
     hlssa_global_types: &[HLType],
+    constants: &HLSSAConstantsSnapshot,
 ) -> LLFunction {
     let mut ll_func = LLFunction::empty(function.get_name().to_string());
     let mut val_map: HashMap<ValueId, ValueId> = HashMap::new();
@@ -538,6 +615,16 @@ fn lower_function(
             val_map.insert(*param_id, ll_param_id);
         }
     }
+
+    // TODO Temporary, until we can handle constants properly in LLSSA.
+    materialize_constants_llssa(
+        function,
+        constants,
+        &mut ll_func,
+        llssa,
+        ll_entry_id,
+        &mut val_map,
+    );
 
     // Lower instructions and terminators in domination order
     for block_id in cfg.get_domination_pre_order() {
@@ -609,7 +696,7 @@ fn lower_instruction(
     hlssa_global_types: &[HLType],
 ) {
     use crate::compiler::ssa::hlssa::{
-        CallTarget, CastTarget, ConstValue, OpCode, Radix, RefCountOp, SequenceTargetType,
+        CallTarget, CastTarget, OpCode, Radix, RefCountOp, SequenceTargetType,
     };
 
     match instruction {
@@ -760,26 +847,6 @@ fn lower_instruction(
             let ll_result = e.select(ll_cond, ll_if_t, ll_if_f);
             val_map.insert(*result, ll_result);
         }
-
-        OpCode::Const { result, value } => match value {
-            ConstValue::U(bits, val) | ConstValue::I(bits, val) => {
-                let ll_val = e.int_const(*bits as u32, *val as u64);
-                val_map.insert(*result, ll_val);
-            }
-            ConstValue::Field(fr) => {
-                let field_struct = LLStruct::field_elem();
-                let limbs = fr.0.0;
-                let l0 = e.int_const(64, limbs[0]);
-                let l1 = e.int_const(64, limbs[1]);
-                let l2 = e.int_const(64, limbs[2]);
-                let l3 = e.int_const(64, limbs[3]);
-                let mk = e.mk_struct(field_struct, vec![l0, l1, l2, l3]);
-                val_map.insert(*result, mk);
-            }
-            ConstValue::FnPtr(_) => {
-                panic!("FnPtr constants not supported in HLSSA->LLSSA lowering");
-            }
-        },
 
         // -- Array operations --
         OpCode::MkSeq {
@@ -2042,7 +2109,6 @@ fn generate_all_ad_functions(llssa: &mut LLSSA, ad_fns: &AdFunctions) {
         for matrix in [DMatrix::A, DMatrix::B, DMatrix::C] {
             let id = bumps.get(matrix);
             let func = generate_ad_bump_function(llssa, matrix);
-            let _old = llssa.take_function(id);
             llssa.put_function(id, func);
         }
     }
@@ -2053,7 +2119,6 @@ fn generate_all_ad_functions(llssa: &mut LLSSA, ad_fns: &AdFunctions) {
              This is a bug in AdFunctions — get_drop_fn must call ensure_bumps.",
         );
         let func = generate_ad_drop_function(llssa, bumps, drop_id);
-        let _old = llssa.take_function(drop_id);
         llssa.put_function(drop_id, func);
     }
 }
@@ -2306,7 +2371,6 @@ fn generate_all_drop_functions(llssa: &mut LLSSA, drop_fns: &[DropFnEntry]) {
             HLTypeExpr::WitnessOf(_) => continue,
             other => panic!("No drop function generator for type: {:?}", other),
         };
-        let _old = llssa.take_function(entry.fn_id);
         llssa.put_function(entry.fn_id, func);
     }
 }

--- a/compiler/src/compiler/ssa/llssa/mod.rs
+++ b/compiler/src/compiler/ssa/llssa/mod.rs
@@ -22,9 +22,11 @@ pub type LLSSA = SSA<LLOp, Type, Constants>;
 // CONSTANT STORAGE
 // ================================================================================================
 
-/// Constant storage for the low-level SSA. Currently a placeholder while constants still live
-/// inline as `LLOp::IntConst` / `LLOp::NullPtr` instructions; future work moves the constant data
-/// into this side-table for the LLVM backend.
+/// The value type stored in the low-level SSA's constants table.
+///
+/// Currently a unit placeholder while constants still live inline as `LLOp::IntConst` /
+/// `LLOp::NullPtr` instructions; future work is planned to move the constant data into this table
+/// for use by the LLVM backend and other LLSSA clients.
 pub type Constants = ();
 
 // LLSSA OPCODES
@@ -1154,7 +1156,7 @@ mod tests {
 
     #[test]
     fn build_simple_function() {
-        let mut ssa = LLSSA::with_main("test_main".to_string(), ());
+        let mut ssa = LLSSA::with_main("test_main".to_string());
         let main_id = ssa.get_main_id();
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
@@ -1175,7 +1177,7 @@ mod tests {
 
     #[test]
     fn build_struct_ops() {
-        let mut ssa = LLSSA::with_main("struct_test".to_string(), ());
+        let mut ssa = LLSSA::with_main("struct_test".to_string());
         let main_id = ssa.get_main_id();
 
         let field_elem = LLStruct::new(vec![
@@ -1205,7 +1207,7 @@ mod tests {
 
     #[test]
     fn build_memory_ops() {
-        let mut ssa = LLSSA::with_main("memory_test".to_string(), ());
+        let mut ssa = LLSSA::with_main("memory_test".to_string());
         let main_id = ssa.get_main_id();
 
         let rc_header = LLStruct::new(vec![LLFieldType::Int(64)]);
@@ -1249,7 +1251,7 @@ mod tests {
 
     #[test]
     fn build_call_and_select() {
-        let mut ssa = LLSSA::with_main("call_test".to_string(), ());
+        let mut ssa = LLSSA::with_main("call_test".to_string());
         let helper_id = ssa.add_function("helper".to_string());
         let main_id = ssa.get_main_id();
         let mut sb = LLSSABuilder::new(&mut ssa);
@@ -1272,7 +1274,7 @@ mod tests {
 
     #[test]
     fn build_field_ops() {
-        let mut ssa = LLSSA::with_main("field_test".to_string(), ());
+        let mut ssa = LLSSA::with_main("field_test".to_string());
         let main_id = ssa.get_main_id();
 
         let field_elem = LLStruct::new(vec![
@@ -1311,7 +1313,7 @@ mod tests {
 
     #[test]
     fn build_width_and_global() {
-        let mut ssa = LLSSA::with_main("width_test".to_string(), ());
+        let mut ssa = LLSSA::with_main("width_test".to_string());
         let main_id = ssa.get_main_id();
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
@@ -1334,7 +1336,7 @@ mod tests {
 
     #[test]
     fn build_branching() {
-        let mut ssa = LLSSA::with_main("branch_test".to_string(), ());
+        let mut ssa = LLSSA::with_main("branch_test".to_string());
         let main_id = ssa.get_main_id();
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
@@ -1371,7 +1373,7 @@ mod tests {
 
     #[test]
     fn build_memcpy() {
-        let mut ssa = LLSSA::with_main("memcpy_test".to_string(), ());
+        let mut ssa = LLSSA::with_main("memcpy_test".to_string());
         let main_id = ssa.get_main_id();
 
         let elem = LLStruct::new(vec![LLFieldType::Int(64)]);

--- a/compiler/src/compiler/ssa/mod.rs
+++ b/compiler/src/compiler/ssa/mod.rs
@@ -8,11 +8,38 @@ pub mod id;
 pub mod llssa;
 pub mod traits;
 
+use bimap::BiHashMap;
 use itertools::Itertools;
-use std::{collections::HashMap, fmt::Debug, vec};
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    hash::Hash,
+    sync::{
+        Arc, RwLock,
+        atomic::{AtomicU64, Ordering},
+    },
+    vec,
+};
 
 pub use id::{BlockId, FunctionId, ValueId};
 pub use traits::{Instruction, SSAAnotator, SSAType};
+
+// TYPE ALIASES
+// ================================================================================================
+
+/// Storage for constants inside the SSA, maintaining a 1:1 mapping between value and its
+/// identifier.
+///
+/// Wrapped in a [`RwLock`] so constants can be interned and read through a shared `&SSA`, and the
+/// values are `Arc`-shared so reads can hand back owned handles without keeping the lock held. The
+/// lock is an implementation detail: all access goes through [`SSA`] methods that acquire and
+/// release it internally, so callers never see a guard.
+pub type SSAConstants<C> = RwLock<BiHashMap<ValueId, Arc<C>>>;
+
+/// An owned, lock-free snapshot of the constants (the `ValueId -> value` direction only), handed
+/// out by [`SSA::const_snapshot`] so callers can iterate and look up constants without holding the
+/// constants lock.
+pub type SSAConstantsSnapshot<C> = HashMap<ValueId, Arc<C>>;
 
 // SSA
 // ================================================================================================
@@ -23,9 +50,14 @@ pub use traits::{Instruction, SSAAnotator, SSAType};
 /// - `Op` is the type of instructions in the SSA, allowing customization of the instruction set
 ///   over which the IR is operating.
 /// - `Ty` is the type system for the SSA, describing the valid types and their interactions.
-/// - `Cn` is the type of the constant storage for the SSA, providing an arbitrary interface.
-#[derive(Clone)]
-pub struct SSA<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> {
+/// - `C` is the value type stored in the SSA's constants side-table, which maps each constant
+///   `ValueId` to its value bidirectionally.
+///
+/// It is assumed that all `ValueId`s refer to unique values within the program. If one identifier
+/// is used to refer to two different values, then miscompilation may occur. All sources of value
+/// identifiers should either re-use identifiers known to be unique, or be issued (however
+/// transitively) from [`SSA::fresh_value`].
+pub struct SSA<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> {
     /// A mapping from function identifiers to true functions contained in the SSA.
     functions: HashMap<FunctionId, Function<Op, Ty>>,
 
@@ -49,14 +81,35 @@ pub struct SSA<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> {
     next_function_id: u64,
 
     /// A monotonic counter for `ValueId`s, globally unique within this SSA.
-    next_value_id: u64,
+    ///
+    /// Atomic so passes can mint fresh IDs from a shared `&SSA` (e.g. in the specializer) without
+    /// needing exclusive access.
+    next_value_id: AtomicU64,
 
-    /// Side-table holding constant data for the SSA.
-    constants: Cn,
+    /// Bidirectional mapping between constant `ValueId`s and their values. The bijection is
+    /// maintained by routing all insertions through [`SSA::add_const`], which interns by value.
+    constants: SSAConstants<C>,
 }
 
-impl<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSA<Op, Ty, Cn> {
-    pub fn with_main(name: String, constants: Cn) -> Self {
+impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> Clone for SSA<Op, Ty, C> {
+    /// Take care when cloning the SSA as both original and clone will have the same state for the
+    /// fresh variable allocation.
+    fn clone(&self) -> Self {
+        SSA {
+            functions: self.functions.clone(),
+            global_types: self.global_types.clone(),
+            globals_init_fn: self.globals_init_fn,
+            globals_deinit_fn: self.globals_deinit_fn,
+            main_id: self.main_id,
+            next_function_id: self.next_function_id,
+            next_value_id: AtomicU64::new(self.next_value_id.load(Ordering::Relaxed)),
+            constants: RwLock::new(self.constants.read().unwrap().clone()),
+        }
+    }
+}
+
+impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSA<Op, Ty, C> {
+    pub fn with_main(name: String) -> Self {
         let main_function = Function::<Op, Ty>::empty(name);
         let main_id = FunctionId(0);
         let mut functions = HashMap::new();
@@ -68,17 +121,17 @@ impl<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSA<Op, Ty, Cn> {
             globals_deinit_fn: None,
             main_id,
             next_function_id: 1,
-            next_value_id: 0,
-            constants,
+            next_value_id: AtomicU64::new(0),
+            constants: RwLock::new(BiHashMap::new()),
         }
     }
 }
 
-impl<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSA<Op, Ty, Cn> {
+impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSA<Op, Ty, C> {
     pub fn prepare_rebuild(
         self,
     ) -> (
-        SSA<Op, Ty, Cn>,
+        SSA<Op, Ty, C>,
         HashMap<FunctionId, Function<Op, Ty>>,
         Vec<Ty>,
     ) {
@@ -98,11 +151,37 @@ impl<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSA<Op, Ty, Cn> {
         )
     }
 
+    /// Inserts the provided `function` into the SSA.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that `function` does not reference any value that is not available in the
+    /// SSA, and that all values in the function have unique identifiers.
     pub fn insert_function(&mut self, function: Function<Op, Ty>) -> FunctionId {
         let new_id = FunctionId(self.next_function_id);
         self.next_function_id += 1;
         self.functions.insert(new_id, function);
         new_id
+    }
+
+    /// Remove a function from the SSA, returning it if present.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure no surviving instruction, constant, or SSA-level reference still
+    /// references `id`.
+    pub fn delete_function(&mut self, id: FunctionId) -> Option<Function<Op, Ty>> {
+        self.functions.remove(&id)
+    }
+
+    /// Drop functions for which `f` returns `false`.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure no surviving instruction, constant, or SSA-level reference still
+    /// references the identifier of any removed function.
+    pub fn retain_functions(&mut self, mut f: impl FnMut(FunctionId, &Function<Op, Ty>) -> bool) {
+        self.functions.retain(|id, fun| f(*id, fun));
     }
 
     pub fn set_entry_point(&mut self, id: FunctionId) {
@@ -113,12 +192,18 @@ impl<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSA<Op, Ty, Cn> {
         self.main_id
     }
 
+    /// Gets a mutable reference to the main function or panics if no main function exists.
+    ///
+    /// # Safety
+    ///
+    /// All mutations made to the main function must ensure the internal consistency of the SSA.
     pub fn get_main_mut(&mut self) -> &mut Function<Op, Ty> {
         self.functions
             .get_mut(&self.main_id)
             .expect("Main function should exist")
     }
 
+    /// Gets a reference to the main function or panics if no main function exists.
     pub fn get_main(&self) -> &Function<Op, Ty> {
         self.functions
             .get(&self.main_id)
@@ -129,10 +214,21 @@ impl<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSA<Op, Ty, Cn> {
         self.functions.get(&id).expect("Function should exist")
     }
 
+    /// Gets a mutable reference to a function in the SSA or panics if no such function exists.
+    ///
+    /// # Safety
+    ///
+    /// Any mutations made to the returned function must ensure the internal consistency of the SSA.
     pub fn get_function_mut(&mut self, id: FunctionId) -> &mut Function<Op, Ty> {
         self.functions.get_mut(&id).expect("Function should exist")
     }
 
+    /// Removes the provided function from the SSA or panics if it does not exist.
+    ///
+    /// # Safety
+    ///
+    /// The caller is responsible for fixing any references to this function in the SSA that may be
+    /// left dangling by this operation.
     pub fn take_function(&mut self, id: FunctionId) -> Function<Op, Ty> {
         self.functions.remove(&id).expect("Function should exist")
     }
@@ -149,25 +245,99 @@ impl<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSA<Op, Ty, Cn> {
         new_id
     }
 
+    /// Creates a unique copy of the function identified by `function_id` under the returned
+    /// function identifier.
+    ///
+    /// The copy has been inserted into the SSA, and while it contains the same block identifiers,
+    /// all value identifiers barring those for constants are now unique to the new occurrences.
+    pub fn duplicate_function(&mut self, function_id: FunctionId) -> FunctionId {
+        let mut cloned = self
+            .functions
+            .get(&function_id)
+            .expect("Function should exist")
+            .clone();
+
+        // Phase 1: collect every ValueId appearing anywhere in the function, then
+        // allocate a fresh id for each unique non-constant one.
+        let mut all_ids: Vec<ValueId> = Vec::new();
+        for (_, block) in cloned.get_blocks() {
+            for (v, _) in block.get_parameters() {
+                all_ids.push(*v);
+            }
+            for instr in block.get_instructions() {
+                all_ids.extend(instr.get_inputs().copied());
+                all_ids.extend(instr.get_results().copied());
+            }
+            if let Some(term) = block.get_terminator() {
+                match term {
+                    Terminator::Jmp(_, args) => all_ids.extend(args.iter().copied()),
+                    Terminator::JmpIf(cond, _, _) => all_ids.push(*cond),
+                    Terminator::Return(vs) => all_ids.extend(vs.iter().copied()),
+                }
+            }
+        }
+        let mut remap: HashMap<ValueId, ValueId> = HashMap::new();
+        for v in all_ids {
+            if remap.contains_key(&v) || self.is_const(v) {
+                continue;
+            }
+            let fresh = self.fresh_value();
+            remap.insert(v, fresh);
+        }
+
+        // Phase 2: apply the remap to every ValueId reference in the cloned function.
+        for (_, block) in cloned.get_blocks_mut() {
+            for (v, _) in block.get_parameters_mut() {
+                if let Some(&new_id) = remap.get(v) {
+                    *v = new_id;
+                }
+            }
+            for instr in block.get_instructions_mut() {
+                for op in instr.get_operands_mut() {
+                    if let Some(&new_id) = remap.get(op) {
+                        *op = new_id;
+                    }
+                }
+            }
+            if block.get_terminator().is_some() {
+                match block.get_terminator_mut() {
+                    Terminator::Jmp(_, args) => {
+                        for v in args.iter_mut() {
+                            if let Some(&new_id) = remap.get(v) {
+                                *v = new_id;
+                            }
+                        }
+                    }
+                    Terminator::JmpIf(cond, _, _) => {
+                        if let Some(&new_id) = remap.get(cond) {
+                            *cond = new_id;
+                        }
+                    }
+                    Terminator::Return(vs) => {
+                        for v in vs.iter_mut() {
+                            if let Some(&new_id) = remap.get(v) {
+                                *v = new_id;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        self.insert_function(cloned)
+    }
+
     /// Allocate a fresh `ValueId` from the SSA-wide counter.
-    pub fn fresh_value(&mut self) -> ValueId {
-        let value_id = ValueId(self.next_value_id);
-        self.next_value_id += 1;
-        value_id
+    ///
+    /// Takes `&self` so passes that hold a shared `&HLSSA` (e.g. the specializer, while the
+    /// symbolic executor borrows the SSA) can still mint ids. The counter is atomic.
+    pub fn fresh_value(&self) -> ValueId {
+        ValueId(self.next_value_id.fetch_add(1, Ordering::Relaxed))
     }
 
     /// Upper bound on `ValueId`s issued so far. Useful for sizing dense per-value tables.
     pub fn value_num_bound(&self) -> usize {
-        self.next_value_id as usize
-    }
-
-    /// Advance the value counter to `end` if it is currently lower. Used by passes that
-    /// allocate `ValueId`s into a transient buffer (see e.g. the specializer) and want to
-    /// reconcile the buffer's IDs back into the SSA.
-    pub fn reserve_values_up_to(&mut self, end: u64) {
-        if end > self.next_value_id {
-            self.next_value_id = end;
-        }
+        self.next_value_id.load(Ordering::Relaxed) as usize
     }
 
     pub fn iter_functions(&self) -> impl Iterator<Item = (&FunctionId, &Function<Op, Ty>)> {
@@ -212,23 +382,118 @@ impl<Op: Instruction, Ty: SSAType, Cn: Clone + Debug> SSA<Op, Ty, Cn> {
         self.globals_deinit_fn
     }
 
-    pub fn const_storage(&self) -> &Cn {
-        &self.constants
+    /// Return a shared handle to the constant bound to `vid`, if any.
+    ///
+    /// The constants lock is acquired and released internally, so the caller never holds it.
+    pub fn get_const(&self, vid: ValueId) -> Option<Arc<C>> {
+        self.constants.read().unwrap().get_by_left(&vid).cloned()
     }
 
-    pub fn const_storage_mut(&mut self) -> &mut Cn {
-        &mut self.constants
+    /// Whether `vid` names a constant.
+    pub fn is_const(&self, vid: ValueId) -> bool {
+        self.constants.read().unwrap().contains_left(&vid)
+    }
+
+    /// Take an owned, lock-free snapshot of the constants (`ValueId -> value`).
+    ///
+    /// The values are `Arc`-shared, so cloning the table is cheap. The lock is released before
+    /// returning, letting callers iterate and look up constants without holding it.
+    pub fn const_snapshot(&self) -> SSAConstantsSnapshot<C> {
+        self.constants
+            .read()
+            .unwrap()
+            .iter()
+            .map(|(vid, cv)| (*vid, cv.clone()))
+            .collect()
+    }
+
+    /// Store a constant in the SSA.
+    ///
+    /// If `value` is already present in the constants table, returns its existing `ValueId`;
+    /// otherwise allocates a fresh `ValueId`, inserts the pair, and returns it. This is the only
+    /// safe way to introduce a constant. Takes `&self` so constants can be interned through a
+    /// shared `&SSA`.
+    pub fn add_const(&self, value: C) -> ValueId {
+        // Fast path: re-interning an existing constant is by far the common case
+        // (`materialize_constants` re-emits the whole table on every function entry). Resolve those
+        // hits under a shared read lock so they don't serialize on the write lock.
+        if let Some(&id) = self.constants.read().unwrap().get_by_right(&value) {
+            return id;
+        }
+
+        // Slow path: a genuine miss. Take the write lock and re-check, since another writer may have
+        // inserted between releasing the read lock and acquiring the write lock. Holding the write
+        // lock across the re-check and the insert keeps them atomic; an intervening reader/writer
+        // cannot observe a half-updated table.
+        let mut constants = self.constants.write().unwrap();
+        if let Some(&id) = constants.get_by_right(&value) {
+            return id;
+        }
+        let id = self.fresh_value();
+        constants.insert(id, Arc::new(value));
+        id
+    }
+
+    /// Remove the constant bound to `vid` from the table, returning its value if present and
+    /// panicking if not.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure the SSA no longer references `vid` lest a dangling reference be created.
+    pub fn remove_const_by_id(&self, vid: ValueId) -> Arc<C> {
+        self.constants
+            .write()
+            .unwrap()
+            .remove_by_left(&vid)
+            .map(|(_, v)| v)
+            .expect("Constant should exist")
+    }
+
+    /// Drop constants for which `f` returns `false`.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure the SSA does not reference any removed value ids to avoid creating
+    /// dangling references.
+    pub fn retain_constants(&self, mut f: impl FnMut(&ValueId, &Arc<C>) -> bool) {
+        self.constants.write().unwrap().retain(|vid, cv| f(vid, cv));
+    }
+
+    /// Visit every constant in place, without cloning the table.
+    ///
+    /// Holds the constants read lock for the duration of the walk and hands each
+    /// `(&ValueId, &Arc<C>)` to `f`. Prefer this over [`SSA::const_snapshot`] when you only need a
+    /// single pass and do not need to keep the constants around afterwards.
+    ///
+    /// `f` must not call any method that mutates the constants table (e.g. [`SSA::add_const`],
+    /// [`SSA::retain_constants`]); doing so would deadlock on the read lock held here.
+    pub fn for_each_const(&self, mut f: impl FnMut(&ValueId, &Arc<C>)) {
+        for (vid, cv) in self.constants.read().unwrap().iter() {
+            f(vid, cv);
+        }
     }
 }
 
-impl<Op: Instruction, Ty: SSAType, C: Clone + Debug> SSA<Op, Ty, C> {
+impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSA<Op, Ty, C> {
     pub fn to_string(&self, value_annotator: &dyn SSAAnotator) -> String {
         let func_name = |id: FunctionId| self.get_function(id).get_name().to_string();
-        self.functions
+        let functions = self
+            .functions
             .iter()
             .sorted_by_key(|(fn_id, _)| fn_id.0)
             .map(|(fn_id, func)| func.to_string(&func_name, *fn_id, value_annotator))
-            .join("\n\n")
+            .join("\n\n");
+        let const_guard = self.constants.read().unwrap();
+        if const_guard.is_empty() {
+            functions
+        } else {
+            let constants = const_guard
+                .iter()
+                .sorted_by_key(|(vid, _)| vid.0)
+                .map(|(vid, cv)| format!("  v{} = {:?}", vid.0, cv))
+                .join("\n");
+            format!("constants:\n{}\n\n{}", constants, functions)
+        }
     }
 }
 
@@ -635,3 +900,27 @@ impl Terminator {
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct DefaultSSAAnnotator;
 impl SSAAnotator for DefaultSSAAnnotator {}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::compiler::ssa::hlssa::{Constant, HLSSA};
+
+    /// `for_each_const` visits every interned constant exactly once, in place.
+    #[test]
+    fn for_each_const_visits_all() {
+        let ssa = HLSSA::with_main("main".to_string());
+        let a = ssa.add_const(Constant::U(8, 1));
+        let b = ssa.add_const(Constant::U(8, 2));
+
+        let mut seen = HashMap::new();
+        ssa.for_each_const(|vid, cv| {
+            seen.insert(*vid, cv.as_ref().clone());
+        });
+
+        assert_eq!(seen.len(), 2);
+        assert_eq!(seen.get(&a), Some(&Constant::U(8, 1)));
+        assert_eq!(seen.get(&b), Some(&Constant::U(8, 2)));
+    }
+}

--- a/compiler/src/compiler/ssa/mod.rs
+++ b/compiler/src/compiler/ssa/mod.rs
@@ -152,11 +152,6 @@ impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSA<Op, Ty, C> 
     }
 
     /// Inserts the provided `function` into the SSA.
-    ///
-    /// # Safety
-    ///
-    /// Caller must ensure that `function` does not reference any value that is not available in the
-    /// SSA, and that all values in the function have unique identifiers.
     pub fn insert_function(&mut self, function: Function<Op, Ty>) -> FunctionId {
         let new_id = FunctionId(self.next_function_id);
         self.next_function_id += 1;
@@ -165,21 +160,11 @@ impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSA<Op, Ty, C> 
     }
 
     /// Remove a function from the SSA, returning it if present.
-    ///
-    /// # Safety
-    ///
-    /// Callers must ensure no surviving instruction, constant, or SSA-level reference still
-    /// references `id`.
     pub fn delete_function(&mut self, id: FunctionId) -> Option<Function<Op, Ty>> {
         self.functions.remove(&id)
     }
 
     /// Drop functions for which `f` returns `false`.
-    ///
-    /// # Safety
-    ///
-    /// Callers must ensure no surviving instruction, constant, or SSA-level reference still
-    /// references the identifier of any removed function.
     pub fn retain_functions(&mut self, mut f: impl FnMut(FunctionId, &Function<Op, Ty>) -> bool) {
         self.functions.retain(|id, fun| f(*id, fun));
     }
@@ -193,10 +178,6 @@ impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSA<Op, Ty, C> 
     }
 
     /// Gets a mutable reference to the main function or panics if no main function exists.
-    ///
-    /// # Safety
-    ///
-    /// All mutations made to the main function must ensure the internal consistency of the SSA.
     pub fn get_main_mut(&mut self) -> &mut Function<Op, Ty> {
         self.functions
             .get_mut(&self.main_id)
@@ -215,20 +196,11 @@ impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSA<Op, Ty, C> 
     }
 
     /// Gets a mutable reference to a function in the SSA or panics if no such function exists.
-    ///
-    /// # Safety
-    ///
-    /// Any mutations made to the returned function must ensure the internal consistency of the SSA.
     pub fn get_function_mut(&mut self, id: FunctionId) -> &mut Function<Op, Ty> {
         self.functions.get_mut(&id).expect("Function should exist")
     }
 
     /// Removes the provided function from the SSA or panics if it does not exist.
-    ///
-    /// # Safety
-    ///
-    /// The caller is responsible for fixing any references to this function in the SSA that may be
-    /// left dangling by this operation.
     pub fn take_function(&mut self, id: FunctionId) -> Function<Op, Ty> {
         self.functions.remove(&id).expect("Function should exist")
     }
@@ -436,10 +408,6 @@ impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSA<Op, Ty, C> 
 
     /// Remove the constant bound to `vid` from the table, returning its value if present and
     /// panicking if not.
-    ///
-    /// # Safety
-    ///
-    /// Callers must ensure the SSA no longer references `vid` lest a dangling reference be created.
     pub fn remove_const_by_id(&self, vid: ValueId) -> Arc<C> {
         self.constants
             .write()
@@ -450,11 +418,6 @@ impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSA<Op, Ty, C> 
     }
 
     /// Drop constants for which `f` returns `false`.
-    ///
-    /// # Safety
-    ///
-    /// Callers must ensure the SSA does not reference any removed value ids to avoid creating
-    /// dangling references.
     pub fn retain_constants(&self, mut f: impl FnMut(&ValueId, &Arc<C>) -> bool) {
         self.constants.write().unwrap().retain(|vid, cv| f(vid, cv));
     }

--- a/compiler/src/compiler/untaint_control_flow.rs
+++ b/compiler/src/compiler/untaint_control_flow.rs
@@ -239,8 +239,6 @@ impl UntaintControlFlow {
                 } else {
                     None
                 };
-                // Safe as we put the modified function back under the same ID, avoiding any
-                // dangling references.
                 let mut function = ssa.take_function(function_id);
                 self.run_function(
                     function_id,

--- a/compiler/src/compiler/untaint_control_flow.rs
+++ b/compiler/src/compiler/untaint_control_flow.rs
@@ -239,6 +239,8 @@ impl UntaintControlFlow {
                 } else {
                     None
                 };
+                // Safe as we put the modified function back under the same ID, avoiding any
+                // dangling references.
                 let mut function = ssa.take_function(function_id);
                 self.run_function(
                     function_id,


### PR DESCRIPTION
This commit concretizes the storage for constants a bit more to allow more functionality to be implemented on SSA. It also provides a function that creates a deep duplicate of functions in the SSA to avoid issues with ValueId reuse.

At the same time, it changes HLSSA to use the new constant storage mechanism, though these are translated back into the previous handling for LLSSA at this stage. LLSSA support is coming in a new PR.

Replaces #191 and contains partial work for #184. 