### PR TITLE
Do constants better in LLSSA

### DIFF
--- a/compiler/src/compiler/codegen/llssa_to_llvm.rs
+++ b/compiler/src/compiler/codegen/llssa_to_llvm.rs
@@ -24,7 +24,8 @@ use inkwell::values::{
 use crate::compiler::analysis::flow_analysis;
 use crate::compiler::analysis::flow_analysis::FlowAnalysis;
 use crate::compiler::ssa::llssa::{
-    FieldArithOp, IntArithOp, IntCmpOp, LLFieldType, LLFunction, LLOp, LLSSA, LLStruct, Type,
+    Constant, FieldArithOp, IntArithOp, IntCmpOp, LLFieldType, LLFunction, LLOp, LLSSA, LLStruct,
+    Type,
 };
 use crate::compiler::ssa::{BlockId, FunctionId, Terminator, ValueId};
 
@@ -62,6 +63,7 @@ pub struct LLVMCodeGen<'ctx> {
     module: Module<'ctx>,
     builder: Builder<'ctx>,
     value_map: HashMap<ValueId, BasicValueEnum<'ctx>>,
+    constant_values: HashMap<ValueId, BasicValueEnum<'ctx>>,
     block_map: HashMap<BlockId, inkwell::basic_block::BasicBlock<'ctx>>,
     function_map: HashMap<FunctionId, FunctionValue<'ctx>>,
     vm_ptr: Option<PointerValue<'ctx>>,
@@ -88,6 +90,7 @@ impl<'ctx> LLVMCodeGen<'ctx> {
             module,
             builder,
             value_map: HashMap::new(),
+            constant_values: HashMap::new(),
             block_map: HashMap::new(),
             function_map: HashMap::new(),
             vm_ptr: None,
@@ -386,6 +389,30 @@ impl<'ctx> LLVMCodeGen<'ctx> {
             self.globals.push(global);
         }
 
+        // Materialise module-level LLSSA constants once; each function body will re-seed its
+        // `value_map` from this table. This is a HACK, to be removed once we compile to proper
+        // LLVM constants (#184).
+        self.constant_values.clear();
+        for (vid, c) in llssa.const_snapshot().iter() {
+            let val: BasicValueEnum<'ctx> = match c.as_ref() {
+                Constant::Int { bits, value } => {
+                    let int_type = self
+                        .context
+                        .custom_width_int_type(
+                            NonZeroU32::new(*bits).expect("Cannot have zero-width integer"),
+                        )
+                        .expect("A basic integer type can be created");
+                    int_type.const_int(*value, false).into()
+                }
+                Constant::NullPtr => self
+                    .context
+                    .ptr_type(AddressSpace::default())
+                    .const_null()
+                    .into(),
+            };
+            self.constant_values.insert(*vid, val);
+        }
+
         // First pass: declare all functions
         for (fn_id, function) in llssa.iter_functions() {
             self.declare_function(*fn_id, function, main_id);
@@ -444,6 +471,8 @@ impl<'ctx> LLVMCodeGen<'ctx> {
         main_id: FunctionId,
     ) {
         self.value_map.clear();
+        self.value_map
+            .extend(self.constant_values.iter().map(|(vid, val)| (*vid, *val)));
         self.block_map.clear();
 
         let fn_value = self.function_map[&fn_id];
@@ -601,21 +630,6 @@ impl<'ctx> LLVMCodeGen<'ctx> {
 
     fn compile_instruction(&mut self, op: &LLOp) {
         match op {
-            LLOp::IntConst {
-                result,
-                bits,
-                value,
-            } => {
-                let int_type = self
-                    .context
-                    .custom_width_int_type(
-                        NonZeroU32::new(*bits).expect("Cannot have zero-width integer"),
-                    )
-                    .expect("A basic integer type can be created");
-                let val = int_type.const_int(*value, false);
-                self.value_map.insert(*result, val.into());
-            }
-
             LLOp::IntArith { kind, result, a, b } => {
                 let lhs = self.value_map[a].into_int_value();
                 let rhs = self.value_map[b].into_int_value();
@@ -932,12 +946,6 @@ impl<'ctx> LLVMCodeGen<'ctx> {
             }
 
             // ── Memory operations ───────────────────────────────────────
-            LLOp::NullPtr { result } => {
-                let ptr_type = self.context.ptr_type(AddressSpace::default());
-                let null = ptr_type.const_null();
-                self.value_map.insert(*result, null.into());
-            }
-
             LLOp::HeapAlloc {
                 result,
                 struct_type,

--- a/compiler/src/compiler/ssa/hlssa_to_llssa.rs
+++ b/compiler/src/compiler/ssa/hlssa_to_llssa.rs
@@ -1,21 +1,19 @@
 //! HLSSA -> LLSSA lowering pass
 //!
-//! Translates the high-level SSA (with abstract Field/U types and a separate
-//! constant map) into low-level SSA (explicit integer widths, field-as-struct,
-//! constants-as-instructions).
-//!
-//! Array types lower to heap-allocated RC'd structs behind `Ptr`, following
-//! the layout in `docs/llssa.md`. MkSeq, ArrayGet, ArraySet, and MemOp
-//! (Bump/Drop) are lowered to explicit memory operations.
+//! Array types lower to heap-allocated RC'd structs behind `Ptr`. MkSeq, ArrayGet, ArraySet, and
+//! MemOp (Bump/Drop) are lowered to explicit memory operations.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     marker::PhantomData,
 };
 
-use crate::compiler::analysis::{
-    flow_analysis::{self, FlowAnalysis},
-    types::{FunctionTypeInfo, TypeInfo},
+use crate::compiler::{
+    analysis::{
+        flow_analysis::{self, FlowAnalysis},
+        types::{FunctionTypeInfo, TypeInfo},
+    },
+    ssa::{Instruction, hlssa::Endianness},
 };
 
 use super::{
@@ -25,8 +23,8 @@ use super::{
         Type as HLType, TypeExpr as HLTypeExpr,
     },
     llssa::{
-        FieldArithOp, IntArithOp, IntCmpOp, LLFieldType, LLFunction, LLOp, LLSSA, LLStruct,
-        Type as LLType,
+        Constant as LLConstant, FieldArithOp, IntArithOp, IntCmpOp, LLFieldType, LLFunction, LLOp,
+        LLSSA, LLStruct, Type as LLType,
         builder::{LLBlockEmitter, LLEmitter},
     },
 };
@@ -493,23 +491,22 @@ fn lower_inner(
 // Per-function lowering
 // =============================================================================
 
-/// Materialize every HLSSA constant `ValueId` referenced by `function` into the LLSSA function's
-/// entry block.
+/// Lower every HLSSA constant `ValueId` referenced by `function` into LLSSA.
 ///
-/// This is mostly a temporary hack to keep LLSSA working as before while adjusting constant
-/// handling in HLSSA. It will be removed.
-fn materialize_constants_llssa(
+/// Scalar HLSSA constants (`U`/`I`/`nullptr`) are interned into LLSSA's module-level constants
+/// table. Field constants don't fit in the LLSSA constants table (which only stores scalars), so
+/// they're materialized as an `LLOp::MkStruct` in this function's entry block, with the four limbs
+/// themselves drawn from the LLSSA constants table. This restriction is will be lifted in the
+/// future (#184).
+fn lower_constants_llssa(
     function: &HLFunction,
     constants: &HLSSAConstantsSnapshot,
     ll_func: &mut LLFunction,
     llssa: &mut LLSSA,
-    ll_entry_id: crate::compiler::ssa::BlockId,
+    ll_entry_id: BlockId,
     val_map: &mut HashMap<ValueId, ValueId>,
 ) {
-    use crate::compiler::ssa::Instruction;
-    use crate::compiler::ssa::llssa::builder::LLEmitter;
-
-    let mut referenced: std::collections::HashSet<ValueId> = std::collections::HashSet::new();
+    let mut referenced = HashSet::new();
     for (_, block) in function.get_blocks() {
         for instr in block.get_instructions() {
             for vid in instr.get_inputs() {
@@ -520,15 +517,14 @@ fn materialize_constants_llssa(
         }
         if let Some(term) = block.get_terminator() {
             match term {
-                crate::compiler::ssa::Terminator::Jmp(_, args)
-                | crate::compiler::ssa::Terminator::Return(args) => {
+                Terminator::Jmp(_, args) | Terminator::Return(args) => {
                     for vid in args {
                         if constants.contains_key(vid) {
                             referenced.insert(*vid);
                         }
                     }
                 }
-                crate::compiler::ssa::Terminator::JmpIf(cond, _, _) => {
+                Terminator::JmpIf(cond, _, _) => {
                     if constants.contains_key(cond) {
                         referenced.insert(*cond);
                     }
@@ -544,25 +540,37 @@ fn materialize_constants_llssa(
     let mut referenced: Vec<ValueId> = referenced.into_iter().collect();
     referenced.sort_by_key(|v| v.0);
 
-    let mut emitter = LLBlockEmitter::new(ll_func, llssa, ll_entry_id);
+    let mut field_constants: Vec<(ValueId, [u64; 4])> = Vec::new();
     for vid in referenced {
-        let ll_val = match constants.get(&vid).expect("vid is in constants").as_ref() {
+        match constants.get(&vid).expect("vid is in constants").as_ref() {
             Constant::U(bits, val) | Constant::I(bits, val) => {
-                emitter.int_const(*bits as u32, *val as u64)
+                let ll_val = llssa.add_const(LLConstant::Int {
+                    bits: *bits as u32,
+                    value: *val as u64,
+                });
+                val_map.insert(vid, ll_val);
             }
             Constant::Field(fr) => {
-                let field_struct = LLStruct::field_elem();
-                let limbs = fr.0.0;
-                let l0 = emitter.int_const(64, limbs[0]);
-                let l1 = emitter.int_const(64, limbs[1]);
-                let l2 = emitter.int_const(64, limbs[2]);
-                let l3 = emitter.int_const(64, limbs[3]);
-                emitter.mk_struct(field_struct, vec![l0, l1, l2, l3])
+                field_constants.push((vid, fr.0.0));
             }
             Constant::FnPtr(_) => {
                 panic!("FnPtr constants not supported in HLSSA->LLSSA lowering");
             }
-        };
+        }
+    }
+
+    if field_constants.is_empty() {
+        return;
+    }
+
+    let mut emitter = LLBlockEmitter::new(ll_func, llssa, ll_entry_id);
+    for (vid, limbs) in field_constants {
+        let field_struct = LLStruct::field_elem();
+        let l0 = emitter.add_int_const(64, limbs[0]);
+        let l1 = emitter.add_int_const(64, limbs[1]);
+        let l2 = emitter.add_int_const(64, limbs[2]);
+        let l3 = emitter.add_int_const(64, limbs[3]);
+        let ll_val = emitter.mk_struct(field_struct, vec![l0, l1, l2, l3]);
         val_map.insert(vid, ll_val);
     }
 }
@@ -616,8 +624,7 @@ fn lower_function(
         }
     }
 
-    // TODO Temporary, until we can handle constants properly in LLSSA.
-    materialize_constants_llssa(
+    lower_constants_llssa(
         function,
         constants,
         &mut ll_func,
@@ -984,7 +991,7 @@ fn lower_instruction(
                             HLTypeExpr::U(64) | HLTypeExpr::I(64) => ll_value,
                             _ => panic!("Cast to Field from unsupported type: {}", source_type),
                         };
-                        let zero = e.int_const(64, 0);
+                        let zero = e.add_int_const(64, 0);
                         let limbs = e.mk_struct(LLStruct::limbs(), vec![val64, zero, zero, zero]);
                         let field_val = e.field_from_limbs(limbs);
                         val_map.insert(*result, field_val);
@@ -1432,16 +1439,16 @@ fn lower_mk_array(
     // Init RC to 1
     let rc_hdr = e.struct_field_ptr(arr, rc_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.int_const(64, 1);
+    let one = e.add_int_const(64, 1);
     e.ll_store(rc_word, one);
     let table_id = e.struct_field_ptr(arr, rc_struct.clone(), 1);
-    let unassigned = e.int_const(64, u64::MAX);
+    let unassigned = e.add_int_const(64, u64::MAX);
     e.ll_store(table_id, unassigned);
 
     // Store elements
     let data = e.struct_field_ptr(arr, rc_struct, 2);
     for (i, elem) in elems.iter().enumerate() {
-        let idx = e.int_const(64, i as u64);
+        let idx = e.add_int_const(64, i as u64);
         let elem_ptr = e.array_elem_ptr(data, es.clone(), idx);
         let ll_elem = val_map[elem];
         e.ll_store(elem_ptr, ll_elem);
@@ -1470,10 +1477,10 @@ fn lower_mk_repeated(
 
     let rc_hdr = e.struct_field_ptr(arr, rc_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.int_const(64, 1);
+    let one = e.add_int_const(64, 1);
     e.ll_store(rc_word, one);
     let table_id = e.struct_field_ptr(arr, rc_struct.clone(), 1);
-    let unassigned = e.int_const(64, u64::MAX);
+    let unassigned = e.add_int_const(64, u64::MAX);
     e.ll_store(table_id, unassigned);
 
     let data = e.struct_field_ptr(arr, rc_struct, 2);
@@ -1493,11 +1500,9 @@ fn lower_to_bytes(
     val_map: &mut HashMap<ValueId, ValueId>,
     result: ValueId,
     value: ValueId,
-    endianness: crate::compiler::ssa::hlssa::Endianness,
+    endianness: Endianness,
     count: usize,
 ) {
-    use crate::compiler::ssa::hlssa::Endianness;
-
     let ll_value = val_map[&value];
 
     // Decompose field → 4 × u64 limbs (little-endian: limb 0 = least significant)
@@ -1514,7 +1519,7 @@ fn lower_to_bytes(
     // Byte positions i >= 32 are structurally zero: the field representation
     // is only 32 bytes, so any higher byte is definitionally 0. Matches the
     // old VM `to_bytes_be` behavior of zero-padding past the field width.
-    let zero_byte = e.int_const(8, 0);
+    let zero_byte = e.add_int_const(8, 0);
     let mut bytes_le = Vec::with_capacity(count);
     for i in 0..count {
         if i >= 32 {
@@ -1526,7 +1531,7 @@ fn lower_to_bytes(
         let shifted = if byte_offset == 0 {
             limb[limb_idx]
         } else {
-            let shift = e.int_const(64, byte_offset as u64);
+            let shift = e.add_int_const(64, byte_offset as u64);
             e.int_arith(IntArithOp::UShr, limb[limb_idx], shift)
         };
         let byte_val = e.truncate(shifted, 8);
@@ -1543,10 +1548,10 @@ fn lower_to_bytes(
     // Init RC to 1
     let rc_hdr = e.struct_field_ptr(arr, rc_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.int_const(64, 1);
+    let one = e.add_int_const(64, 1);
     e.ll_store(rc_word, one);
     let table_id = e.struct_field_ptr(arr, rc_struct.clone(), 1);
-    let unassigned = e.int_const(64, u64::MAX);
+    let unassigned = e.add_int_const(64, u64::MAX);
     e.ll_store(table_id, unassigned);
 
     // Store bytes into the array
@@ -1556,7 +1561,7 @@ fn lower_to_bytes(
             Endianness::Big => count - 1 - i,
             Endianness::Little => i,
         };
-        let idx = e.int_const(64, i as u64);
+        let idx = e.add_int_const(64, i as u64);
         let elem_ptr = e.array_elem_ptr(data, es.clone(), idx);
         e.ll_store(elem_ptr, bytes_le[src_idx]);
     }
@@ -1580,7 +1585,7 @@ fn lower_mk_tuple(
     // Init RC to 1
     let rc_hdr = e.struct_field_ptr(tuple_ptr, rc_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.int_const(64, 1);
+    let one = e.add_int_const(64, 1);
     e.ll_store(rc_word, one);
 
     // Store each element into its field (fields are at index 1, 2, 3, ...)
@@ -1631,12 +1636,12 @@ fn lower_alloc(
 
     let rc_hdr = e.struct_field_ptr(ptr, rc_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.int_const(64, 1);
+    let one = e.add_int_const(64, 1);
     e.ll_store(rc_word, one);
 
     if needs_drop(&elem_type.expr) {
         let slot = e.struct_field_ptr(ptr, rc_struct, 1);
-        let null = e.null_ptr();
+        let null = e.add_nullptr_const();
         e.ll_store(slot, null);
     }
 
@@ -1662,7 +1667,7 @@ fn lower_ref_store(
     if needs_drop(&inner_type.expr) {
         let drop_fn = get_or_create_drop_fn(inner_type, e.ssa, drop_fns, ad_fns);
         let old = e.ll_load(slot, LLType::Ptr);
-        let null = e.null_ptr();
+        let null = e.add_nullptr_const();
         let is_null = e.int_eq(old, null);
         e.build_if_else(
             is_null,
@@ -1775,7 +1780,7 @@ fn lower_array_set(
     let hdr = e.struct_field_ptr(ll_arr, rc_struct.clone(), 0);
     let rc_ptr = e.struct_field_ptr(hdr, LLStruct::rc_header(), 0);
     let rc = e.ll_load(rc_ptr, LLType::i64());
-    let one = e.int_const(64, 1);
+    let one = e.add_int_const(64, 1);
     let unique = e.int_eq(rc, one);
 
     let merge_results = e.build_if_else(
@@ -1794,7 +1799,7 @@ fn lower_array_set(
 
             me.ll_store(slot, ll_val);
             let table_id = me.struct_field_ptr(ll_arr, rc_struct.clone(), 1);
-            let unassigned = me.int_const(64, u64::MAX);
+            let unassigned = me.add_int_const(64, u64::MAX);
             me.ll_store(table_id, unassigned);
             vec![ll_arr]
         },
@@ -1812,13 +1817,13 @@ fn lower_array_set(
             let new_rc_ptr = ce.struct_field_ptr(new_hdr, LLStruct::rc_header(), 0);
             ce.ll_store(new_rc_ptr, one);
             let new_table_id = ce.struct_field_ptr(new_arr, rc_struct.clone(), 1);
-            let unassigned = ce.int_const(64, u64::MAX);
+            let unassigned = ce.add_int_const(64, u64::MAX);
             ce.ll_store(new_table_id, unassigned);
 
             // Copy all data
             let old_data = ce.struct_field_ptr(ll_arr, rc_struct.clone(), 2);
             let new_data = ce.struct_field_ptr(new_arr, rc_struct.clone(), 2);
-            let count_val = ce.int_const(64, count as u64);
+            let count_val = ce.add_int_const(64, count as u64);
             ce.memcpy(new_data, old_data, es.clone(), Some(count_val));
 
             // Bump RC of all copied elements except the one we're overwriting
@@ -1881,7 +1886,7 @@ fn lower_rc_bump(
     let hdr = e.struct_field_ptr(ll_arr, rc_struct, 0);
     let rc_ptr = e.struct_field_ptr(hdr, LLStruct::rc_header(), 0);
     let rc = e.ll_load(rc_ptr, LLType::i64());
-    let n_val = e.int_const(64, n as u64);
+    let n_val = e.add_int_const(64, n as u64);
     let new_rc = e.int_add(rc, n_val);
     e.ll_store(rc_ptr, new_rc);
 }
@@ -1921,7 +1926,7 @@ fn ensure_field_sized(
         HLTypeExpr::U(64) | HLTypeExpr::I(64) => ll_val,
         _ => panic!("ensure_field_sized: unsupported type: {}", source_type),
     };
-    let zero = e.int_const(64, 0);
+    let zero = e.add_int_const(64, 0);
     let limbs = e.mk_struct(LLStruct::limbs(), vec![val64, zero, zero, zero]);
     e.field_from_limbs(limbs)
 }
@@ -1941,12 +1946,12 @@ fn lower_ad_const_wrap(
     // RC = 1
     let rc_hdr = e.struct_field_ptr(node, node_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.int_const(64, 1);
+    let one = e.add_int_const(64, 1);
     e.ll_store(rc_word, one);
 
     // tag = AD_TAG_CONST
     let tag_ptr = e.struct_field_ptr(node, node_struct.clone(), 1);
-    let tag = e.int_const(32, LLStruct::AD_TAG_CONST);
+    let tag = e.add_int_const(32, LLStruct::AD_TAG_CONST);
     e.ll_store(tag_ptr, tag);
 
     // value = field element
@@ -1968,12 +1973,12 @@ fn lower_ad_fresh_witness(
     // RC = 1
     let rc_hdr = e.struct_field_ptr(node, node_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.int_const(64, 1);
+    let one = e.add_int_const(64, 1);
     e.ll_store(rc_word, one);
 
     // tag = AD_TAG_WITNESS
     let tag_ptr = e.struct_field_ptr(node, node_struct.clone(), 1);
-    let tag = e.int_const(32, LLStruct::AD_TAG_WITNESS);
+    let tag = e.add_int_const(32, LLStruct::AD_TAG_WITNESS);
     e.ll_store(tag_ptr, tag);
 
     // index = next witness index from VM
@@ -1993,12 +1998,12 @@ fn lower_ad_sum(e: &mut LLBlockEmitter<'_>, ll_a: ValueId, ll_b: ValueId) -> Val
     // RC = 1
     let rc_hdr = e.struct_field_ptr(node, node_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.int_const(64, 1);
+    let one = e.add_int_const(64, 1);
     e.ll_store(rc_word, one);
 
     // tag = AD_TAG_SUM
     let tag_ptr = e.struct_field_ptr(node, node_struct.clone(), 1);
-    let tag = e.int_const(32, LLStruct::AD_TAG_SUM);
+    let tag = e.add_int_const(32, LLStruct::AD_TAG_SUM);
     e.ll_store(tag_ptr, tag);
 
     // a, b = children
@@ -2036,12 +2041,12 @@ fn lower_ad_mul_const(
     // RC = 1
     let rc_hdr = e.struct_field_ptr(node, node_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.int_const(64, 1);
+    let one = e.add_int_const(64, 1);
     e.ll_store(rc_word, one);
 
     // tag = AD_TAG_MUL_CONST
     let tag_ptr = e.struct_field_ptr(node, node_struct.clone(), 1);
-    let tag = e.int_const(32, LLStruct::AD_TAG_MUL_CONST);
+    let tag = e.add_int_const(32, LLStruct::AD_TAG_MUL_CONST);
     e.ll_store(tag_ptr, tag);
 
     // coeff
@@ -2076,7 +2081,7 @@ fn lower_ad_rc_bump(
     let hdr = e.struct_field_ptr(ll_node, base, 0);
     let rc_ptr = e.struct_field_ptr(hdr, LLStruct::rc_header(), 0);
     let rc = e.ll_load(rc_ptr, LLType::i64());
-    let n_val = e.int_const(64, n as u64);
+    let n_val = e.add_int_const(64, n as u64);
     let new_rc = e.int_add(rc, n_val);
     e.ll_store(rc_ptr, new_rc);
 }
@@ -2095,7 +2100,7 @@ fn lower_ad_rc_drop(
 
 /// Construct a zero field element as a struct value.
 fn make_field_zero(e: &mut LLBlockEmitter<'_>) -> ValueId {
-    let z = e.int_const(64, 0);
+    let z = e.add_int_const(64, 0);
     e.mk_struct(LLStruct::field_elem(), vec![z, z, z, z])
 }
 
@@ -2153,7 +2158,7 @@ fn generate_ad_bump_function(llssa: &mut LLSSA, matrix: DMatrix) -> LLFunction {
     let tag = e.ll_load(tag_ptr, LLType::i32());
 
     // CONST?
-    let const_tag = e.int_const(32, LLStruct::AD_TAG_CONST);
+    let const_tag = e.add_int_const(32, LLStruct::AD_TAG_CONST);
     let is_const = e.int_eq(tag, const_tag);
     e.build_if_else(
         is_const,
@@ -2169,7 +2174,7 @@ fn generate_ad_bump_function(llssa: &mut LLSSA, matrix: DMatrix) -> LLFunction {
             // Not CONST — check WITNESS
             let tag_ptr = e.struct_field_ptr(node, LLStruct::ad_node_base(), 1);
             let tag = e.ll_load(tag_ptr, LLType::i32());
-            let wit_tag = e.int_const(32, LLStruct::AD_TAG_WITNESS);
+            let wit_tag = e.add_int_const(32, LLStruct::AD_TAG_WITNESS);
             let is_wit = e.int_eq(tag, wit_tag);
             e.build_if_else(
                 is_wit,
@@ -2186,7 +2191,7 @@ fn generate_ad_bump_function(llssa: &mut LLSSA, matrix: DMatrix) -> LLFunction {
                     // SUM or MUL_CONST: accumulate into node.d{a,b,c}
                     let tag_ptr = e.struct_field_ptr(node, LLStruct::ad_node_base(), 1);
                     let tag = e.ll_load(tag_ptr, LLType::i32());
-                    let sum_tag = e.int_const(32, LLStruct::AD_TAG_SUM);
+                    let sum_tag = e.add_int_const(32, LLStruct::AD_TAG_SUM);
                     let is_sum = e.int_eq(tag, sum_tag);
                     e.build_if_else(
                         is_sum,
@@ -2250,12 +2255,12 @@ fn generate_ad_drop_function(
     let rc_hdr = e.struct_field_ptr(node, LLStruct::ad_node_base(), 0);
     let rc_ptr = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
     let rc = e.ll_load(rc_ptr, LLType::i64());
-    let one = e.int_const(64, 1);
+    let one = e.add_int_const(64, 1);
     let new_rc = e.int_sub(rc, one);
     e.ll_store(rc_ptr, new_rc);
 
     // If RC hit zero, dispatch on tag and tear down
-    let zero = e.int_const(64, 0);
+    let zero = e.add_int_const(64, 0);
     let dead = e.int_eq(new_rc, zero);
     e.build_if_else(
         dead,
@@ -2266,7 +2271,7 @@ fn generate_ad_drop_function(
             let tag = e.ll_load(tag_ptr, LLType::i32());
 
             // CONST or WITNESS (tag < 2) → just free
-            let two = e.int_const(32, 2);
+            let two = e.add_int_const(32, 2);
             let is_simple = e.int_ult(tag, two);
             e.build_if_else(
                 is_simple,
@@ -2279,7 +2284,7 @@ fn generate_ad_drop_function(
                     // SUM or MUL_CONST
                     let tag_ptr = e.struct_field_ptr(node, LLStruct::ad_node_base(), 1);
                     let tag = e.ll_load(tag_ptr, LLType::i32());
-                    let sum_tag = e.int_const(32, LLStruct::AD_TAG_SUM);
+                    let sum_tag = e.add_int_const(32, LLStruct::AD_TAG_SUM);
                     let is_sum = e.int_eq(tag, sum_tag);
                     e.build_if_else(
                         is_sum,
@@ -2416,12 +2421,12 @@ fn generate_drop_function_for_array(
     let hdr = e.struct_field_ptr(ptr, rc_struct.clone(), 0);
     let rc_ptr = e.struct_field_ptr(hdr, LLStruct::rc_header(), 0);
     let rc = e.ll_load(rc_ptr, LLType::i64());
-    let one = e.int_const(64, 1);
+    let one = e.add_int_const(64, 1);
     let new_rc = e.int_sub(rc, one);
     e.ll_store(rc_ptr, new_rc);
 
     // If RC hit zero, drop inner elements and free
-    let zero = e.int_const(64, 0);
+    let zero = e.add_int_const(64, 0);
     let dead = e.int_eq(new_rc, zero);
     e.build_if_else(
         dead,
@@ -2483,12 +2488,12 @@ fn generate_drop_function_for_tuple(
     let hdr = e.struct_field_ptr(ptr, rc_struct.clone(), 0);
     let rc_ptr = e.struct_field_ptr(hdr, LLStruct::rc_header(), 0);
     let rc = e.ll_load(rc_ptr, LLType::i64());
-    let one = e.int_const(64, 1);
+    let one = e.add_int_const(64, 1);
     let new_rc = e.int_sub(rc, one);
     e.ll_store(rc_ptr, new_rc);
 
     // If RC hit zero, drop inner heap-allocated elements and free
-    let zero = e.int_const(64, 0);
+    let zero = e.add_int_const(64, 0);
     let dead = e.int_eq(new_rc, zero);
     e.build_if_else(
         dead,
@@ -2551,11 +2556,11 @@ fn generate_drop_function_for_ref(
     let hdr = e.struct_field_ptr(ptr, rc_struct.clone(), 0);
     let rc_ptr = e.struct_field_ptr(hdr, LLStruct::rc_header(), 0);
     let rc = e.ll_load(rc_ptr, LLType::i64());
-    let one = e.int_const(64, 1);
+    let one = e.add_int_const(64, 1);
     let new_rc = e.int_sub(rc, one);
     e.ll_store(rc_ptr, new_rc);
 
-    let zero = e.int_const(64, 0);
+    let zero = e.add_int_const(64, 0);
     let dead = e.int_eq(new_rc, zero);
     e.build_if_else(
         dead,
@@ -2570,7 +2575,7 @@ fn generate_drop_function_for_ref(
 
                 let slot = e.struct_field_ptr(ptr, rc_struct.clone(), 1);
                 let inner_val = e.ll_load(slot, LLType::Ptr);
-                let null = e.null_ptr();
+                let null = e.add_nullptr_const();
                 let is_null = e.int_eq(inner_val, null);
                 e.build_if_else(
                     is_null,
@@ -2765,13 +2770,13 @@ fn assert(e: &mut LLBlockEmitter<'_>, ok: ValueId) {
 
 /// Build a Field whose low limb is `lo` and upper limbs are zero.
 fn u64_as_field(e: &mut LLBlockEmitter<'_>, lo: ValueId) -> ValueId {
-    let zero = e.int_const(64, 0);
+    let zero = e.add_int_const(64, 0);
     let limbs = e.mk_struct(LLStruct::limbs(), vec![lo, zero, zero, zero]);
     e.field_from_limbs(limbs)
 }
 
 fn field_neg_via_sub(e: &mut LLBlockEmitter<'_>, value: ValueId) -> ValueId {
-    let zero_i64 = e.int_const(64, 0);
+    let zero_i64 = e.add_int_const(64, 0);
     let zero_field = u64_as_field(e, zero_i64);
     e.field_arith(FieldArithOp::Sub, zero_field, value)
 }
@@ -2786,7 +2791,7 @@ fn write_tape_entry_u64(e: &mut LLBlockEmitter<'_>, cursor_field: usize, value_u
     let low_ptr = e.struct_field_ptr(cursor, LLStruct::field_elem(), 0);
     e.ll_store(low_ptr, value_u64);
     // Advance cursor by one Field (4 i64s).
-    let one = e.int_const(32, 1);
+    let one = e.add_int_const(32, 1);
     let next = e.array_elem_ptr(cursor, LLStruct::field_elem(), one);
     e.ll_store(cursor_slot, next);
 }
@@ -2796,7 +2801,7 @@ fn write_tape_entry_field(e: &mut LLBlockEmitter<'_>, cursor_field: usize, field
     let cursor_slot = e.witgen_vm_field_ptr(cursor_field);
     let cursor = e.ll_load(cursor_slot, LLType::Ptr);
     e.ll_store(cursor, field_val);
-    let one = e.int_const(32, 1);
+    let one = e.add_int_const(32, 1);
     let next = e.array_elem_ptr(cursor, LLStruct::field_elem(), one);
     e.ll_store(cursor_slot, next);
 }
@@ -2898,14 +2903,14 @@ fn get_or_init_forward_lookup_table(
         ForwardLookupTableState::Global { table_idx_global } => {
             let snap_idx_slot = e.global_addr(table_idx_global);
             let snap_idx_plus_one = e.ll_load(snap_idx_slot, LLType::i32());
-            let zero_i32 = e.int_const(32, 0);
+            let zero_i32 = e.add_int_const(32, 0);
             e.int_eq(snap_idx_plus_one, zero_i32)
         }
         ForwardLookupTableState::Array {
             table_id_or_sentinel,
             ..
         } => {
-            let sentinel = e.int_const(64, u64::MAX);
+            let sentinel = e.add_int_const(64, u64::MAX);
             e.int_eq(table_id_or_sentinel, sentinel)
         }
     };
@@ -2929,11 +2934,11 @@ fn get_or_init_forward_lookup_table(
             let inv_wit_off = e.ll_load(wit_cursor_slot, LLType::i32());
 
             let slot_ptr = witgen_table_info_ptr(e, table_idx);
-            let one_i32 = e.int_const(32, 1);
-            let table_len_i32 = e.int_const(32, lookup.length as u64);
-            let table_values_i32 = e.int_const(32, lookup.num_values());
-            let table_wit_bump_i32 = e.int_const(32, lookup.witness_slots() as u64);
-            let table_cnst_bump_i32 = e.int_const(32, lookup.constraint_slots() as u64);
+            let one_i32 = e.add_int_const(32, 1);
+            let table_len_i32 = e.add_int_const(32, lookup.length as u64);
+            let table_values_i32 = e.add_int_const(32, lookup.num_values());
+            let table_wit_bump_i32 = e.add_int_const(32, lookup.witness_slots() as u64);
+            let table_cnst_bump_i32 = e.add_int_const(32, lookup.constraint_slots() as u64);
             let table_info_writes = [
                 (LLStruct::TABLE_INFO_MULTS_BASE, mults_base),
                 (LLStruct::TABLE_INFO_INV_CNST_OFF, inv_cnst_off),
@@ -2976,7 +2981,7 @@ fn get_or_init_forward_lookup_table(
                 ForwardLookupTableState::Global { table_idx_global } => {
                     let snap_idx_slot = e.global_addr(table_idx_global);
                     let snap_idx_plus_one = e.ll_load(snap_idx_slot, LLType::i32());
-                    let one_i32 = e.int_const(32, 1);
+                    let one_i32 = e.add_int_const(32, 1);
                     e.int_arith(IntArithOp::Sub, snap_idx_plus_one, one_i32)
                 }
                 ForwardLookupTableState::Array {
@@ -3013,7 +3018,7 @@ fn emit_forward_lookup_key_entry(
             vec![]
         },
         |e| {
-            let table_len_i64 = e.int_const(64, lookup.length as u64);
+            let table_len_i64 = e.add_int_const(64, lookup.length as u64);
             let in_range = e.int_ult(key, table_len_i64);
             assert(e, in_range);
             for high in key_high_limbs {
@@ -3141,7 +3146,7 @@ fn generate_array_lookup_function(llssa: &mut LLSSA, array_type: &HLType) -> LLF
     let key = key_l0;
     let flag_u64 = flag_l0;
 
-    let zero_i64 = e.int_const(64, 0);
+    let zero_i64 = e.add_int_const(64, 0);
     for high in [flag_l1, flag_l2, flag_l3] {
         let ok = e.int_eq(high, zero_i64);
         assert(&mut e, ok);
@@ -3164,7 +3169,7 @@ fn generate_array_lookup_function(llssa: &mut LLSSA, array_type: &HLType) -> LLF
                 let elem_ptr = e.array_elem_ptr(data, elem_struct.clone(), i_i64);
                 let elem_field = load_pure_lookup_elem_as_field(e, elem_ptr, elem_type);
                 let i_i32 = e.truncate(i_i64, 32);
-                let two_i32 = e.int_const(32, 2);
+                let two_i32 = e.add_int_const(32, 2);
                 let doubled_i = e.int_arith(IntArithOp::Mul, i_i32, two_i32);
                 let table_slot_idx = e.int_arith(IntArithOp::Add, inv_cnst_off, doubled_i);
                 let table_slot = e.array_elem_ptr(a_base, LLStruct::field_elem(), table_slot_idx);
@@ -3219,7 +3224,7 @@ fn generate_spread_lookup_function(
     let key = key_l0;
     let flag_u64 = flag_l0;
 
-    let zero_i64 = e.int_const(64, 0);
+    let zero_i64 = e.add_int_const(64, 0);
     // flag is 0 or 1 by construction; sanity-check its high BigInt limbs.
     // `key`'s high limbs and `key < length` are validated only when
     // `flag != 0` (see post-merge tape emission below), matching the VM's
@@ -3248,7 +3253,7 @@ fn generate_spread_lookup_function(
                 };
                 let spread_field = u64_as_field(e, spread_u64);
                 let i_i32 = e.truncate(i_i64, 32);
-                let two_i32 = e.int_const(32, 2);
+                let two_i32 = e.add_int_const(32, 2);
                 let doubled_i = e.int_arith(IntArithOp::Mul, i_i32, two_i32);
                 let table_idx = e.int_arith(IntArithOp::Add, inv_cnst_off, doubled_i);
                 let table_slot = e.array_elem_ptr(a_base, LLStruct::field_elem(), table_idx);
@@ -3314,7 +3319,7 @@ fn generate_rngchk_8_function(llssa: &mut LLSSA, table_idx_global: usize) -> LLF
     let key = val_l0;
 
     // flag is 0 or 1 by construction; sanity-check its high BigInt limbs.
-    let zero_i64 = e.int_const(64, 0);
+    let zero_i64 = e.add_int_const(64, 0);
     for high in [flag_l1, flag_l2, flag_l3] {
         let ok = e.int_eq(high, zero_i64);
         assert(&mut e, ok);
@@ -3352,7 +3357,7 @@ fn generate_rngchk_8_function(llssa: &mut LLSSA, table_idx_global: usize) -> LLF
 fn ad_next_lookup_wit_off(e: &mut LLBlockEmitter<'_>) -> ValueId {
     let slot = e.ad_vm_field_ptr(LLStruct::AD_VM_CURRENT_LOOKUP_WIT_OFF);
     let idx = e.ll_load(slot, LLType::i32());
-    let one = e.int_const(32, 1);
+    let one = e.add_int_const(32, 1);
     let next = e.int_add(idx, one);
     e.ll_store(slot, next);
     idx
@@ -3379,13 +3384,13 @@ fn claim_ad_lookup_table_region(
     let wit_mults_slot = e.ad_vm_field_ptr(LLStruct::AD_VM_CURRENT_WIT_MULTIPLICITIES_OFF);
     let mults_wit_off = e.ll_load(wit_mults_slot, LLType::i32());
 
-    let cnst_bump = e.int_const(32, lookup.constraint_slots() as u64);
+    let cnst_bump = e.add_int_const(32, lookup.constraint_slots() as u64);
     let next_cnst = e.int_arith(IntArithOp::Add, inv_cnst_off, cnst_bump);
     e.ll_store(cnst_tables_slot, next_cnst);
-    let wit_bump = e.int_const(32, lookup.witness_slots() as u64);
+    let wit_bump = e.add_int_const(32, lookup.witness_slots() as u64);
     let next_wit = e.int_arith(IntArithOp::Add, inv_wit_off, wit_bump);
     e.ll_store(wit_tables_slot, next_wit);
-    let mults_bump = e.int_const(32, lookup.length as u64);
+    let mults_bump = e.add_int_const(32, lookup.length as u64);
     let next_mults = e.int_arith(IntArithOp::Add, mults_wit_off, mults_bump);
     e.ll_store(wit_mults_slot, next_mults);
 
@@ -3398,7 +3403,7 @@ fn store_ad_global_snapshot(
     inv_cnst_off: ValueId,
 ) {
     let snap_slot = e.global_addr(inv_cnst_off_global);
-    let one_i32 = e.int_const(32, 1);
+    let one_i32 = e.add_int_const(32, 1);
     let snap = e.int_arith(IntArithOp::Add, inv_cnst_off, one_i32);
     e.ll_store(snap_slot, snap);
 }
@@ -3415,18 +3420,18 @@ fn emit_key_value_ad_table_init_body(
     let (inv_cnst_off, inv_wit_off, mults_wit_off) = claim_ad_lookup_table_region(e, lookup);
     save_table_snapshot(e, inv_cnst_off);
 
-    let sum_offset_i32 = e.int_const(32, lookup.sum_constraint_offset() as u64);
+    let sum_offset_i32 = e.add_int_const(32, lookup.sum_constraint_offset() as u64);
     let sum_idx = e.int_arith(IntArithOp::Add, inv_cnst_off, sum_offset_i32);
     let inv_sum_coeff = ad_read_coeff_at_dyn(e, sum_idx);
-    let logup_alpha_i32 = e.int_const(32, witness_layout.challenges_start() as u64);
-    let logup_beta_i32 = e.int_const(32, witness_layout.challenges_start() as u64 + 1);
+    let logup_alpha_i32 = e.add_int_const(32, witness_layout.challenges_start() as u64);
+    let logup_beta_i32 = e.add_int_const(32, witness_layout.challenges_start() as u64 + 1);
 
     e.build_counted_loop(lookup.length, vec![], |e, i_i64, _| {
         let i_i32 = e.truncate(i_i64, 32);
-        let two_i32 = e.int_const(32, 2);
+        let two_i32 = e.add_int_const(32, 2);
         let twice_i = e.int_arith(IntArithOp::Mul, i_i32, two_i32);
         let x_cnst_idx = e.int_arith(IntArithOp::Add, inv_cnst_off, twice_i);
-        let one_i32 = e.int_const(32, 1);
+        let one_i32 = e.add_int_const(32, 1);
         let y_cnst_idx = e.int_arith(IntArithOp::Add, x_cnst_idx, one_i32);
         let x_coeff = ad_read_coeff_at_dyn(e, x_cnst_idx);
         let y_coeff = ad_read_coeff_at_dyn(e, y_cnst_idx);
@@ -3454,7 +3459,7 @@ fn emit_key_value_ad_table_init_body(
         vec![]
     });
 
-    let one_i64 = e.int_const(64, 1);
+    let one_i64 = e.add_int_const(64, 1);
     let one_field = u64_as_field(e, one_i64);
     e.ad_write_const(DMatrix::B, one_field, inv_sum_coeff);
 
@@ -3475,14 +3480,15 @@ fn emit_key_value_ad_lookup_call_body(
 ) {
     lookup.assert_key_value("AD lookup call");
 
-    let sum_offset_i32 = e.int_const(32, lookup.sum_constraint_offset() as u64);
+    let sum_offset_i32 = e.add_int_const(32, lookup.sum_constraint_offset() as u64);
     let sum_idx = e.int_arith(IntArithOp::Add, inv_cnst_off, sum_offset_i32);
     let inv_sum_coeff = ad_read_coeff_at_dyn(e, sum_idx);
 
     let x_wit_off = ad_next_lookup_wit_off(e);
     let y_wit_off = ad_next_lookup_wit_off(e);
-    let lookups_wit_start_i32 = e.int_const(32, witness_layout.lookups_data_start() as u64);
-    let lookups_cnst_start_i32 = e.int_const(32, constraints_layout.lookups_data_start() as u64);
+    let lookups_wit_start_i32 = e.add_int_const(32, witness_layout.lookups_data_start() as u64);
+    let lookups_cnst_start_i32 =
+        e.add_int_const(32, constraints_layout.lookups_data_start() as u64);
     let x_n = e.int_arith(IntArithOp::Sub, x_wit_off, lookups_wit_start_i32);
     let x_cnst_idx = e.int_arith(IntArithOp::Add, lookups_cnst_start_i32, x_n);
     let y_n = e.int_arith(IntArithOp::Sub, y_wit_off, lookups_wit_start_i32);
@@ -3490,8 +3496,8 @@ fn emit_key_value_ad_lookup_call_body(
     let x_coeff = ad_read_coeff_at_dyn(e, x_cnst_idx);
     let y_coeff = ad_read_coeff_at_dyn(e, y_cnst_idx);
 
-    let logup_alpha_i32 = e.int_const(32, witness_layout.challenges_start() as u64);
-    let logup_beta_i32 = e.int_const(32, witness_layout.challenges_start() as u64 + 1);
+    let logup_alpha_i32 = e.add_int_const(32, witness_layout.challenges_start() as u64);
+    let logup_beta_i32 = e.add_int_const(32, witness_layout.challenges_start() as u64 + 1);
 
     e.ad_write_witness(DMatrix::A, logup_beta_i32, x_coeff);
     e.call(bump_db_fn, vec![result_ptr, x_coeff], 0);
@@ -3532,11 +3538,11 @@ fn emit_rngchk_8_ad_init_body(
 
     // inv_sum_coeff sits at the sum-constraint AD coefficient (one past the
     // 256 per-element coefficients for this table).
-    let two_fifty_six_i32 = e.int_const(32, 256);
+    let two_fifty_six_i32 = e.add_int_const(32, 256);
     let sum_idx = e.int_arith(IntArithOp::Add, inv_cnst_off, two_fifty_six_i32);
     let inv_sum_coeff = ad_read_coeff_at_dyn(e, sum_idx);
 
-    let logup_challenge_i32 = e.int_const(32, witness_layout.challenges_start() as u64);
+    let logup_challenge_i32 = e.add_int_const(32, witness_layout.challenges_start() as u64);
 
     e.build_counted_loop(256, vec![], |e, i_i64, _| {
         let i_i32 = e.truncate(i_i64, 32);
@@ -3556,7 +3562,7 @@ fn emit_rngchk_8_ad_init_body(
         // out_db[0] += (-i_field) * coeff. `field_neg` isn't wired up in LLVM
         // codegen — express as `0 - i` so it goes through `__field_sub`.
         let i_field = u64_as_field(e, i_i64);
-        let zero_i64_f = e.int_const(64, 0);
+        let zero_i64_f = e.add_int_const(64, 0);
         let zero_field = u64_as_field(e, zero_i64_f);
         let neg_i_field = e.field_arith(FieldArithOp::Sub, zero_field, i_field);
         e.ad_write_const(DMatrix::B, neg_i_field, coeff);
@@ -3572,7 +3578,7 @@ fn emit_rngchk_8_ad_init_body(
     });
 
     // After the loop: out_db[0] += inv_sum_coeff
-    let one_i64 = e.int_const(64, 1);
+    let one_i64 = e.add_int_const(64, 1);
     let one_field = u64_as_field(e, one_i64);
     e.ad_write_const(DMatrix::B, one_field, inv_sum_coeff);
 
@@ -3632,7 +3638,7 @@ fn emit_array_ad_init_body(
         witness_layout,
         |e, inv_cnst_off| {
             let table_id_ptr = e.struct_field_ptr(array, rc_struct.clone(), 1);
-            let one_i32 = e.int_const(32, 1);
+            let one_i32 = e.add_int_const(32, 1);
             let snap = e.int_arith(IntArithOp::Add, inv_cnst_off, one_i32);
             let snap_u64 = e.zext(snap, 64);
             e.ll_store(table_id_ptr, snap_u64);
@@ -3666,7 +3672,7 @@ fn generate_darray_ad_call(
 
     let table_id_ptr = e.struct_field_ptr(array, rc_struct, 1);
     let snap = e.ll_load(table_id_ptr, LLType::i64());
-    let sentinel = e.int_const(64, u64::MAX);
+    let sentinel = e.add_int_const(64, u64::MAX);
     let is_unalloc = e.int_eq(snap, sentinel);
     let merge = e.build_if_else(
         is_unalloc,
@@ -3678,7 +3684,7 @@ fn generate_darray_ad_call(
         },
         |e| {
             let snap_i32 = e.truncate(snap, 32);
-            let one_i32 = e.int_const(32, 1);
+            let one_i32 = e.add_int_const(32, 1);
             let inv_cnst_off = e.int_arith(IntArithOp::Sub, snap_i32, one_i32);
             vec![inv_cnst_off]
         },
@@ -3726,7 +3732,7 @@ fn generate_dspread_ad_call(
 
     let snap_slot = e.global_addr(inv_cnst_off_global);
     let snap = e.ll_load(snap_slot, LLType::i32());
-    let zero_i32 = e.int_const(32, 0);
+    let zero_i32 = e.add_int_const(32, 0);
     let is_unalloc = e.int_eq(snap, zero_i32);
     let merge = e.build_if_else(
         is_unalloc,
@@ -3739,7 +3745,7 @@ fn generate_dspread_ad_call(
         |e| {
             let snap_slot = e.global_addr(inv_cnst_off_global);
             let snap = e.ll_load(snap_slot, LLType::i32());
-            let one_i32 = e.int_const(32, 1);
+            let one_i32 = e.add_int_const(32, 1);
             let inv_cnst_off = e.int_arith(IntArithOp::Sub, snap, one_i32);
             vec![inv_cnst_off]
         },
@@ -3801,7 +3807,7 @@ fn generate_drngchk_8_ad_call(
     // stores `inv_cnst_off + 1`. Zero means "not yet allocated".
     let snap_slot = e.global_addr(inv_cnst_off_global);
     let snap = e.ll_load(snap_slot, LLType::i32());
-    let zero_i32 = e.int_const(32, 0);
+    let zero_i32 = e.add_int_const(32, 0);
     let is_unalloc = e.int_eq(snap, zero_i32);
     let merge = e.build_if_else(
         is_unalloc,
@@ -3814,7 +3820,7 @@ fn generate_drngchk_8_ad_call(
             // Table already allocated — just reload the snapshot.
             let snap_slot = e.global_addr(inv_cnst_off_global);
             let snap = e.ll_load(snap_slot, LLType::i32());
-            let one_i32 = e.int_const(32, 1);
+            let one_i32 = e.add_int_const(32, 1);
             let inv_cnst_off = e.int_arith(IntArithOp::Sub, snap, one_i32);
             vec![inv_cnst_off]
         },
@@ -3822,7 +3828,7 @@ fn generate_drngchk_8_ad_call(
     let inv_cnst_off = merge[0];
 
     // inv_sum_coeff = ad_coeffs[inv_cnst_off + 256]
-    let two_fifty_six_i32 = e.int_const(32, 256);
+    let two_fifty_six_i32 = e.add_int_const(32, 256);
     let sum_idx = e.int_arith(IntArithOp::Add, inv_cnst_off, two_fifty_six_i32);
     let inv_sum_coeff = ad_read_coeff_at_dyn(&mut e, sum_idx);
 
@@ -3835,20 +3841,21 @@ fn generate_drngchk_8_ad_call(
     // lookups-section start offsets are layout-structural (a Lookup
     // section is one contiguous slab whose start is fixed by the layout),
     // not table-allocation dynamic, so they can stay as constants.
-    let lookups_wit_start_i32 = e.int_const(32, witness_layout.lookups_data_start() as u64);
-    let lookups_cnst_start_i32 = e.int_const(32, constraints_layout.lookups_data_start() as u64);
+    let lookups_wit_start_i32 = e.add_int_const(32, witness_layout.lookups_data_start() as u64);
+    let lookups_cnst_start_i32 =
+        e.add_int_const(32, constraints_layout.lookups_data_start() as u64);
     let n = e.int_arith(IntArithOp::Sub, inv_wit_off, lookups_wit_start_i32);
     let cnst_idx = e.int_arith(IntArithOp::Add, lookups_cnst_start_i32, n);
     let inv_coeff = ad_read_coeff_at_dyn(&mut e, cnst_idx);
 
     e.ad_write_witness(DMatrix::C, inv_wit_off, inv_sum_coeff);
     e.ad_write_witness(DMatrix::A, inv_wit_off, inv_coeff);
-    let logup_ch_i32 = e.int_const(32, witness_layout.challenges_start() as u64);
+    let logup_ch_i32 = e.add_int_const(32, witness_layout.challenges_start() as u64);
     e.ad_write_witness(DMatrix::B, logup_ch_i32, inv_coeff);
 
     // val.bump_db(-inv_coeff) — `0 - inv_coeff` via the Sub runtime
     // helper, matching the lowering of FieldArithOp::Sub.
-    let zero_i64 = e.int_const(64, 0);
+    let zero_i64 = e.add_int_const(64, 0);
     let zero_field = u64_as_field(&mut e, zero_i64);
     let neg_inv = e.field_arith(FieldArithOp::Sub, zero_field, inv_coeff);
     e.call(bump_db_fn, vec![val_ptr, neg_inv], 0);

--- a/compiler/src/compiler/ssa/hlssa_to_llssa.rs
+++ b/compiler/src/compiler/ssa/hlssa_to_llssa.rs
@@ -566,10 +566,10 @@ fn lower_constants_llssa(
     let mut emitter = LLBlockEmitter::new(ll_func, llssa, ll_entry_id);
     for (vid, limbs) in field_constants {
         let field_struct = LLStruct::field_elem();
-        let l0 = emitter.add_int_const(64, limbs[0]);
-        let l1 = emitter.add_int_const(64, limbs[1]);
-        let l2 = emitter.add_int_const(64, limbs[2]);
-        let l3 = emitter.add_int_const(64, limbs[3]);
+        let l0 = emitter.emit_int_const(64, limbs[0]);
+        let l1 = emitter.emit_int_const(64, limbs[1]);
+        let l2 = emitter.emit_int_const(64, limbs[2]);
+        let l3 = emitter.emit_int_const(64, limbs[3]);
         let ll_val = emitter.mk_struct(field_struct, vec![l0, l1, l2, l3]);
         val_map.insert(vid, ll_val);
     }
@@ -991,7 +991,7 @@ fn lower_instruction(
                             HLTypeExpr::U(64) | HLTypeExpr::I(64) => ll_value,
                             _ => panic!("Cast to Field from unsupported type: {}", source_type),
                         };
-                        let zero = e.add_int_const(64, 0);
+                        let zero = e.emit_int_const(64, 0);
                         let limbs = e.mk_struct(LLStruct::limbs(), vec![val64, zero, zero, zero]);
                         let field_val = e.field_from_limbs(limbs);
                         val_map.insert(*result, field_val);
@@ -1439,16 +1439,16 @@ fn lower_mk_array(
     // Init RC to 1
     let rc_hdr = e.struct_field_ptr(arr, rc_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.add_int_const(64, 1);
+    let one = e.emit_int_const(64, 1);
     e.ll_store(rc_word, one);
     let table_id = e.struct_field_ptr(arr, rc_struct.clone(), 1);
-    let unassigned = e.add_int_const(64, u64::MAX);
+    let unassigned = e.emit_int_const(64, u64::MAX);
     e.ll_store(table_id, unassigned);
 
     // Store elements
     let data = e.struct_field_ptr(arr, rc_struct, 2);
     for (i, elem) in elems.iter().enumerate() {
-        let idx = e.add_int_const(64, i as u64);
+        let idx = e.emit_int_const(64, i as u64);
         let elem_ptr = e.array_elem_ptr(data, es.clone(), idx);
         let ll_elem = val_map[elem];
         e.ll_store(elem_ptr, ll_elem);
@@ -1477,10 +1477,10 @@ fn lower_mk_repeated(
 
     let rc_hdr = e.struct_field_ptr(arr, rc_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.add_int_const(64, 1);
+    let one = e.emit_int_const(64, 1);
     e.ll_store(rc_word, one);
     let table_id = e.struct_field_ptr(arr, rc_struct.clone(), 1);
-    let unassigned = e.add_int_const(64, u64::MAX);
+    let unassigned = e.emit_int_const(64, u64::MAX);
     e.ll_store(table_id, unassigned);
 
     let data = e.struct_field_ptr(arr, rc_struct, 2);
@@ -1519,7 +1519,7 @@ fn lower_to_bytes(
     // Byte positions i >= 32 are structurally zero: the field representation
     // is only 32 bytes, so any higher byte is definitionally 0. Matches the
     // old VM `to_bytes_be` behavior of zero-padding past the field width.
-    let zero_byte = e.add_int_const(8, 0);
+    let zero_byte = e.emit_int_const(8, 0);
     let mut bytes_le = Vec::with_capacity(count);
     for i in 0..count {
         if i >= 32 {
@@ -1531,7 +1531,7 @@ fn lower_to_bytes(
         let shifted = if byte_offset == 0 {
             limb[limb_idx]
         } else {
-            let shift = e.add_int_const(64, byte_offset as u64);
+            let shift = e.emit_int_const(64, byte_offset as u64);
             e.int_arith(IntArithOp::UShr, limb[limb_idx], shift)
         };
         let byte_val = e.truncate(shifted, 8);
@@ -1548,10 +1548,10 @@ fn lower_to_bytes(
     // Init RC to 1
     let rc_hdr = e.struct_field_ptr(arr, rc_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.add_int_const(64, 1);
+    let one = e.emit_int_const(64, 1);
     e.ll_store(rc_word, one);
     let table_id = e.struct_field_ptr(arr, rc_struct.clone(), 1);
-    let unassigned = e.add_int_const(64, u64::MAX);
+    let unassigned = e.emit_int_const(64, u64::MAX);
     e.ll_store(table_id, unassigned);
 
     // Store bytes into the array
@@ -1561,7 +1561,7 @@ fn lower_to_bytes(
             Endianness::Big => count - 1 - i,
             Endianness::Little => i,
         };
-        let idx = e.add_int_const(64, i as u64);
+        let idx = e.emit_int_const(64, i as u64);
         let elem_ptr = e.array_elem_ptr(data, es.clone(), idx);
         e.ll_store(elem_ptr, bytes_le[src_idx]);
     }
@@ -1585,7 +1585,7 @@ fn lower_mk_tuple(
     // Init RC to 1
     let rc_hdr = e.struct_field_ptr(tuple_ptr, rc_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.add_int_const(64, 1);
+    let one = e.emit_int_const(64, 1);
     e.ll_store(rc_word, one);
 
     // Store each element into its field (fields are at index 1, 2, 3, ...)
@@ -1636,12 +1636,12 @@ fn lower_alloc(
 
     let rc_hdr = e.struct_field_ptr(ptr, rc_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.add_int_const(64, 1);
+    let one = e.emit_int_const(64, 1);
     e.ll_store(rc_word, one);
 
     if needs_drop(&elem_type.expr) {
         let slot = e.struct_field_ptr(ptr, rc_struct, 1);
-        let null = e.add_nullptr_const();
+        let null = e.emit_nullptr_const();
         e.ll_store(slot, null);
     }
 
@@ -1667,7 +1667,7 @@ fn lower_ref_store(
     if needs_drop(&inner_type.expr) {
         let drop_fn = get_or_create_drop_fn(inner_type, e.ssa, drop_fns, ad_fns);
         let old = e.ll_load(slot, LLType::Ptr);
-        let null = e.add_nullptr_const();
+        let null = e.emit_nullptr_const();
         let is_null = e.int_eq(old, null);
         e.build_if_else(
             is_null,
@@ -1780,7 +1780,7 @@ fn lower_array_set(
     let hdr = e.struct_field_ptr(ll_arr, rc_struct.clone(), 0);
     let rc_ptr = e.struct_field_ptr(hdr, LLStruct::rc_header(), 0);
     let rc = e.ll_load(rc_ptr, LLType::i64());
-    let one = e.add_int_const(64, 1);
+    let one = e.emit_int_const(64, 1);
     let unique = e.int_eq(rc, one);
 
     let merge_results = e.build_if_else(
@@ -1799,7 +1799,7 @@ fn lower_array_set(
 
             me.ll_store(slot, ll_val);
             let table_id = me.struct_field_ptr(ll_arr, rc_struct.clone(), 1);
-            let unassigned = me.add_int_const(64, u64::MAX);
+            let unassigned = me.emit_int_const(64, u64::MAX);
             me.ll_store(table_id, unassigned);
             vec![ll_arr]
         },
@@ -1817,13 +1817,13 @@ fn lower_array_set(
             let new_rc_ptr = ce.struct_field_ptr(new_hdr, LLStruct::rc_header(), 0);
             ce.ll_store(new_rc_ptr, one);
             let new_table_id = ce.struct_field_ptr(new_arr, rc_struct.clone(), 1);
-            let unassigned = ce.add_int_const(64, u64::MAX);
+            let unassigned = ce.emit_int_const(64, u64::MAX);
             ce.ll_store(new_table_id, unassigned);
 
             // Copy all data
             let old_data = ce.struct_field_ptr(ll_arr, rc_struct.clone(), 2);
             let new_data = ce.struct_field_ptr(new_arr, rc_struct.clone(), 2);
-            let count_val = ce.add_int_const(64, count as u64);
+            let count_val = ce.emit_int_const(64, count as u64);
             ce.memcpy(new_data, old_data, es.clone(), Some(count_val));
 
             // Bump RC of all copied elements except the one we're overwriting
@@ -1886,7 +1886,7 @@ fn lower_rc_bump(
     let hdr = e.struct_field_ptr(ll_arr, rc_struct, 0);
     let rc_ptr = e.struct_field_ptr(hdr, LLStruct::rc_header(), 0);
     let rc = e.ll_load(rc_ptr, LLType::i64());
-    let n_val = e.add_int_const(64, n as u64);
+    let n_val = e.emit_int_const(64, n as u64);
     let new_rc = e.int_add(rc, n_val);
     e.ll_store(rc_ptr, new_rc);
 }
@@ -1926,7 +1926,7 @@ fn ensure_field_sized(
         HLTypeExpr::U(64) | HLTypeExpr::I(64) => ll_val,
         _ => panic!("ensure_field_sized: unsupported type: {}", source_type),
     };
-    let zero = e.add_int_const(64, 0);
+    let zero = e.emit_int_const(64, 0);
     let limbs = e.mk_struct(LLStruct::limbs(), vec![val64, zero, zero, zero]);
     e.field_from_limbs(limbs)
 }
@@ -1946,12 +1946,12 @@ fn lower_ad_const_wrap(
     // RC = 1
     let rc_hdr = e.struct_field_ptr(node, node_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.add_int_const(64, 1);
+    let one = e.emit_int_const(64, 1);
     e.ll_store(rc_word, one);
 
     // tag = AD_TAG_CONST
     let tag_ptr = e.struct_field_ptr(node, node_struct.clone(), 1);
-    let tag = e.add_int_const(32, LLStruct::AD_TAG_CONST);
+    let tag = e.emit_int_const(32, LLStruct::AD_TAG_CONST);
     e.ll_store(tag_ptr, tag);
 
     // value = field element
@@ -1973,12 +1973,12 @@ fn lower_ad_fresh_witness(
     // RC = 1
     let rc_hdr = e.struct_field_ptr(node, node_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.add_int_const(64, 1);
+    let one = e.emit_int_const(64, 1);
     e.ll_store(rc_word, one);
 
     // tag = AD_TAG_WITNESS
     let tag_ptr = e.struct_field_ptr(node, node_struct.clone(), 1);
-    let tag = e.add_int_const(32, LLStruct::AD_TAG_WITNESS);
+    let tag = e.emit_int_const(32, LLStruct::AD_TAG_WITNESS);
     e.ll_store(tag_ptr, tag);
 
     // index = next witness index from VM
@@ -1998,12 +1998,12 @@ fn lower_ad_sum(e: &mut LLBlockEmitter<'_>, ll_a: ValueId, ll_b: ValueId) -> Val
     // RC = 1
     let rc_hdr = e.struct_field_ptr(node, node_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.add_int_const(64, 1);
+    let one = e.emit_int_const(64, 1);
     e.ll_store(rc_word, one);
 
     // tag = AD_TAG_SUM
     let tag_ptr = e.struct_field_ptr(node, node_struct.clone(), 1);
-    let tag = e.add_int_const(32, LLStruct::AD_TAG_SUM);
+    let tag = e.emit_int_const(32, LLStruct::AD_TAG_SUM);
     e.ll_store(tag_ptr, tag);
 
     // a, b = children
@@ -2041,12 +2041,12 @@ fn lower_ad_mul_const(
     // RC = 1
     let rc_hdr = e.struct_field_ptr(node, node_struct.clone(), 0);
     let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.add_int_const(64, 1);
+    let one = e.emit_int_const(64, 1);
     e.ll_store(rc_word, one);
 
     // tag = AD_TAG_MUL_CONST
     let tag_ptr = e.struct_field_ptr(node, node_struct.clone(), 1);
-    let tag = e.add_int_const(32, LLStruct::AD_TAG_MUL_CONST);
+    let tag = e.emit_int_const(32, LLStruct::AD_TAG_MUL_CONST);
     e.ll_store(tag_ptr, tag);
 
     // coeff
@@ -2081,7 +2081,7 @@ fn lower_ad_rc_bump(
     let hdr = e.struct_field_ptr(ll_node, base, 0);
     let rc_ptr = e.struct_field_ptr(hdr, LLStruct::rc_header(), 0);
     let rc = e.ll_load(rc_ptr, LLType::i64());
-    let n_val = e.add_int_const(64, n as u64);
+    let n_val = e.emit_int_const(64, n as u64);
     let new_rc = e.int_add(rc, n_val);
     e.ll_store(rc_ptr, new_rc);
 }
@@ -2100,7 +2100,7 @@ fn lower_ad_rc_drop(
 
 /// Construct a zero field element as a struct value.
 fn make_field_zero(e: &mut LLBlockEmitter<'_>) -> ValueId {
-    let z = e.add_int_const(64, 0);
+    let z = e.emit_int_const(64, 0);
     e.mk_struct(LLStruct::field_elem(), vec![z, z, z, z])
 }
 
@@ -2158,7 +2158,7 @@ fn generate_ad_bump_function(llssa: &mut LLSSA, matrix: DMatrix) -> LLFunction {
     let tag = e.ll_load(tag_ptr, LLType::i32());
 
     // CONST?
-    let const_tag = e.add_int_const(32, LLStruct::AD_TAG_CONST);
+    let const_tag = e.emit_int_const(32, LLStruct::AD_TAG_CONST);
     let is_const = e.int_eq(tag, const_tag);
     e.build_if_else(
         is_const,
@@ -2174,7 +2174,7 @@ fn generate_ad_bump_function(llssa: &mut LLSSA, matrix: DMatrix) -> LLFunction {
             // Not CONST — check WITNESS
             let tag_ptr = e.struct_field_ptr(node, LLStruct::ad_node_base(), 1);
             let tag = e.ll_load(tag_ptr, LLType::i32());
-            let wit_tag = e.add_int_const(32, LLStruct::AD_TAG_WITNESS);
+            let wit_tag = e.emit_int_const(32, LLStruct::AD_TAG_WITNESS);
             let is_wit = e.int_eq(tag, wit_tag);
             e.build_if_else(
                 is_wit,
@@ -2191,7 +2191,7 @@ fn generate_ad_bump_function(llssa: &mut LLSSA, matrix: DMatrix) -> LLFunction {
                     // SUM or MUL_CONST: accumulate into node.d{a,b,c}
                     let tag_ptr = e.struct_field_ptr(node, LLStruct::ad_node_base(), 1);
                     let tag = e.ll_load(tag_ptr, LLType::i32());
-                    let sum_tag = e.add_int_const(32, LLStruct::AD_TAG_SUM);
+                    let sum_tag = e.emit_int_const(32, LLStruct::AD_TAG_SUM);
                     let is_sum = e.int_eq(tag, sum_tag);
                     e.build_if_else(
                         is_sum,
@@ -2255,12 +2255,12 @@ fn generate_ad_drop_function(
     let rc_hdr = e.struct_field_ptr(node, LLStruct::ad_node_base(), 0);
     let rc_ptr = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
     let rc = e.ll_load(rc_ptr, LLType::i64());
-    let one = e.add_int_const(64, 1);
+    let one = e.emit_int_const(64, 1);
     let new_rc = e.int_sub(rc, one);
     e.ll_store(rc_ptr, new_rc);
 
     // If RC hit zero, dispatch on tag and tear down
-    let zero = e.add_int_const(64, 0);
+    let zero = e.emit_int_const(64, 0);
     let dead = e.int_eq(new_rc, zero);
     e.build_if_else(
         dead,
@@ -2271,7 +2271,7 @@ fn generate_ad_drop_function(
             let tag = e.ll_load(tag_ptr, LLType::i32());
 
             // CONST or WITNESS (tag < 2) → just free
-            let two = e.add_int_const(32, 2);
+            let two = e.emit_int_const(32, 2);
             let is_simple = e.int_ult(tag, two);
             e.build_if_else(
                 is_simple,
@@ -2284,7 +2284,7 @@ fn generate_ad_drop_function(
                     // SUM or MUL_CONST
                     let tag_ptr = e.struct_field_ptr(node, LLStruct::ad_node_base(), 1);
                     let tag = e.ll_load(tag_ptr, LLType::i32());
-                    let sum_tag = e.add_int_const(32, LLStruct::AD_TAG_SUM);
+                    let sum_tag = e.emit_int_const(32, LLStruct::AD_TAG_SUM);
                     let is_sum = e.int_eq(tag, sum_tag);
                     e.build_if_else(
                         is_sum,
@@ -2421,12 +2421,12 @@ fn generate_drop_function_for_array(
     let hdr = e.struct_field_ptr(ptr, rc_struct.clone(), 0);
     let rc_ptr = e.struct_field_ptr(hdr, LLStruct::rc_header(), 0);
     let rc = e.ll_load(rc_ptr, LLType::i64());
-    let one = e.add_int_const(64, 1);
+    let one = e.emit_int_const(64, 1);
     let new_rc = e.int_sub(rc, one);
     e.ll_store(rc_ptr, new_rc);
 
     // If RC hit zero, drop inner elements and free
-    let zero = e.add_int_const(64, 0);
+    let zero = e.emit_int_const(64, 0);
     let dead = e.int_eq(new_rc, zero);
     e.build_if_else(
         dead,
@@ -2488,12 +2488,12 @@ fn generate_drop_function_for_tuple(
     let hdr = e.struct_field_ptr(ptr, rc_struct.clone(), 0);
     let rc_ptr = e.struct_field_ptr(hdr, LLStruct::rc_header(), 0);
     let rc = e.ll_load(rc_ptr, LLType::i64());
-    let one = e.add_int_const(64, 1);
+    let one = e.emit_int_const(64, 1);
     let new_rc = e.int_sub(rc, one);
     e.ll_store(rc_ptr, new_rc);
 
     // If RC hit zero, drop inner heap-allocated elements and free
-    let zero = e.add_int_const(64, 0);
+    let zero = e.emit_int_const(64, 0);
     let dead = e.int_eq(new_rc, zero);
     e.build_if_else(
         dead,
@@ -2556,11 +2556,11 @@ fn generate_drop_function_for_ref(
     let hdr = e.struct_field_ptr(ptr, rc_struct.clone(), 0);
     let rc_ptr = e.struct_field_ptr(hdr, LLStruct::rc_header(), 0);
     let rc = e.ll_load(rc_ptr, LLType::i64());
-    let one = e.add_int_const(64, 1);
+    let one = e.emit_int_const(64, 1);
     let new_rc = e.int_sub(rc, one);
     e.ll_store(rc_ptr, new_rc);
 
-    let zero = e.add_int_const(64, 0);
+    let zero = e.emit_int_const(64, 0);
     let dead = e.int_eq(new_rc, zero);
     e.build_if_else(
         dead,
@@ -2575,7 +2575,7 @@ fn generate_drop_function_for_ref(
 
                 let slot = e.struct_field_ptr(ptr, rc_struct.clone(), 1);
                 let inner_val = e.ll_load(slot, LLType::Ptr);
-                let null = e.add_nullptr_const();
+                let null = e.emit_nullptr_const();
                 let is_null = e.int_eq(inner_val, null);
                 e.build_if_else(
                     is_null,
@@ -2770,13 +2770,13 @@ fn assert(e: &mut LLBlockEmitter<'_>, ok: ValueId) {
 
 /// Build a Field whose low limb is `lo` and upper limbs are zero.
 fn u64_as_field(e: &mut LLBlockEmitter<'_>, lo: ValueId) -> ValueId {
-    let zero = e.add_int_const(64, 0);
+    let zero = e.emit_int_const(64, 0);
     let limbs = e.mk_struct(LLStruct::limbs(), vec![lo, zero, zero, zero]);
     e.field_from_limbs(limbs)
 }
 
 fn field_neg_via_sub(e: &mut LLBlockEmitter<'_>, value: ValueId) -> ValueId {
-    let zero_i64 = e.add_int_const(64, 0);
+    let zero_i64 = e.emit_int_const(64, 0);
     let zero_field = u64_as_field(e, zero_i64);
     e.field_arith(FieldArithOp::Sub, zero_field, value)
 }
@@ -2791,7 +2791,7 @@ fn write_tape_entry_u64(e: &mut LLBlockEmitter<'_>, cursor_field: usize, value_u
     let low_ptr = e.struct_field_ptr(cursor, LLStruct::field_elem(), 0);
     e.ll_store(low_ptr, value_u64);
     // Advance cursor by one Field (4 i64s).
-    let one = e.add_int_const(32, 1);
+    let one = e.emit_int_const(32, 1);
     let next = e.array_elem_ptr(cursor, LLStruct::field_elem(), one);
     e.ll_store(cursor_slot, next);
 }
@@ -2801,7 +2801,7 @@ fn write_tape_entry_field(e: &mut LLBlockEmitter<'_>, cursor_field: usize, field
     let cursor_slot = e.witgen_vm_field_ptr(cursor_field);
     let cursor = e.ll_load(cursor_slot, LLType::Ptr);
     e.ll_store(cursor, field_val);
-    let one = e.add_int_const(32, 1);
+    let one = e.emit_int_const(32, 1);
     let next = e.array_elem_ptr(cursor, LLStruct::field_elem(), one);
     e.ll_store(cursor_slot, next);
 }
@@ -2903,14 +2903,14 @@ fn get_or_init_forward_lookup_table(
         ForwardLookupTableState::Global { table_idx_global } => {
             let snap_idx_slot = e.global_addr(table_idx_global);
             let snap_idx_plus_one = e.ll_load(snap_idx_slot, LLType::i32());
-            let zero_i32 = e.add_int_const(32, 0);
+            let zero_i32 = e.emit_int_const(32, 0);
             e.int_eq(snap_idx_plus_one, zero_i32)
         }
         ForwardLookupTableState::Array {
             table_id_or_sentinel,
             ..
         } => {
-            let sentinel = e.add_int_const(64, u64::MAX);
+            let sentinel = e.emit_int_const(64, u64::MAX);
             e.int_eq(table_id_or_sentinel, sentinel)
         }
     };
@@ -2934,11 +2934,11 @@ fn get_or_init_forward_lookup_table(
             let inv_wit_off = e.ll_load(wit_cursor_slot, LLType::i32());
 
             let slot_ptr = witgen_table_info_ptr(e, table_idx);
-            let one_i32 = e.add_int_const(32, 1);
-            let table_len_i32 = e.add_int_const(32, lookup.length as u64);
-            let table_values_i32 = e.add_int_const(32, lookup.num_values());
-            let table_wit_bump_i32 = e.add_int_const(32, lookup.witness_slots() as u64);
-            let table_cnst_bump_i32 = e.add_int_const(32, lookup.constraint_slots() as u64);
+            let one_i32 = e.emit_int_const(32, 1);
+            let table_len_i32 = e.emit_int_const(32, lookup.length as u64);
+            let table_values_i32 = e.emit_int_const(32, lookup.num_values());
+            let table_wit_bump_i32 = e.emit_int_const(32, lookup.witness_slots() as u64);
+            let table_cnst_bump_i32 = e.emit_int_const(32, lookup.constraint_slots() as u64);
             let table_info_writes = [
                 (LLStruct::TABLE_INFO_MULTS_BASE, mults_base),
                 (LLStruct::TABLE_INFO_INV_CNST_OFF, inv_cnst_off),
@@ -2981,7 +2981,7 @@ fn get_or_init_forward_lookup_table(
                 ForwardLookupTableState::Global { table_idx_global } => {
                     let snap_idx_slot = e.global_addr(table_idx_global);
                     let snap_idx_plus_one = e.ll_load(snap_idx_slot, LLType::i32());
-                    let one_i32 = e.add_int_const(32, 1);
+                    let one_i32 = e.emit_int_const(32, 1);
                     e.int_arith(IntArithOp::Sub, snap_idx_plus_one, one_i32)
                 }
                 ForwardLookupTableState::Array {
@@ -3018,7 +3018,7 @@ fn emit_forward_lookup_key_entry(
             vec![]
         },
         |e| {
-            let table_len_i64 = e.add_int_const(64, lookup.length as u64);
+            let table_len_i64 = e.emit_int_const(64, lookup.length as u64);
             let in_range = e.int_ult(key, table_len_i64);
             assert(e, in_range);
             for high in key_high_limbs {
@@ -3146,7 +3146,7 @@ fn generate_array_lookup_function(llssa: &mut LLSSA, array_type: &HLType) -> LLF
     let key = key_l0;
     let flag_u64 = flag_l0;
 
-    let zero_i64 = e.add_int_const(64, 0);
+    let zero_i64 = e.emit_int_const(64, 0);
     for high in [flag_l1, flag_l2, flag_l3] {
         let ok = e.int_eq(high, zero_i64);
         assert(&mut e, ok);
@@ -3169,7 +3169,7 @@ fn generate_array_lookup_function(llssa: &mut LLSSA, array_type: &HLType) -> LLF
                 let elem_ptr = e.array_elem_ptr(data, elem_struct.clone(), i_i64);
                 let elem_field = load_pure_lookup_elem_as_field(e, elem_ptr, elem_type);
                 let i_i32 = e.truncate(i_i64, 32);
-                let two_i32 = e.add_int_const(32, 2);
+                let two_i32 = e.emit_int_const(32, 2);
                 let doubled_i = e.int_arith(IntArithOp::Mul, i_i32, two_i32);
                 let table_slot_idx = e.int_arith(IntArithOp::Add, inv_cnst_off, doubled_i);
                 let table_slot = e.array_elem_ptr(a_base, LLStruct::field_elem(), table_slot_idx);
@@ -3224,7 +3224,7 @@ fn generate_spread_lookup_function(
     let key = key_l0;
     let flag_u64 = flag_l0;
 
-    let zero_i64 = e.add_int_const(64, 0);
+    let zero_i64 = e.emit_int_const(64, 0);
     // flag is 0 or 1 by construction; sanity-check its high BigInt limbs.
     // `key`'s high limbs and `key < length` are validated only when
     // `flag != 0` (see post-merge tape emission below), matching the VM's
@@ -3253,7 +3253,7 @@ fn generate_spread_lookup_function(
                 };
                 let spread_field = u64_as_field(e, spread_u64);
                 let i_i32 = e.truncate(i_i64, 32);
-                let two_i32 = e.add_int_const(32, 2);
+                let two_i32 = e.emit_int_const(32, 2);
                 let doubled_i = e.int_arith(IntArithOp::Mul, i_i32, two_i32);
                 let table_idx = e.int_arith(IntArithOp::Add, inv_cnst_off, doubled_i);
                 let table_slot = e.array_elem_ptr(a_base, LLStruct::field_elem(), table_idx);
@@ -3319,7 +3319,7 @@ fn generate_rngchk_8_function(llssa: &mut LLSSA, table_idx_global: usize) -> LLF
     let key = val_l0;
 
     // flag is 0 or 1 by construction; sanity-check its high BigInt limbs.
-    let zero_i64 = e.add_int_const(64, 0);
+    let zero_i64 = e.emit_int_const(64, 0);
     for high in [flag_l1, flag_l2, flag_l3] {
         let ok = e.int_eq(high, zero_i64);
         assert(&mut e, ok);
@@ -3357,7 +3357,7 @@ fn generate_rngchk_8_function(llssa: &mut LLSSA, table_idx_global: usize) -> LLF
 fn ad_next_lookup_wit_off(e: &mut LLBlockEmitter<'_>) -> ValueId {
     let slot = e.ad_vm_field_ptr(LLStruct::AD_VM_CURRENT_LOOKUP_WIT_OFF);
     let idx = e.ll_load(slot, LLType::i32());
-    let one = e.add_int_const(32, 1);
+    let one = e.emit_int_const(32, 1);
     let next = e.int_add(idx, one);
     e.ll_store(slot, next);
     idx
@@ -3384,13 +3384,13 @@ fn claim_ad_lookup_table_region(
     let wit_mults_slot = e.ad_vm_field_ptr(LLStruct::AD_VM_CURRENT_WIT_MULTIPLICITIES_OFF);
     let mults_wit_off = e.ll_load(wit_mults_slot, LLType::i32());
 
-    let cnst_bump = e.add_int_const(32, lookup.constraint_slots() as u64);
+    let cnst_bump = e.emit_int_const(32, lookup.constraint_slots() as u64);
     let next_cnst = e.int_arith(IntArithOp::Add, inv_cnst_off, cnst_bump);
     e.ll_store(cnst_tables_slot, next_cnst);
-    let wit_bump = e.add_int_const(32, lookup.witness_slots() as u64);
+    let wit_bump = e.emit_int_const(32, lookup.witness_slots() as u64);
     let next_wit = e.int_arith(IntArithOp::Add, inv_wit_off, wit_bump);
     e.ll_store(wit_tables_slot, next_wit);
-    let mults_bump = e.add_int_const(32, lookup.length as u64);
+    let mults_bump = e.emit_int_const(32, lookup.length as u64);
     let next_mults = e.int_arith(IntArithOp::Add, mults_wit_off, mults_bump);
     e.ll_store(wit_mults_slot, next_mults);
 
@@ -3403,7 +3403,7 @@ fn store_ad_global_snapshot(
     inv_cnst_off: ValueId,
 ) {
     let snap_slot = e.global_addr(inv_cnst_off_global);
-    let one_i32 = e.add_int_const(32, 1);
+    let one_i32 = e.emit_int_const(32, 1);
     let snap = e.int_arith(IntArithOp::Add, inv_cnst_off, one_i32);
     e.ll_store(snap_slot, snap);
 }
@@ -3420,18 +3420,18 @@ fn emit_key_value_ad_table_init_body(
     let (inv_cnst_off, inv_wit_off, mults_wit_off) = claim_ad_lookup_table_region(e, lookup);
     save_table_snapshot(e, inv_cnst_off);
 
-    let sum_offset_i32 = e.add_int_const(32, lookup.sum_constraint_offset() as u64);
+    let sum_offset_i32 = e.emit_int_const(32, lookup.sum_constraint_offset() as u64);
     let sum_idx = e.int_arith(IntArithOp::Add, inv_cnst_off, sum_offset_i32);
     let inv_sum_coeff = ad_read_coeff_at_dyn(e, sum_idx);
-    let logup_alpha_i32 = e.add_int_const(32, witness_layout.challenges_start() as u64);
-    let logup_beta_i32 = e.add_int_const(32, witness_layout.challenges_start() as u64 + 1);
+    let logup_alpha_i32 = e.emit_int_const(32, witness_layout.challenges_start() as u64);
+    let logup_beta_i32 = e.emit_int_const(32, witness_layout.challenges_start() as u64 + 1);
 
     e.build_counted_loop(lookup.length, vec![], |e, i_i64, _| {
         let i_i32 = e.truncate(i_i64, 32);
-        let two_i32 = e.add_int_const(32, 2);
+        let two_i32 = e.emit_int_const(32, 2);
         let twice_i = e.int_arith(IntArithOp::Mul, i_i32, two_i32);
         let x_cnst_idx = e.int_arith(IntArithOp::Add, inv_cnst_off, twice_i);
-        let one_i32 = e.add_int_const(32, 1);
+        let one_i32 = e.emit_int_const(32, 1);
         let y_cnst_idx = e.int_arith(IntArithOp::Add, x_cnst_idx, one_i32);
         let x_coeff = ad_read_coeff_at_dyn(e, x_cnst_idx);
         let y_coeff = ad_read_coeff_at_dyn(e, y_cnst_idx);
@@ -3459,7 +3459,7 @@ fn emit_key_value_ad_table_init_body(
         vec![]
     });
 
-    let one_i64 = e.add_int_const(64, 1);
+    let one_i64 = e.emit_int_const(64, 1);
     let one_field = u64_as_field(e, one_i64);
     e.ad_write_const(DMatrix::B, one_field, inv_sum_coeff);
 
@@ -3480,15 +3480,15 @@ fn emit_key_value_ad_lookup_call_body(
 ) {
     lookup.assert_key_value("AD lookup call");
 
-    let sum_offset_i32 = e.add_int_const(32, lookup.sum_constraint_offset() as u64);
+    let sum_offset_i32 = e.emit_int_const(32, lookup.sum_constraint_offset() as u64);
     let sum_idx = e.int_arith(IntArithOp::Add, inv_cnst_off, sum_offset_i32);
     let inv_sum_coeff = ad_read_coeff_at_dyn(e, sum_idx);
 
     let x_wit_off = ad_next_lookup_wit_off(e);
     let y_wit_off = ad_next_lookup_wit_off(e);
-    let lookups_wit_start_i32 = e.add_int_const(32, witness_layout.lookups_data_start() as u64);
+    let lookups_wit_start_i32 = e.emit_int_const(32, witness_layout.lookups_data_start() as u64);
     let lookups_cnst_start_i32 =
-        e.add_int_const(32, constraints_layout.lookups_data_start() as u64);
+        e.emit_int_const(32, constraints_layout.lookups_data_start() as u64);
     let x_n = e.int_arith(IntArithOp::Sub, x_wit_off, lookups_wit_start_i32);
     let x_cnst_idx = e.int_arith(IntArithOp::Add, lookups_cnst_start_i32, x_n);
     let y_n = e.int_arith(IntArithOp::Sub, y_wit_off, lookups_wit_start_i32);
@@ -3496,8 +3496,8 @@ fn emit_key_value_ad_lookup_call_body(
     let x_coeff = ad_read_coeff_at_dyn(e, x_cnst_idx);
     let y_coeff = ad_read_coeff_at_dyn(e, y_cnst_idx);
 
-    let logup_alpha_i32 = e.add_int_const(32, witness_layout.challenges_start() as u64);
-    let logup_beta_i32 = e.add_int_const(32, witness_layout.challenges_start() as u64 + 1);
+    let logup_alpha_i32 = e.emit_int_const(32, witness_layout.challenges_start() as u64);
+    let logup_beta_i32 = e.emit_int_const(32, witness_layout.challenges_start() as u64 + 1);
 
     e.ad_write_witness(DMatrix::A, logup_beta_i32, x_coeff);
     e.call(bump_db_fn, vec![result_ptr, x_coeff], 0);
@@ -3538,11 +3538,11 @@ fn emit_rngchk_8_ad_init_body(
 
     // inv_sum_coeff sits at the sum-constraint AD coefficient (one past the
     // 256 per-element coefficients for this table).
-    let two_fifty_six_i32 = e.add_int_const(32, 256);
+    let two_fifty_six_i32 = e.emit_int_const(32, 256);
     let sum_idx = e.int_arith(IntArithOp::Add, inv_cnst_off, two_fifty_six_i32);
     let inv_sum_coeff = ad_read_coeff_at_dyn(e, sum_idx);
 
-    let logup_challenge_i32 = e.add_int_const(32, witness_layout.challenges_start() as u64);
+    let logup_challenge_i32 = e.emit_int_const(32, witness_layout.challenges_start() as u64);
 
     e.build_counted_loop(256, vec![], |e, i_i64, _| {
         let i_i32 = e.truncate(i_i64, 32);
@@ -3562,7 +3562,7 @@ fn emit_rngchk_8_ad_init_body(
         // out_db[0] += (-i_field) * coeff. `field_neg` isn't wired up in LLVM
         // codegen — express as `0 - i` so it goes through `__field_sub`.
         let i_field = u64_as_field(e, i_i64);
-        let zero_i64_f = e.add_int_const(64, 0);
+        let zero_i64_f = e.emit_int_const(64, 0);
         let zero_field = u64_as_field(e, zero_i64_f);
         let neg_i_field = e.field_arith(FieldArithOp::Sub, zero_field, i_field);
         e.ad_write_const(DMatrix::B, neg_i_field, coeff);
@@ -3578,7 +3578,7 @@ fn emit_rngchk_8_ad_init_body(
     });
 
     // After the loop: out_db[0] += inv_sum_coeff
-    let one_i64 = e.add_int_const(64, 1);
+    let one_i64 = e.emit_int_const(64, 1);
     let one_field = u64_as_field(e, one_i64);
     e.ad_write_const(DMatrix::B, one_field, inv_sum_coeff);
 
@@ -3638,7 +3638,7 @@ fn emit_array_ad_init_body(
         witness_layout,
         |e, inv_cnst_off| {
             let table_id_ptr = e.struct_field_ptr(array, rc_struct.clone(), 1);
-            let one_i32 = e.add_int_const(32, 1);
+            let one_i32 = e.emit_int_const(32, 1);
             let snap = e.int_arith(IntArithOp::Add, inv_cnst_off, one_i32);
             let snap_u64 = e.zext(snap, 64);
             e.ll_store(table_id_ptr, snap_u64);
@@ -3672,7 +3672,7 @@ fn generate_darray_ad_call(
 
     let table_id_ptr = e.struct_field_ptr(array, rc_struct, 1);
     let snap = e.ll_load(table_id_ptr, LLType::i64());
-    let sentinel = e.add_int_const(64, u64::MAX);
+    let sentinel = e.emit_int_const(64, u64::MAX);
     let is_unalloc = e.int_eq(snap, sentinel);
     let merge = e.build_if_else(
         is_unalloc,
@@ -3684,7 +3684,7 @@ fn generate_darray_ad_call(
         },
         |e| {
             let snap_i32 = e.truncate(snap, 32);
-            let one_i32 = e.add_int_const(32, 1);
+            let one_i32 = e.emit_int_const(32, 1);
             let inv_cnst_off = e.int_arith(IntArithOp::Sub, snap_i32, one_i32);
             vec![inv_cnst_off]
         },
@@ -3732,7 +3732,7 @@ fn generate_dspread_ad_call(
 
     let snap_slot = e.global_addr(inv_cnst_off_global);
     let snap = e.ll_load(snap_slot, LLType::i32());
-    let zero_i32 = e.add_int_const(32, 0);
+    let zero_i32 = e.emit_int_const(32, 0);
     let is_unalloc = e.int_eq(snap, zero_i32);
     let merge = e.build_if_else(
         is_unalloc,
@@ -3745,7 +3745,7 @@ fn generate_dspread_ad_call(
         |e| {
             let snap_slot = e.global_addr(inv_cnst_off_global);
             let snap = e.ll_load(snap_slot, LLType::i32());
-            let one_i32 = e.add_int_const(32, 1);
+            let one_i32 = e.emit_int_const(32, 1);
             let inv_cnst_off = e.int_arith(IntArithOp::Sub, snap, one_i32);
             vec![inv_cnst_off]
         },
@@ -3807,7 +3807,7 @@ fn generate_drngchk_8_ad_call(
     // stores `inv_cnst_off + 1`. Zero means "not yet allocated".
     let snap_slot = e.global_addr(inv_cnst_off_global);
     let snap = e.ll_load(snap_slot, LLType::i32());
-    let zero_i32 = e.add_int_const(32, 0);
+    let zero_i32 = e.emit_int_const(32, 0);
     let is_unalloc = e.int_eq(snap, zero_i32);
     let merge = e.build_if_else(
         is_unalloc,
@@ -3820,7 +3820,7 @@ fn generate_drngchk_8_ad_call(
             // Table already allocated — just reload the snapshot.
             let snap_slot = e.global_addr(inv_cnst_off_global);
             let snap = e.ll_load(snap_slot, LLType::i32());
-            let one_i32 = e.add_int_const(32, 1);
+            let one_i32 = e.emit_int_const(32, 1);
             let inv_cnst_off = e.int_arith(IntArithOp::Sub, snap, one_i32);
             vec![inv_cnst_off]
         },
@@ -3828,7 +3828,7 @@ fn generate_drngchk_8_ad_call(
     let inv_cnst_off = merge[0];
 
     // inv_sum_coeff = ad_coeffs[inv_cnst_off + 256]
-    let two_fifty_six_i32 = e.add_int_const(32, 256);
+    let two_fifty_six_i32 = e.emit_int_const(32, 256);
     let sum_idx = e.int_arith(IntArithOp::Add, inv_cnst_off, two_fifty_six_i32);
     let inv_sum_coeff = ad_read_coeff_at_dyn(&mut e, sum_idx);
 
@@ -3841,21 +3841,21 @@ fn generate_drngchk_8_ad_call(
     // lookups-section start offsets are layout-structural (a Lookup
     // section is one contiguous slab whose start is fixed by the layout),
     // not table-allocation dynamic, so they can stay as constants.
-    let lookups_wit_start_i32 = e.add_int_const(32, witness_layout.lookups_data_start() as u64);
+    let lookups_wit_start_i32 = e.emit_int_const(32, witness_layout.lookups_data_start() as u64);
     let lookups_cnst_start_i32 =
-        e.add_int_const(32, constraints_layout.lookups_data_start() as u64);
+        e.emit_int_const(32, constraints_layout.lookups_data_start() as u64);
     let n = e.int_arith(IntArithOp::Sub, inv_wit_off, lookups_wit_start_i32);
     let cnst_idx = e.int_arith(IntArithOp::Add, lookups_cnst_start_i32, n);
     let inv_coeff = ad_read_coeff_at_dyn(&mut e, cnst_idx);
 
     e.ad_write_witness(DMatrix::C, inv_wit_off, inv_sum_coeff);
     e.ad_write_witness(DMatrix::A, inv_wit_off, inv_coeff);
-    let logup_ch_i32 = e.add_int_const(32, witness_layout.challenges_start() as u64);
+    let logup_ch_i32 = e.emit_int_const(32, witness_layout.challenges_start() as u64);
     e.ad_write_witness(DMatrix::B, logup_ch_i32, inv_coeff);
 
     // val.bump_db(-inv_coeff) — `0 - inv_coeff` via the Sub runtime
     // helper, matching the lowering of FieldArithOp::Sub.
-    let zero_i64 = e.add_int_const(64, 0);
+    let zero_i64 = e.emit_int_const(64, 0);
     let zero_field = u64_as_field(&mut e, zero_i64);
     let neg_inv = e.field_arith(FieldArithOp::Sub, zero_field, inv_coeff);
     e.call(bump_db_fn, vec![val_ptr, neg_inv], 0);

--- a/compiler/src/compiler/ssa/llssa/builder.rs
+++ b/compiler/src/compiler/ssa/llssa/builder.rs
@@ -13,16 +13,16 @@ pub trait LLEmitter {
     fn fresh_value(&mut self) -> ValueId;
     fn emit_ll(&mut self, op: LLOp);
     fn vm_ptr(&mut self) -> ValueId;
-    fn intern_constant(&mut self, value: Constant) -> ValueId;
+    fn emit_constant(&mut self, value: Constant) -> ValueId;
 
     // -- Constant --
 
-    fn add_int_const(&mut self, bits: u32, value: u64) -> ValueId {
-        self.intern_constant(Constant::Int { bits, value })
+    fn emit_int_const(&mut self, bits: u32, value: u64) -> ValueId {
+        self.emit_constant(Constant::Int { bits, value })
     }
 
-    fn add_nullptr_const(&mut self) -> ValueId {
-        self.intern_constant(Constant::NullPtr)
+    fn emit_nullptr_const(&mut self) -> ValueId {
+        self.emit_constant(Constant::NullPtr)
     }
 
     // -- Integer Arithmetic --
@@ -313,7 +313,7 @@ pub trait LLEmitter {
         let coeffs_slot = self.ad_vm_field_ptr(LLStruct::AD_VM_COEFFS);
         let coeffs = self.ll_load(coeffs_slot, Type::Ptr);
         let value = self.ll_load(coeffs, Type::Struct(LLStruct::field_elem()));
-        let one = self.add_int_const(32, 1);
+        let one = self.emit_int_const(32, 1);
         let next_coeffs = self.array_elem_ptr(coeffs, LLStruct::field_elem(), one);
         self.ll_store(coeffs_slot, next_coeffs);
         value
@@ -340,7 +340,7 @@ pub trait LLEmitter {
     fn ad_fresh_witness(&mut self) -> ValueId {
         let slot = self.ad_vm_field_ptr(LLStruct::AD_VM_CURRENT_WIT_OFF);
         let index = self.ll_load(slot, Type::i32());
-        let one = self.add_int_const(32, 1);
+        let one = self.emit_int_const(32, 1);
         let next = self.int_add(index, one);
         self.ll_store(slot, next);
         index
@@ -362,7 +362,7 @@ pub trait LLEmitter {
         let cursor_slot = self.witgen_vm_field_ptr(cursor_field);
         let cursor = self.ll_load(cursor_slot, Type::Ptr);
         self.ll_store(cursor, value);
-        let one = self.add_int_const(32, 1);
+        let one = self.emit_int_const(32, 1);
         let next = self.array_elem_ptr(cursor, LLStruct::field_elem(), one);
         self.ll_store(cursor_slot, next);
     }
@@ -407,7 +407,7 @@ impl LLEmitter for LLInstrBuilder<'_> {
             .0
     }
 
-    fn intern_constant(&mut self, value: Constant) -> ValueId {
+    fn emit_constant(&mut self, value: Constant) -> ValueId {
         self.ssa.add_const(value)
     }
 }
@@ -438,7 +438,7 @@ impl LLEmitter for LLBlockEmitter<'_> {
         }
     }
 
-    fn intern_constant(&mut self, value: Constant) -> ValueId {
+    fn emit_constant(&mut self, value: Constant) -> ValueId {
         self.ssa.add_const(value)
     }
 }
@@ -453,9 +453,9 @@ impl LLBlockEmitter<'_> {
         accumulators: Vec<(ValueId, Type)>,
         body: impl FnOnce(&mut Self, ValueId, &[ValueId]) -> Vec<ValueId>,
     ) -> Vec<ValueId> {
-        let const_0 = self.add_int_const(64, 0);
-        let const_1 = self.add_int_const(64, 1);
-        let const_len = self.add_int_const(64, count as u64);
+        let const_0 = self.emit_int_const(64, 0);
+        let const_1 = self.emit_int_const(64, 1);
+        let const_len = self.emit_int_const(64, count as u64);
 
         let mut params = vec![(const_0, Type::i64())];
         params.extend(accumulators);

--- a/compiler/src/compiler/ssa/llssa/builder.rs
+++ b/compiler/src/compiler/ssa/llssa/builder.rs
@@ -2,7 +2,7 @@ use crate::compiler::ssa::{
     FunctionId, ValueId,
     builder::{BlockEmitter, FunctionBuilder, InstrBuilder, SSABuilder},
     hlssa::DMatrix,
-    llssa::{Constants, FieldArithOp, IntArithOp, IntCmpOp, LLOp, LLStruct, Type},
+    llssa::{Constant, FieldArithOp, IntArithOp, IntCmpOp, LLOp, LLStruct, Type},
 };
 
 // ---------------------------------------------------------------------------
@@ -13,23 +13,16 @@ pub trait LLEmitter {
     fn fresh_value(&mut self) -> ValueId;
     fn emit_ll(&mut self, op: LLOp);
     fn vm_ptr(&mut self) -> ValueId;
+    fn intern_constant(&mut self, value: Constant) -> ValueId;
 
-    // -- Constants --
+    // -- Constant --
 
-    fn int_const(&mut self, bits: u32, value: u64) -> ValueId {
-        let r = self.fresh_value();
-        self.emit_ll(LLOp::IntConst {
-            result: r,
-            bits,
-            value,
-        });
-        r
+    fn add_int_const(&mut self, bits: u32, value: u64) -> ValueId {
+        self.intern_constant(Constant::Int { bits, value })
     }
 
-    fn null_ptr(&mut self) -> ValueId {
-        let r = self.fresh_value();
-        self.emit_ll(LLOp::NullPtr { result: r });
-        r
+    fn add_nullptr_const(&mut self) -> ValueId {
+        self.intern_constant(Constant::NullPtr)
     }
 
     // -- Integer Arithmetic --
@@ -320,7 +313,7 @@ pub trait LLEmitter {
         let coeffs_slot = self.ad_vm_field_ptr(LLStruct::AD_VM_COEFFS);
         let coeffs = self.ll_load(coeffs_slot, Type::Ptr);
         let value = self.ll_load(coeffs, Type::Struct(LLStruct::field_elem()));
-        let one = self.int_const(32, 1);
+        let one = self.add_int_const(32, 1);
         let next_coeffs = self.array_elem_ptr(coeffs, LLStruct::field_elem(), one);
         self.ll_store(coeffs_slot, next_coeffs);
         value
@@ -347,7 +340,7 @@ pub trait LLEmitter {
     fn ad_fresh_witness(&mut self) -> ValueId {
         let slot = self.ad_vm_field_ptr(LLStruct::AD_VM_CURRENT_WIT_OFF);
         let index = self.ll_load(slot, Type::i32());
-        let one = self.int_const(32, 1);
+        let one = self.add_int_const(32, 1);
         let next = self.int_add(index, one);
         self.ll_store(slot, next);
         index
@@ -369,7 +362,7 @@ pub trait LLEmitter {
         let cursor_slot = self.witgen_vm_field_ptr(cursor_field);
         let cursor = self.ll_load(cursor_slot, Type::Ptr);
         self.ll_store(cursor, value);
-        let one = self.int_const(32, 1);
+        let one = self.add_int_const(32, 1);
         let next = self.array_elem_ptr(cursor, LLStruct::field_elem(), one);
         self.ll_store(cursor_slot, next);
     }
@@ -387,10 +380,10 @@ fn ad_out_field(matrix: DMatrix) -> usize {
 // Type aliases
 // ---------------------------------------------------------------------------
 
-pub type LLInstrBuilder<'a> = InstrBuilder<'a, LLOp, Type, Constants>;
-pub type LLFunctionBuilder<'a> = FunctionBuilder<'a, LLOp, Type, Constants>;
-pub type LLBlockEmitter<'a> = BlockEmitter<'a, LLOp, Type, Constants>;
-pub type LLSSABuilder<'a> = SSABuilder<'a, LLOp, Type, Constants>;
+pub type LLInstrBuilder<'a> = InstrBuilder<'a, LLOp, Type, Constant>;
+pub type LLFunctionBuilder<'a> = FunctionBuilder<'a, LLOp, Type, Constant>;
+pub type LLBlockEmitter<'a> = BlockEmitter<'a, LLOp, Type, Constant>;
+pub type LLSSABuilder<'a> = SSABuilder<'a, LLOp, Type, Constant>;
 
 // ---------------------------------------------------------------------------
 // LLEmitter impls
@@ -412,6 +405,10 @@ impl LLEmitter for LLInstrBuilder<'_> {
             .next()
             .expect("LLSSA functions must have a VM pointer entry parameter")
             .0
+    }
+
+    fn intern_constant(&mut self, value: Constant) -> ValueId {
+        self.ssa.add_const(value)
     }
 }
 
@@ -440,6 +437,10 @@ impl LLEmitter for LLBlockEmitter<'_> {
                 .0
         }
     }
+
+    fn intern_constant(&mut self, value: Constant) -> ValueId {
+        self.ssa.add_const(value)
+    }
 }
 
 impl LLBlockEmitter<'_> {
@@ -452,9 +453,9 @@ impl LLBlockEmitter<'_> {
         accumulators: Vec<(ValueId, Type)>,
         body: impl FnOnce(&mut Self, ValueId, &[ValueId]) -> Vec<ValueId>,
     ) -> Vec<ValueId> {
-        let const_0 = self.int_const(64, 0);
-        let const_1 = self.int_const(64, 1);
-        let const_len = self.int_const(64, count as u64);
+        let const_0 = self.add_int_const(64, 0);
+        let const_1 = self.add_int_const(64, 1);
+        let const_len = self.add_int_const(64, count as u64);
 
         let mut params = vec![(const_0, Type::i64())];
         params.extend(accumulators);

--- a/compiler/src/compiler/ssa/llssa/mod.rs
+++ b/compiler/src/compiler/ssa/llssa/mod.rs
@@ -6,7 +6,7 @@ pub mod type_system;
 use itertools::Itertools;
 use std::fmt::{self, Display, Formatter};
 
-use crate::compiler::ssa::{Block, Function, FunctionId, Instruction, SSA, ValueId};
+use crate::compiler::ssa::{Block, Function, FunctionId, Instruction, SSA, SSAConstants, ValueId};
 pub use type_system::Type;
 
 // Re-export DMatrix for use by other LLSSA modules.
@@ -17,33 +17,30 @@ pub use super::hlssa::DMatrix;
 
 /// The low-level SSA exposes runtime details: explicit struct layouts, pointer arithmetic,
 /// integer/field arithmetic split, and explicit memory management.
-pub type LLSSA = SSA<LLOp, Type, Constants>;
+pub type LLSSA = SSA<LLOp, Type, Constant>;
 
 // CONSTANT STORAGE
 // ================================================================================================
 
 /// The value type stored in the low-level SSA's constants table.
 ///
-/// Currently a unit placeholder while constants still live inline as `LLOp::IntConst` /
-/// `LLOp::NullPtr` instructions; future work is planned to move the constant data into this table
-/// for use by the LLVM backend and other LLSSA clients.
-pub type Constants = ();
+/// LLSSA constants are scalar leaves: integers of a given bit width and the null pointer. Aggregate
+/// constants (e.g. the four-limb field element struct) remain as `LLOp::MkStruct` instructions for
+/// now, but this will be changed in subsequent work (#184).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Constant {
+    Int { bits: u32, value: u64 },
+    NullPtr,
+}
+
+/// The constants table type for LLSSA.
+pub type LLSSAConstants = SSAConstants<Constant>;
 
 // LLSSA OPCODES
 // ================================================================================================
 
 #[derive(Clone, Debug)]
 pub enum LLOp {
-    // ── Constants ────────────────────────────────────────────────────────
-    IntConst {
-        result: ValueId,
-        bits: u32,
-        value: u64,
-    },
-    NullPtr {
-        result: ValueId,
-    },
-
     // ── Integer Arithmetic ──────────────────────────────────────────────
     IntArith {
         kind: IntArithOp,
@@ -192,10 +189,8 @@ pub enum LLOp {
 impl Instruction for LLOp {
     fn get_inputs(&self) -> impl Iterator<Item = &ValueId> {
         match self {
-            // No inputs (constants / traps / etc.)
-            LLOp::IntConst { .. } | LLOp::NullPtr { .. } | LLOp::GlobalAddr { .. } | LLOp::Trap => {
-                vec![].into_iter()
-            }
+            // No inputs (globals / traps / etc.)
+            LLOp::GlobalAddr { .. } | LLOp::Trap => vec![].into_iter(),
 
             // Unary
             LLOp::Not { value, .. }
@@ -247,9 +242,7 @@ impl Instruction for LLOp {
     fn get_results(&self) -> impl Iterator<Item = &ValueId> {
         match self {
             // Single result
-            LLOp::IntConst { result, .. }
-            | LLOp::NullPtr { result }
-            | LLOp::IntArith { result, .. }
+            LLOp::IntArith { result, .. }
             | LLOp::Not { result, .. }
             | LLOp::Spread { result, .. }
             | LLOp::IntCmp { result, .. }
@@ -286,9 +279,7 @@ impl Instruction for LLOp {
 
     fn get_results_mut(&mut self) -> impl Iterator<Item = &mut ValueId> {
         match self {
-            LLOp::IntConst { result, .. }
-            | LLOp::NullPtr { result }
-            | LLOp::IntArith { result, .. }
+            LLOp::IntArith { result, .. }
             | LLOp::Not { result, .. }
             | LLOp::Spread { result, .. }
             | LLOp::IntCmp { result, .. }
@@ -322,9 +313,7 @@ impl Instruction for LLOp {
     fn get_inputs_mut(&mut self) -> impl Iterator<Item = &mut ValueId> {
         match self {
             // No inputs
-            LLOp::IntConst { .. } | LLOp::NullPtr { .. } | LLOp::GlobalAddr { .. } | LLOp::Trap => {
-                vec![].into_iter()
-            }
+            LLOp::GlobalAddr { .. } | LLOp::Trap => vec![].into_iter(),
 
             // Unary
             LLOp::Not { value, .. }
@@ -377,9 +366,7 @@ impl Instruction for LLOp {
 
     fn get_operands_mut(&mut self) -> impl Iterator<Item = &mut ValueId> {
         match self {
-            LLOp::IntConst { result, .. }
-            | LLOp::NullPtr { result }
-            | LLOp::GlobalAddr { result, .. } => vec![result].into_iter(),
+            LLOp::GlobalAddr { result, .. } => vec![result].into_iter(),
 
             LLOp::Trap => vec![].into_iter(),
 
@@ -468,16 +455,6 @@ impl Instruction for LLOp {
         let v = |id: ValueId| format!("v{}{}", id.0, annotate_value(id));
         let vr = |id: ValueId| format!("v{}", id.0); // raw, no annotation (for inputs)
         match self {
-            LLOp::IntConst {
-                result,
-                bits,
-                value,
-            } => {
-                format!("{} = int_const i{} {}", v(*result), bits, value)
-            }
-            LLOp::NullPtr { result } => {
-                format!("{} = null_ptr", v(*result))
-            }
             LLOp::IntArith { kind, result, a, b } => {
                 format!("{} = {} {}, {}", v(*result), kind, vr(*a), vr(*b))
             }
@@ -1162,15 +1139,16 @@ mod tests {
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
             let mut e = fb.block(entry);
-            let x = e.int_const(64, 42);
-            let y = e.int_const(64, 7);
+            let x = e.add_int_const(64, 42);
+            let y = e.add_int_const(64, 7);
             let z = e.int_add(x, y);
             e.terminate_return(vec![z]);
         });
 
         let dump = ssa.to_string(&DefaultSSAAnnotator);
-        assert!(dump.contains("int_const i64 42"));
-        assert!(dump.contains("int_const i64 7"));
+        assert!(dump.contains("constants:"));
+        assert!(dump.contains("Int { bits: 64, value: 42 }"));
+        assert!(dump.contains("Int { bits: 64, value: 7 }"));
         assert!(dump.contains("add"));
         assert!(dump.contains("return"));
     }
@@ -1191,10 +1169,10 @@ mod tests {
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
             let mut e = fb.block(entry);
-            let l0 = e.int_const(64, 1);
-            let l1 = e.int_const(64, 0);
-            let l2 = e.int_const(64, 0);
-            let l3 = e.int_const(64, 0);
+            let l0 = e.add_int_const(64, 1);
+            let l1 = e.add_int_const(64, 0);
+            let l2 = e.add_int_const(64, 0);
+            let l3 = e.add_int_const(64, 0);
             let s = e.mk_struct(field_elem.clone(), vec![l0, l1, l2, l3]);
             let f0 = e.extract_field(s, field_elem, 0);
             e.terminate_return(vec![f0, s]);
@@ -1229,11 +1207,11 @@ mod tests {
             let arr = e.heap_alloc(rc_array.clone(), None);
             let rc_ptr = e.struct_field_ptr(arr, rc_array.clone(), 0);
             let rc_word = e.struct_field_ptr(rc_ptr, rc_header, 0);
-            let one = e.int_const(64, 1);
+            let one = e.add_int_const(64, 1);
             e.ll_store(rc_word, one);
 
             let data = e.struct_field_ptr(arr, rc_array, 1);
-            let idx = e.int_const(64, 0);
+            let idx = e.add_int_const(64, 0);
             let elem_ptr = e.array_elem_ptr(data, field_elem, idx);
             let loaded = e.ll_load(elem_ptr, Type::i64());
             e.free(arr);
@@ -1258,8 +1236,8 @@ mod tests {
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
             let mut e = fb.block(entry);
-            let a = e.int_const(64, 1);
-            let b = e.int_const(64, 2);
+            let a = e.add_int_const(64, 1);
+            let b = e.add_int_const(64, 2);
             let results = e.call(helper_id, vec![a, b], 1);
             let cond = e.int_eq(results[0], a);
             let selected = e.select(cond, a, b);
@@ -1288,10 +1266,10 @@ mod tests {
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
             let mut e = fb.block(entry);
-            let l0 = e.int_const(64, 1);
-            let l1 = e.int_const(64, 0);
-            let l2 = e.int_const(64, 0);
-            let l3 = e.int_const(64, 0);
+            let l0 = e.add_int_const(64, 1);
+            let l1 = e.add_int_const(64, 0);
+            let l2 = e.add_int_const(64, 0);
+            let l3 = e.add_int_const(64, 0);
             let a = e.mk_struct(field_elem.clone(), vec![l0, l1, l2, l3]);
             let b = e.mk_struct(field_elem, vec![l0, l1, l2, l3]);
 
@@ -1319,7 +1297,7 @@ mod tests {
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
             let mut e = fb.block(entry);
-            let x = e.int_const(64, 256);
+            let x = e.add_int_const(64, 256);
             let narrow = e.truncate(x, 8);
             let wide = e.zext(narrow, 64);
             let gp = e.global_addr(3);
@@ -1347,19 +1325,19 @@ mod tests {
 
             {
                 let mut e = fb.block(entry);
-                let x = e.int_const(64, 42);
-                let zero = e.int_const(64, 0);
+                let x = e.add_int_const(64, 42);
+                let zero = e.add_int_const(64, 0);
                 let cond = e.int_eq(x, zero);
                 e.terminate_jmp_if(cond, then_blk, else_blk);
             }
             {
                 let mut e = fb.block(then_blk);
-                let one = e.int_const(64, 1);
+                let one = e.add_int_const(64, 1);
                 e.terminate_jmp(merge_blk, vec![one]);
             }
             {
                 let mut e = fb.block(else_blk);
-                let two = e.int_const(64, 2);
+                let two = e.add_int_const(64, 2);
                 e.terminate_jmp(merge_blk, vec![two]);
             }
 
@@ -1382,9 +1360,9 @@ mod tests {
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
             let mut e = fb.block(entry);
-            let dst = e.null_ptr();
-            let src = e.null_ptr();
-            let count = e.int_const(64, 10);
+            let dst = e.add_nullptr_const();
+            let src = e.add_nullptr_const();
+            let count = e.add_int_const(64, 10);
             e.memcpy(dst, src, elem, Some(count));
             e.terminate_return(vec![]);
         });

--- a/compiler/src/compiler/ssa/llssa/mod.rs
+++ b/compiler/src/compiler/ssa/llssa/mod.rs
@@ -1139,8 +1139,8 @@ mod tests {
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
             let mut e = fb.block(entry);
-            let x = e.add_int_const(64, 42);
-            let y = e.add_int_const(64, 7);
+            let x = e.emit_int_const(64, 42);
+            let y = e.emit_int_const(64, 7);
             let z = e.int_add(x, y);
             e.terminate_return(vec![z]);
         });
@@ -1169,10 +1169,10 @@ mod tests {
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
             let mut e = fb.block(entry);
-            let l0 = e.add_int_const(64, 1);
-            let l1 = e.add_int_const(64, 0);
-            let l2 = e.add_int_const(64, 0);
-            let l3 = e.add_int_const(64, 0);
+            let l0 = e.emit_int_const(64, 1);
+            let l1 = e.emit_int_const(64, 0);
+            let l2 = e.emit_int_const(64, 0);
+            let l3 = e.emit_int_const(64, 0);
             let s = e.mk_struct(field_elem.clone(), vec![l0, l1, l2, l3]);
             let f0 = e.extract_field(s, field_elem, 0);
             e.terminate_return(vec![f0, s]);
@@ -1207,11 +1207,11 @@ mod tests {
             let arr = e.heap_alloc(rc_array.clone(), None);
             let rc_ptr = e.struct_field_ptr(arr, rc_array.clone(), 0);
             let rc_word = e.struct_field_ptr(rc_ptr, rc_header, 0);
-            let one = e.add_int_const(64, 1);
+            let one = e.emit_int_const(64, 1);
             e.ll_store(rc_word, one);
 
             let data = e.struct_field_ptr(arr, rc_array, 1);
-            let idx = e.add_int_const(64, 0);
+            let idx = e.emit_int_const(64, 0);
             let elem_ptr = e.array_elem_ptr(data, field_elem, idx);
             let loaded = e.ll_load(elem_ptr, Type::i64());
             e.free(arr);
@@ -1236,8 +1236,8 @@ mod tests {
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
             let mut e = fb.block(entry);
-            let a = e.add_int_const(64, 1);
-            let b = e.add_int_const(64, 2);
+            let a = e.emit_int_const(64, 1);
+            let b = e.emit_int_const(64, 2);
             let results = e.call(helper_id, vec![a, b], 1);
             let cond = e.int_eq(results[0], a);
             let selected = e.select(cond, a, b);
@@ -1266,10 +1266,10 @@ mod tests {
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
             let mut e = fb.block(entry);
-            let l0 = e.add_int_const(64, 1);
-            let l1 = e.add_int_const(64, 0);
-            let l2 = e.add_int_const(64, 0);
-            let l3 = e.add_int_const(64, 0);
+            let l0 = e.emit_int_const(64, 1);
+            let l1 = e.emit_int_const(64, 0);
+            let l2 = e.emit_int_const(64, 0);
+            let l3 = e.emit_int_const(64, 0);
             let a = e.mk_struct(field_elem.clone(), vec![l0, l1, l2, l3]);
             let b = e.mk_struct(field_elem, vec![l0, l1, l2, l3]);
 
@@ -1297,7 +1297,7 @@ mod tests {
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
             let mut e = fb.block(entry);
-            let x = e.add_int_const(64, 256);
+            let x = e.emit_int_const(64, 256);
             let narrow = e.truncate(x, 8);
             let wide = e.zext(narrow, 64);
             let gp = e.global_addr(3);
@@ -1325,19 +1325,19 @@ mod tests {
 
             {
                 let mut e = fb.block(entry);
-                let x = e.add_int_const(64, 42);
-                let zero = e.add_int_const(64, 0);
+                let x = e.emit_int_const(64, 42);
+                let zero = e.emit_int_const(64, 0);
                 let cond = e.int_eq(x, zero);
                 e.terminate_jmp_if(cond, then_blk, else_blk);
             }
             {
                 let mut e = fb.block(then_blk);
-                let one = e.add_int_const(64, 1);
+                let one = e.emit_int_const(64, 1);
                 e.terminate_jmp(merge_blk, vec![one]);
             }
             {
                 let mut e = fb.block(else_blk);
-                let two = e.add_int_const(64, 2);
+                let two = e.emit_int_const(64, 2);
                 e.terminate_jmp(merge_blk, vec![two]);
             }
 
@@ -1360,9 +1360,9 @@ mod tests {
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
             let mut e = fb.block(entry);
-            let dst = e.add_nullptr_const();
-            let src = e.add_nullptr_const();
-            let count = e.add_int_const(64, 10);
+            let dst = e.emit_nullptr_const();
+            let src = e.emit_nullptr_const();
+            let count = e.emit_int_const(64, 10);
             e.memcpy(dst, src, elem, Some(count));
             e.terminate_return(vec![]);
         });


### PR DESCRIPTION
This commit extends the centralized handling of constants in the SSA from the HLSSA into the LLSSA. It now handles constants in the SSA's constant interning table, reducing duplication, but these are still spilled and materialized at LLVM IR codegen for the moment.

More work toward #184. Builds on top of #191. 