### PR TITLE
Remove dead tuple-handling

### DIFF
--- a/compiler/src/compiler/analysis/instrumenter.rs
+++ b/compiler/src/compiler/analysis/instrumenter.rs
@@ -5,6 +5,7 @@
 //! execution combined with an instrumenter for the circuit cost, and gives the compiler an idea of
 //! how much a function could be shrunk through specialization on concrete inputs.
 
+use crate::compiler::util::ice_non_elided_tuple;
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use ark_ff::{AdditiveGroup, BigInt, BigInteger, PrimeField};
@@ -56,7 +57,6 @@ pub enum ValueSignature {
     Unknown(ScalarKind),
     UnknownSlice,
     WitnessOf(Box<ValueSignature>),
-    Tuple(Vec<ValueSignature>),
 }
 
 impl ValueSignature {
@@ -72,9 +72,6 @@ impl ValueSignature {
             ValueSignature::Unknown(kind) => Value::Unknown(*kind),
             ValueSignature::UnknownSlice => Value::UnknownSlice,
             ValueSignature::WitnessOf(inner) => Value::WitnessOf(Box::new(inner.to_value())),
-            ValueSignature::Tuple(elements) => {
-                Value::Tuple(elements.iter().map(|e| e.to_value()).collect())
-            }
         }
     }
 
@@ -96,14 +93,6 @@ impl ValueSignature {
             ValueSignature::Unknown(_) => "?".to_string(),
             ValueSignature::UnknownSlice => "?slice".to_string(),
             ValueSignature::WitnessOf(inner) => format!("W({})", inner.pretty_print(full)),
-            ValueSignature::Tuple(elements) => {
-                if full {
-                    let elements = elements.iter().map(|e| e.pretty_print(full)).join(", ");
-                    format!("({})", elements)
-                } else {
-                    format!("(...)")
-                }
-            }
         }
     }
 }
@@ -118,7 +107,6 @@ pub enum Value {
     Unknown(ScalarKind),
     UnknownSlice,
     WitnessOf(Box<Value>),
-    Tuple(Vec<Value>),
 }
 
 impl Value {
@@ -174,9 +162,7 @@ impl Value {
                 Value::Array(vec![elem_unknown; *n])
             }
             TypeExpr::Slice(_) => Value::UnknownSlice,
-            TypeExpr::Tuple(elems) => {
-                Value::Tuple(elems.iter().map(Value::unknown_from_type).collect())
-            }
+            TypeExpr::Tuple(_) => ice_non_elided_tuple(),
             TypeExpr::Ref(inner) => {
                 Value::Pointer(Rc::new(RefCell::new(Value::unknown_from_type(inner))))
             }
@@ -512,11 +498,6 @@ impl Value {
             Value::Pointer(val) => {
                 val.borrow_mut().blind();
             }
-            Value::Tuple(vals) => {
-                for val in vals {
-                    val.blind();
-                }
-            }
         }
     }
 
@@ -536,11 +517,6 @@ impl Value {
             }
             Value::Pointer(val) => {
                 val.borrow_mut().forget_concrete();
-            }
-            Value::Tuple(vals) => {
-                for val in vals {
-                    val.forget_concrete();
-                }
             }
         }
     }
@@ -566,9 +542,6 @@ impl Value {
             }
             Value::Pointer(val) => {
                 ValueSignature::PointerTo(Box::new(val.borrow().make_unspecialized_sig()))
-            }
-            Value::Tuple(vals) => {
-                ValueSignature::Tuple(vals.iter().map(|v| v.make_unspecialized_sig()).collect())
             }
         }
     }
@@ -628,18 +601,6 @@ impl Value {
             (Value::Unknown(_) | Value::UnknownSlice, _) => Value::unknown_from_type(tp),
             _ => panic!(
                 "Cannot get array element from {:?} with index {:?}",
-                self, index
-            ),
-        }
-    }
-
-    fn tuple_get(&self, index: usize) -> Value {
-        match self {
-            Value::Unknown(_) => Value::Unknown(ScalarKind::Field),
-            Value::WitnessOf(inner) => inner.tuple_get(index),
-            Value::Tuple(vals) => vals[index].clone(),
-            _ => panic!(
-                "Cannot get tuple element from {:?} with index {:?}",
                 self, index
             ),
         }
@@ -1221,21 +1182,6 @@ impl symbolic_executor::Value<CostAnalysis> for SpecSplitValue {
         }
     }
 
-    fn mk_tuple(
-        values: Vec<SpecSplitValue>,
-        _ctx: &mut CostAnalysis,
-        _elem_types: &[Type],
-    ) -> SpecSplitValue {
-        let (uns, spec) = values
-            .into_iter()
-            .map(|v| (v.unspecialized, v.specialized))
-            .unzip();
-        SpecSplitValue {
-            unspecialized: Value::Tuple(uns),
-            specialized: Value::Tuple(spec),
-        }
-    }
-
     fn assert_r1c(
         a: &SpecSplitValue,
         b: &SpecSplitValue,
@@ -1273,18 +1219,6 @@ impl symbolic_executor::Value<CostAnalysis> for SpecSplitValue {
                 tp,
                 instrumenter.get_specialized(),
             ),
-        }
-    }
-
-    fn tuple_get(
-        &self,
-        index: usize,
-        _tp: &Type,
-        _instrumenter: &mut CostAnalysis,
-    ) -> SpecSplitValue {
-        SpecSplitValue {
-            unspecialized: self.unspecialized.tuple_get(index),
-            specialized: self.specialized.tuple_get(index),
         }
     }
 
@@ -1677,9 +1611,7 @@ impl symbolic_executor::Context<SpecSplitValue> for CostAnalysis {
                     TypeExpr::Array(elem, size) => {
                         Value::Array((0..*size).map(|_| unknown_value(elem)).collect())
                     }
-                    TypeExpr::Tuple(elems) => {
-                        Value::Tuple(elems.iter().map(unknown_value).collect())
-                    }
+                    TypeExpr::Tuple(_) => ice_non_elided_tuple(),
                     TypeExpr::WitnessOf(inner) => Value::WitnessOf(Box::new(unknown_value(inner))),
                     TypeExpr::Ref(inner) => {
                         Value::Pointer(Rc::new(RefCell::new(unknown_value(inner))))
@@ -1833,7 +1765,7 @@ impl symbolic_executor::Context<SpecSplitValue> for CostAnalysis {
                 TypeExpr::Array(elem, size) => {
                     Value::Array((0..*size).map(|_| unknown_value(elem)).collect())
                 }
-                TypeExpr::Tuple(elems) => Value::Tuple(elems.iter().map(unknown_value).collect()),
+                TypeExpr::Tuple(_) => ice_non_elided_tuple(),
                 TypeExpr::WitnessOf(inner) => Value::WitnessOf(Box::new(unknown_value(inner))),
                 TypeExpr::Ref(inner) => Value::Pointer(Rc::new(RefCell::new(unknown_value(inner)))),
                 _ => panic!("Unsupported type for unknown value: {:?}", ty),
@@ -2078,9 +2010,7 @@ impl CostEstimator {
                 let elem_sig = self.type_to_unknown_sig(elem);
                 ValueSignature::Array(vec![elem_sig; 0])
             }
-            TypeExpr::Tuple(elems) => {
-                ValueSignature::Tuple(elems.iter().map(|e| self.type_to_unknown_sig(e)).collect())
-            }
+            TypeExpr::Tuple(_) => ice_non_elided_tuple(),
             TypeExpr::Ref(inner) => {
                 ValueSignature::PointerTo(Box::new(self.type_to_unknown_sig(inner)))
             }

--- a/compiler/src/compiler/analysis/symbolic_executor.rs
+++ b/compiler/src/compiler/analysis/symbolic_executor.rs
@@ -2,6 +2,7 @@
 //! into by providing their own `Value` and `Context` implementations that specialize it for their
 //! use-case.
 
+use crate::compiler::util::ice_non_elided_tuple;
 use std::collections::HashMap;
 
 use tracing::{Level, instrument};
@@ -36,7 +37,6 @@ where
     fn assert_cmp(kind: CmpKind, a: &Self, b: &Self, lhs_type: &Type, ctx: &mut Context);
     fn assert_r1c(a: &Self, b: &Self, c: &Self, ctx: &mut Context);
     fn array_get(&self, index: &Self, out_type: &Type, ctx: &mut Context) -> Self;
-    fn tuple_get(&self, index: usize, out_type: &Type, ctx: &mut Context) -> Self;
     fn array_set(&self, index: &Self, value: &Self, out_type: &Type, ctx: &mut Context) -> Self;
     fn sext(&self, from: usize, to: usize, out_type: &Type, ctx: &mut Context) -> Self;
     fn bit_range(&self, offset: usize, width: usize, out_type: &Type, ctx: &mut Context) -> Self;
@@ -67,7 +67,6 @@ where
         seq_type: SequenceTargetType,
         elem_type: &Type,
     ) -> Self;
-    fn mk_tuple(elems: Vec<Self>, ctx: &mut Context, elem_types: &[Type]) -> Self;
     fn alloc(elem_type: &Type, ctx: &mut Context) -> Self;
     fn ptr_write(&self, val: &Self, ctx: &mut Context);
     fn ptr_read(&self, out_type: &Type, ctx: &mut Context) -> Self;
@@ -567,22 +566,8 @@ impl SymbolicExecutor {
                         let flag_value = scope[flag].clone();
                         ctx.dlookup(target, args, flag_value);
                     }
-                    crate::compiler::ssa::hlssa::OpCode::TupleProj {
-                        result: r,
-                        tuple: a,
-                        idx,
-                    } => {
-                        let a = &scope[a];
-                        scope.insert(*r, a.tuple_get(*idx, &fn_type_info.get_value_type(*r), ctx));
-                    }
-                    crate::compiler::ssa::hlssa::OpCode::MkTuple {
-                        result,
-                        elems,
-                        element_types,
-                    } => {
-                        let elems = elems.iter().map(|id| scope[id].clone()).collect::<Vec<_>>();
-                        scope.insert(*result, V::mk_tuple(elems, ctx, element_types));
-                    }
+                    crate::compiler::ssa::hlssa::OpCode::TupleProj { .. }
+                    | crate::compiler::ssa::hlssa::OpCode::MkTuple { .. } => ice_non_elided_tuple(),
                     crate::compiler::ssa::hlssa::OpCode::Todo {
                         payload,
                         results,

--- a/compiler/src/compiler/analysis/witness_info.rs
+++ b/compiler/src/compiler/analysis/witness_info.rs
@@ -48,7 +48,6 @@ pub enum WitnessShape {
     Scalar(WitnessInfo),
     Array(WitnessInfo, Box<WitnessShape>),
     Ref(WitnessInfo, Box<WitnessShape>),
-    Tuple(WitnessInfo, Vec<WitnessShape>),
 }
 
 impl Display for WitnessShape {
@@ -60,13 +59,6 @@ impl Display for WitnessShape {
             }
             WitnessShape::Ref(info, inner) => {
                 write!(f, "[*{info} of {inner}]")
-            }
-            WitnessShape::Tuple(info, children) => {
-                write!(
-                    f,
-                    "({info} of <{}>)",
-                    children.iter().map(|child| child.to_string()).join(", ")
-                )
             }
         }
     }
@@ -85,14 +77,6 @@ impl WitnessShape {
             (WitnessShape::Ref(t1, inner1), WitnessShape::Ref(t2, inner2)) => {
                 WitnessShape::Ref(t1.join(*t2), Box::new(inner1.join(inner2)))
             }
-            (WitnessShape::Tuple(t1, children1), WitnessShape::Tuple(t2, children2)) => {
-                let children_join = children1
-                    .iter()
-                    .zip(children2.iter())
-                    .map(|(c1, c2)| c1.join(c2))
-                    .collect();
-                WitnessShape::Tuple(t1.join(*t2), children_join)
-            }
             _ => panic!(
                 "Cannot join different witness types: {:?} vs {:?}",
                 self, other
@@ -105,7 +89,6 @@ impl WitnessShape {
             WitnessShape::Scalar(info) => *info,
             WitnessShape::Array(info, _) => *info,
             WitnessShape::Ref(info, _) => *info,
-            WitnessShape::Tuple(info, _) => *info,
         }
     }
 
@@ -114,9 +97,6 @@ impl WitnessShape {
             WitnessShape::Array(_, inner) => Some(*inner.clone()),
             WitnessShape::Ref(_, inner) => Some(*inner.clone()),
             WitnessShape::Scalar(_) => None,
-            WitnessShape::Tuple(_, _) => {
-                panic!("Error: child_witness_type shouldn't be called for Tuple values")
-            }
         }
     }
 
@@ -125,15 +105,13 @@ impl WitnessShape {
             WitnessShape::Scalar(_) => WitnessShape::Scalar(toplevel),
             WitnessShape::Array(_, inner) => WitnessShape::Array(toplevel, inner.clone()),
             WitnessShape::Ref(_, inner) => WitnessShape::Ref(toplevel, inner.clone()),
-            WitnessShape::Tuple(_, inner) => WitnessShape::Tuple(toplevel, inner.clone()),
         }
     }
 
-    /// Push witness info into the leaves of composites (arrays, tuples)
-    /// instead of wrapping at the top level. For scalars and refs this
-    /// is equivalent to `with_toplevel_info`. For arrays and tuples, the
-    /// info is pushed recursively into children, keeping the top-level
-    /// info unchanged.
+    /// Push witness info into the leaves of composites (arrays) instead of
+    /// wrapping at the top level. For scalars and refs this is equivalent to
+    /// `with_toplevel_info`. For arrays, the info is pushed recursively into
+    /// children, keeping the top-level info unchanged.
     pub fn with_witness_in_leaves(&self, info: WitnessInfo) -> WitnessShape {
         match self {
             WitnessShape::Scalar(existing) => WitnessShape::Scalar(existing.join(info)),
@@ -141,13 +119,6 @@ impl WitnessShape {
                 WitnessShape::Array(*top, Box::new(inner.with_witness_in_leaves(info)))
             }
             WitnessShape::Ref(_, _) => self.with_toplevel_info(self.toplevel_info().join(info)),
-            WitnessShape::Tuple(top, children) => WitnessShape::Tuple(
-                *top,
-                children
-                    .iter()
-                    .map(|child| child.with_witness_in_leaves(info))
-                    .collect(),
-            ),
         }
     }
 }

--- a/compiler/src/compiler/analysis/witness_type_inference.rs
+++ b/compiler/src/compiler/analysis/witness_type_inference.rs
@@ -1,6 +1,7 @@
 //! Performs whole program analysis to determine which values are potentially witness tainted, which
 //! are _only_ witnesses, and which are only non-witness values.
 
+use crate::compiler::util::ice_non_elided_tuple;
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use super::witness_info::{FunctionWitnessType, WitnessShape, WitnessType};
@@ -811,27 +812,7 @@ impl WitnessTypeInference {
                         WitnessShape::Array(WitnessType::Pure, Box::new(val_wt)),
                     );
                 }
-                OpCode::TupleProj { result, tuple, idx } => {
-                    let tuple_wt = value_wt.get(tuple).unwrap();
-                    match tuple_wt {
-                        WitnessShape::Tuple(top, children) => {
-                            let elem_wt = &children[*idx];
-                            let result_wt =
-                                elem_wt.with_toplevel_info((*top).join(elem_wt.toplevel_info()));
-                            value_wt.insert(*result, result_wt);
-                        }
-                        _ => {
-                            panic!("TupleProj on non-tuple witness type: {:?}", tuple_wt);
-                        }
-                    }
-                }
-                OpCode::MkTuple { result, elems, .. } => {
-                    let children: Vec<WitnessShape> = elems
-                        .iter()
-                        .map(|v| value_wt.get(v).unwrap().clone())
-                        .collect();
-                    value_wt.insert(*result, WitnessShape::Tuple(WitnessType::Pure, children));
-                }
+                OpCode::TupleProj { .. } | OpCode::MkTuple { .. } => ice_non_elided_tuple(),
                 OpCode::WriteWitness { result, .. } => {
                     // WriteWitness records a value on the witness tape.
                     // Its output is always Witness-typed.
@@ -929,13 +910,7 @@ impl WitnessTypeInference {
             TypeExpr::WitnessOf(_) => {
                 panic!("ICE: WitnessOf should not be present at this stage");
             }
-            TypeExpr::Tuple(elements) => WitnessShape::Tuple(
-                WitnessType::Pure,
-                elements
-                    .iter()
-                    .map(Self::construct_pure_witness_for_type)
-                    .collect(),
-            ),
+            TypeExpr::Tuple(_) => ice_non_elided_tuple(),
             TypeExpr::Function => WitnessShape::Scalar(WitnessType::Pure),
         }
     }

--- a/compiler/src/compiler/codegen/bytecode/layout.rs
+++ b/compiler/src/compiler/codegen/bytecode/layout.rs
@@ -1,5 +1,6 @@
 //! Tools and utilities for computing layouts when generating bytecode.
 
+use crate::compiler::util::ice_non_elided_tuple;
 use std::collections::HashMap;
 
 use crate::{
@@ -86,7 +87,7 @@ impl FrameLayouter {
             TypeExpr::Array(_, _) => constants::POINTER_SIZE_CELLS,
             TypeExpr::Slice(_) => constants::POINTER_SIZE_CELLS,
             TypeExpr::WitnessOf(_) => constants::POINTER_SIZE_CELLS,
-            TypeExpr::Tuple(_) => constants::POINTER_SIZE_CELLS,
+            TypeExpr::Tuple(_) => ice_non_elided_tuple(),
             TypeExpr::Ref(_) => constants::POINTER_SIZE_CELLS,
             _ => todo!(),
         }

--- a/compiler/src/compiler/codegen/bytecode/mod.rs
+++ b/compiler/src/compiler/codegen/bytecode/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod layout;
 
+use crate::compiler::util::ice_non_elided_tuple;
 use std::collections::HashMap;
 
 use crate::{
@@ -130,7 +131,7 @@ impl CodeGen {
 
     pub fn run(&self, ssa: &HLSSA, cfg: &FlowAnalysis, type_info: &TypeInfo) -> bytecode::Program {
         let global_layouter = GlobalFrameLayouter::new(ssa);
-        let mut struct_interner = StructLayoutInterner::new();
+        let struct_interner = StructLayoutInterner::new();
         let constants = ssa.const_snapshot();
 
         let function = ssa.get_main();
@@ -139,7 +140,6 @@ impl CodeGen {
             cfg.get_function_cfg(ssa.get_main_id()),
             type_info.get_function(ssa.get_main_id()),
             &global_layouter,
-            &mut struct_interner,
             &constants,
         );
 
@@ -159,7 +159,6 @@ impl CodeGen {
                 cfg.get_function_cfg(*function_id),
                 type_info.get_function(*function_id),
                 &global_layouter,
-                &mut struct_interner,
                 &constants,
             );
             function_ids.insert(*function_id, cur_fn_begin);
@@ -200,7 +199,6 @@ impl CodeGen {
         cfg: &CFG,
         type_info: &FunctionTypeInfo,
         global_layouter: &GlobalFrameLayouter,
-        struct_interner: &mut StructLayoutInterner,
         constants: &HLSSAConstantsSnapshot,
     ) -> bytecode::Function {
         let mut layouter = FrameLayouter::new();
@@ -225,7 +223,6 @@ impl CodeGen {
             &mut layouter,
             &mut emitter,
             global_layouter,
-            struct_interner,
         );
 
         for block_id in cfg.get_domination_pre_order() {
@@ -245,7 +242,6 @@ impl CodeGen {
                 &mut layouter,
                 &mut emitter,
                 global_layouter,
-                struct_interner,
             );
         }
 
@@ -348,7 +344,6 @@ impl CodeGen {
         layouter: &mut FrameLayouter,
         emitter: &mut EmitterState,
         global_layouter: &GlobalFrameLayouter,
-        struct_interner: &mut StructLayoutInterner,
     ) {
         emitter.enter_block(block_id);
         for instruction in block.get_instructions() {
@@ -962,25 +957,7 @@ impl CodeGen {
                             .type_size(&type_info.get_value_type(*arr).get_array_element()),
                     });
                 }
-                hlssa::OpCode::TupleProj {
-                    result: r,
-                    tuple: t,
-                    idx,
-                } => {
-                    let res = layouter.alloc_value(*r, &type_info.get_value_type(*r));
-                    let tuple_elems = type_info.get_value_type(*t).get_tuple_elements();
-                    let field_offset: usize = tuple_elems[..*idx]
-                        .iter()
-                        .map(|elem_type| layouter.type_size(elem_type))
-                        .sum();
-                    let field_size = layouter.type_size(&tuple_elems[*idx]);
-                    emitter.push_op(bytecode::OpCode::TupleProj {
-                        res,
-                        tuple: layouter.get_value(*t),
-                        field_offset,
-                        field_size,
-                    });
-                }
+                hlssa::OpCode::TupleProj { .. } => ice_non_elided_tuple(),
                 hlssa::OpCode::ArraySet {
                     result: r,
                     array: arr,
@@ -1058,32 +1035,7 @@ impl CodeGen {
                         item,
                     });
                 }
-                hlssa::OpCode::MkTuple {
-                    result,
-                    elems,
-                    element_types,
-                } => {
-                    let res = layouter.alloc_value(*result, &type_info.get_value_type(*result));
-                    let fields = elems
-                        .iter()
-                        .map(|a| layouter.get_value(*a))
-                        .collect::<Vec<_>>();
-                    let field_layout: Vec<(u32, bool)> = element_types
-                        .iter()
-                        .map(|elem_type| {
-                            (
-                                layouter.type_size(elem_type) as u32,
-                                elem_type.is_heap_allocated(),
-                            )
-                        })
-                        .collect();
-                    let idx = struct_interner.intern(field_layout);
-                    emitter.push_op(bytecode::OpCode::TupleAlloc {
-                        res,
-                        meta: vm::array::BoxedLayout::new_struct(idx),
-                        fields,
-                    });
-                }
+                hlssa::OpCode::MkTuple { .. } => ice_non_elided_tuple(),
                 hlssa::OpCode::Call {
                     results: r,
                     function: hlssa::CallTarget::Static(fnid),

--- a/compiler/src/compiler/codegen/hlssa_to_r1cs.rs
+++ b/compiler/src/compiler/codegen/hlssa_to_r1cs.rs
@@ -38,16 +38,10 @@ pub struct ArrayData {
 }
 
 #[derive(Clone, Debug)]
-pub struct TupleData {
-    data: Vec<Value>,
-}
-
-#[derive(Clone, Debug)]
 pub enum Value {
     Const(ark_bn254::Fr),
     LC(LC),
     Array(Rc<RefCell<ArrayData>>),
-    Tuple(Rc<RefCell<TupleData>>),
     Ptr(Rc<RefCell<Value>>),
     Invalid,
 }
@@ -257,13 +251,6 @@ impl Value {
         }
     }
 
-    pub fn expect_tuple(&self) -> Rc<RefCell<TupleData>> {
-        match self {
-            Value::Tuple(fields) => fields.clone(),
-            _ => panic!("expected tuple"),
-        }
-    }
-
     pub fn expect_linear_combination(&self) -> Vec<(usize, ark_bn254::Fr)> {
         match self {
             Value::Const(c) => vec![(0, *c)],
@@ -287,10 +274,6 @@ impl Value {
             table_id: None,
             data,
         })))
-    }
-
-    pub fn mk_tuple(fields: Vec<Value>) -> Value {
-        Value::Tuple(Rc::new(RefCell::new(TupleData { data: fields })))
     }
 }
 
@@ -638,10 +621,6 @@ impl symbolic_executor::Value<R1CGen> for Value {
         self.expect_array().borrow().data[index as usize].clone()
     }
 
-    fn tuple_get(&self, index: usize, _out_type: &Type, _ctx: &mut R1CGen) -> Self {
-        self.expect_tuple().borrow().data[index].clone()
-    }
-
     fn array_set(&self, index: &Self, value: &Self, _out_type: &Type, _ctx: &mut R1CGen) -> Self {
         let array = self.expect_array();
         let index = index.expect_u32();
@@ -761,10 +740,6 @@ impl symbolic_executor::Value<R1CGen> for Value {
         _elem_type: &Type,
     ) -> Self {
         Value::mk_array(a)
-    }
-
-    fn mk_tuple(elems: Vec<Self>, _ctx: &mut R1CGen, _elem_types: &[Type]) -> Self {
-        Value::mk_tuple(elems)
     }
 
     fn alloc(_elem_type: &Type, _ctx: &mut R1CGen) -> Self {

--- a/compiler/src/compiler/passes/common_subexpression_elimination.rs
+++ b/compiler/src/compiler/passes/common_subexpression_elimination.rs
@@ -3,6 +3,7 @@
 //! Does not float expressions across branches or otherwise move them outside the block in which
 //! they appear (#172).
 
+use crate::compiler::util::ice_non_elided_tuple;
 use std::collections::{HashMap, HashSet};
 
 use crate::compiler::{
@@ -44,7 +45,6 @@ enum ExprNode {
     BitRange { value: ExprId, offset: usize, width: usize },
     Select { condition: ExprId, then: ExprId, otherwise: ExprId },
     ArrayGet { array: ExprId, index: ExprId },
-    TupleGet { tuple: ExprId, index: ExprId },
     Not(ExprId),
     ReadGlobal(u64),
     Cast { value: ExprId, target: CastTarget },
@@ -241,10 +241,6 @@ impl ExprInterner {
 
     fn array_get(&mut self, array: ExprId, index: ExprId) -> ExprId {
         self.intern(ExprNode::ArrayGet { array, index })
-    }
-
-    fn tuple_get(&mut self, tuple: ExprId, index: ExprId) -> ExprId {
-        self.intern(ExprNode::TupleGet { tuple, index })
     }
 
     fn select(&mut self, condition: ExprId, then: ExprId, otherwise: ExprId) -> ExprId {
@@ -1017,7 +1013,6 @@ impl CSE {
                     | OpCode::Call { .. }
                     | OpCode::MkSeq { .. }
                     | OpCode::MkRepeated { .. }
-                    | OpCode::MkTuple { .. }
                     | OpCode::ArraySet { .. }
                     | OpCode::SlicePush { .. }
                     | OpCode::SliceLen { .. }
@@ -1045,23 +1040,7 @@ impl CSE {
                             result_expr,
                         );
                     }
-                    OpCode::TupleProj {
-                        result: r,
-                        tuple,
-                        idx,
-                    } => {
-                        let tuple_expr = get_expr(&exprs, &mut interner, tuple);
-                        let index_expr = interner.uconst(64, *idx as u128);
-                        let result_expr = interner.tuple_get(tuple_expr, index_expr);
-                        record_expr(
-                            &mut exprs,
-                            &mut result,
-                            block_id,
-                            instruction_idx,
-                            *r,
-                            result_expr,
-                        );
-                    }
+                    OpCode::TupleProj { .. } | OpCode::MkTuple { .. } => ice_non_elided_tuple(),
                     OpCode::Guard { .. } => {
                         // Guards are opaque to CSE
                     }

--- a/compiler/src/compiler/passes/dead_code_elimination.rs
+++ b/compiler/src/compiler/passes/dead_code_elimination.rs
@@ -6,6 +6,7 @@
 //!
 //! TODO Refactor to use the existing liveness analysis (#157).
 
+use crate::compiler::util::ice_non_elided_tuple;
 use std::collections::{HashMap, HashSet};
 
 use crate::compiler::{
@@ -112,7 +113,6 @@ impl DCE {
             | OpCode::Select { .. }
             | OpCode::ArrayGet { .. }
             | OpCode::ArraySet { .. }
-            | OpCode::TupleProj { .. }
             | OpCode::SlicePush { .. }
             | OpCode::SliceLen { .. }
             | OpCode::MkSeq { .. }
@@ -123,10 +123,10 @@ impl DCE {
             | OpCode::Not { .. }
             | OpCode::MulConst { .. }
             | OpCode::ReadGlobal { .. }
-            | OpCode::MkTuple { .. }
             | OpCode::ValueOf { .. }
             | OpCode::Spread { .. }
             | OpCode::Unspread { .. } => false,
+            OpCode::TupleProj { .. } | OpCode::MkTuple { .. } => ice_non_elided_tuple(),
             OpCode::Guard { inner, .. } => self.is_initially_live(inner.as_ref()),
         }
     }

--- a/compiler/src/compiler/passes/instruction_lowering/side_effect_free_guards.rs
+++ b/compiler/src/compiler/passes/instruction_lowering/side_effect_free_guards.rs
@@ -1,5 +1,6 @@
 //! Removes guards around side-effect-free operations that are safe to execute unconditionally.
 
+use crate::compiler::util::ice_non_elided_tuple;
 use crate::compiler::{
     analysis::types::FunctionTypeInfo,
     ssa::hlssa::{
@@ -68,8 +69,6 @@ impl LowerSideEffectFreeGuards {
             | OpCode::Not { .. }
             | OpCode::MkSeq { .. }
             | OpCode::MkRepeated { .. }
-            | OpCode::MkTuple { .. }
-            | OpCode::TupleProj { .. }
             | OpCode::Alloc { .. }
             | OpCode::Load { .. }
             | OpCode::SlicePush { .. }
@@ -101,6 +100,7 @@ impl LowerSideEffectFreeGuards {
             | OpCode::Lookup { .. }
             | OpCode::DLookup { .. }
             | OpCode::Rangecheck { .. } => false,
+            OpCode::MkTuple { .. } | OpCode::TupleProj { .. } => ice_non_elided_tuple(),
             OpCode::Guard { .. } => panic!("nested Guard not expected"),
         }
     }

--- a/compiler/src/compiler/passes/instruction_lowering/witness_array.rs
+++ b/compiler/src/compiler/passes/instruction_lowering/witness_array.rs
@@ -3,6 +3,7 @@
 //! This pass deliberately emits ordinary arithmetic/comparison/rangecheck operations and leaves
 //! their constraint-level lowering to the later spilling passes.
 
+use crate::compiler::util::ice_non_elided_tuple;
 use ark_ff::Field as _;
 
 use crate::compiler::{
@@ -295,7 +296,8 @@ impl LowerWitnessArrayOps {
             TypeExpr::Slice(_) => {
                 panic!("multidimensional witness array read: slice element types not supported")
             }
-            TypeExpr::Tuple(_) | TypeExpr::Ref(_) | TypeExpr::Function => {
+            TypeExpr::Tuple(_) => ice_non_elided_tuple(),
+            TypeExpr::Ref(_) | TypeExpr::Function => {
                 panic!(
                     "multidimensional witness array read: unsupported element type {}",
                     target_type
@@ -331,7 +333,8 @@ fn leaf_scalar_count(t: &Type) -> usize {
         TypeExpr::Array(inner, n) => n * leaf_scalar_count(inner),
         TypeExpr::Field | TypeExpr::U(_) | TypeExpr::I(_) => 1,
         TypeExpr::WitnessOf(inner) => leaf_scalar_count(inner),
-        TypeExpr::Slice(_) | TypeExpr::Ref(_) | TypeExpr::Tuple(_) | TypeExpr::Function => {
+        TypeExpr::Tuple(_) => ice_non_elided_tuple(),
+        TypeExpr::Slice(_) | TypeExpr::Ref(_) | TypeExpr::Function => {
             panic!("leaf_scalar_count: unsupported type {}", t)
         }
     }

--- a/compiler/src/compiler/passes/rc_insertion.rs
+++ b/compiler/src/compiler/passes/rc_insertion.rs
@@ -5,6 +5,7 @@
 //! It also handles cases where values die along edges instead of within a block to actually perform
 //! the necessary decrements.
 
+use crate::compiler::util::ice_non_elided_tuple;
 use itertools::Itertools;
 use tracing::{Level, debug, instrument, trace};
 
@@ -173,42 +174,7 @@ impl RCInsertion {
                         new_instructions.push(instruction.clone());
                         currently_live.insert(*v);
                     }
-                    OpCode::TupleProj {
-                        result,
-                        tuple,
-                        idx: _,
-                    } => {
-                        if !currently_live.contains(tuple) {
-                            // The tuple dies here, so we drop it _after_ the read.
-                            new_instructions.push(OpCode::MemOp {
-                                kind: RefCountOp::Drop,
-                                value: *tuple,
-                            });
-                        }
-                        if self.needs_rc(type_info, result) {
-                            if currently_live.contains(result) {
-                                // The result gets a bump to the RC counter, because
-                                // it's now both accessed here and in the array.
-                                new_instructions.push(OpCode::MemOp {
-                                    kind: RefCountOp::Bump(1),
-                                    value: *result,
-                                });
-                            } else {
-                                panic!(
-                                    "ICE: Result of TupleProj (V{} in block {}) is not live. This is a bug.",
-                                    result.0, block_id.0
-                                )
-                            }
-                        } else {
-                            trace!(
-                                "TupleProj: result={} of type {:?} does not need RC",
-                                result.0,
-                                type_info.get_value_type(*result)
-                            );
-                        }
-                        new_instructions.push(instruction.clone());
-                        currently_live.insert(*tuple);
-                    }
+                    OpCode::TupleProj { .. } => ice_non_elided_tuple(),
                     OpCode::Cast {
                         result: r,
                         value: v,
@@ -728,42 +694,7 @@ impl RCInsertion {
                     OpCode::Guard { .. } => {
                         panic!("ICE: Guard should be lowered before RC insertion");
                     }
-                    OpCode::MkTuple {
-                        result,
-                        elems,
-                        element_types,
-                    } => {
-                        new_instructions.push(instruction.clone());
-                        for (input, group) in elems
-                            .iter()
-                            .zip(element_types)
-                            .sorted_by_key(|(v, _)| v.0)
-                            .chunk_by(|(v, _)| *v)
-                            .into_iter()
-                        {
-                            let items: Vec<_> = group.collect();
-                            let count = items.iter().count();
-                            let (_, elem_type) = items[0];
-
-                            if self.type_needs_rc(elem_type) {
-                                let mut count = count;
-                                if !currently_live.contains(input) {
-                                    count -= 1;
-                                }
-                                if count > 0 {
-                                    new_instructions.push(OpCode::MemOp {
-                                        kind: RefCountOp::Bump(count),
-                                        value: *input,
-                                    });
-                                }
-                            }
-                        }
-
-                        if !currently_live.contains(result) {
-                            panic!("ICE: Result of MkTuple is immediately dropped. This is a bug.")
-                        }
-                        currently_live.extend(elems);
-                    }
+                    OpCode::MkTuple { .. } => ice_non_elided_tuple(),
                 }
             }
             for param in block.get_parameter_values() {
@@ -854,7 +785,7 @@ impl RCInsertion {
             TypeExpr::U(_) => false,
             TypeExpr::I(_) => false,
             TypeExpr::WitnessOf(_) => true,
-            TypeExpr::Tuple(_) => true,
+            TypeExpr::Tuple(_) => ice_non_elided_tuple(),
             TypeExpr::Function => false,
         }
     }

--- a/compiler/src/compiler/passes/specializer.rs
+++ b/compiler/src/compiler/passes/specializer.rs
@@ -50,7 +50,6 @@ enum ConstVal {
     I(usize, u128),
     Field(Field),
     Array(Vec<ValueId>),
-    Tuple(Vec<ValueId>),
     BitsOf(Box<ValueId>, usize, Endianness),
 }
 
@@ -346,17 +345,6 @@ impl symbolic_executor::Value<SpecializationState<'_>> for Val {
         }
     }
 
-    fn tuple_get(&self, index: usize, _out_type: &Type, ctx: &mut SpecializationState) -> Self {
-        let a_const = ctx.const_vals.get(&self.0);
-        match a_const {
-            Some(ConstVal::Tuple(a)) => {
-                let res = a[index];
-                Self(res)
-            }
-            _ => panic!("Not yet implemented {:?}", a_const),
-        }
-    }
-
     fn array_set(
         &self,
         _index: &Self,
@@ -539,13 +527,6 @@ impl symbolic_executor::Value<SpecializationState<'_>> for Val {
         let a = a.into_iter().map(|v| v.0).collect::<Vec<_>>();
         let val = ctx.mk_seq(a.clone(), seq_type, elem_type.clone());
         ctx.const_vals.insert(val, ConstVal::Array(a));
-        Self(val)
-    }
-
-    fn mk_tuple(elems: Vec<Self>, ctx: &mut SpecializationState, elem_types: &[Type]) -> Self {
-        let a = elems.into_iter().map(|v| v.0).collect::<Vec<_>>();
-        let val = ctx.mk_tuple(a.clone(), elem_types.to_vec());
-        ctx.const_vals.insert(val, ConstVal::Tuple(a));
         Self(val)
     }
 
@@ -909,10 +890,6 @@ impl Specializer {
                     call_params.push(Val(val));
                     const_vals.insert(val, ConstVal::I(*bits_size, *value));
                 }
-                ValueSignature::Tuple(_) => {
-                    info!("TODO: Aborting specialization on a tuple value");
-                    return;
-                }
             }
         }
 
@@ -1029,9 +1006,6 @@ impl Specializer {
                         let cst = entry.i_const(*bits_size, *value);
                         let is_eq = entry.eq(*pval, cst);
                         cond = entry.and(cond, is_eq);
-                    }
-                    ValueSignature::Tuple(_) => {
-                        todo!();
                     }
                 }
             }

--- a/compiler/src/compiler/passes/strip_witness_of.rs
+++ b/compiler/src/compiler/passes/strip_witness_of.rs
@@ -4,6 +4,7 @@
 //! distinction. This pass converts all `WitnessOf(X)` types back to `X` and removes
 //! `Cast { target: WitnessOf }` instructions.
 
+use crate::compiler::util::ice_non_elided_tuple;
 use crate::compiler::{
     analysis::flow_analysis::FlowAnalysis,
     pass_manager::{AnalysisId, AnalysisStore, Pass},
@@ -98,11 +99,7 @@ impl StripWitnessOf {
                 *elem_type = elem_type.strip_all_witness();
             }
             OpCode::Cast { .. } => {}
-            OpCode::MkTuple { element_types, .. } => {
-                for tp in element_types.iter_mut() {
-                    *tp = tp.strip_all_witness();
-                }
-            }
+            OpCode::MkTuple { .. } | OpCode::TupleProj { .. } => ice_non_elided_tuple(),
             OpCode::ReadGlobal { result_type, .. } => {
                 *result_type = result_type.strip_all_witness();
             }
@@ -139,7 +136,6 @@ impl StripWitnessOf {
             | OpCode::DLookup { .. }
             | OpCode::MulConst { .. }
             | OpCode::Rangecheck { .. }
-            | OpCode::TupleProj { .. }
             | OpCode::InitGlobal { .. }
             | OpCode::DropGlobal { .. }
             | OpCode::Spread { .. }

--- a/compiler/src/compiler/passes/witness_lowering.rs
+++ b/compiler/src/compiler/passes/witness_lowering.rs
@@ -1,6 +1,7 @@
 //! Lowers witness operations such that there are no more implicit mixed pure / witness operations
 //! and so that every value entering an R1CS cosntraint has been explicitly cast to `WitnessOf`.
 
+use crate::compiler::util::ice_non_elided_tuple;
 use std::collections::HashMap;
 
 use crate::compiler::{
@@ -431,28 +432,13 @@ impl WitnessLowering {
                         | OpCode::ReadGlobal { .. }
                         | OpCode::InitGlobal { .. }
                         | OpCode::DropGlobal { .. }
-                        | OpCode::TupleProj { .. }
                         | OpCode::Todo { .. }
                         | OpCode::ValueOf { .. }
                         | OpCode::Spread { .. }
                         | OpCode::Unspread { .. } => {
                             emitter.emit(instruction);
                         }
-                        OpCode::MkTuple {
-                            result,
-                            elems,
-                            element_types,
-                        } => {
-                            let new_element_types = element_types
-                                .iter()
-                                .map(|tp| self.witness_lowering_in_type(tp))
-                                .collect();
-                            emitter.emit(OpCode::MkTuple {
-                                result,
-                                elems,
-                                element_types: new_element_types,
-                            });
-                        }
+                        OpCode::MkTuple { .. } | OpCode::TupleProj { .. } => ice_non_elided_tuple(),
                     };
                 }
 
@@ -516,20 +502,7 @@ impl WitnessLowering {
                     emitter,
                 )
             }
-            (TypeExpr::Tuple(src_fields), TypeExpr::Tuple(tgt_fields)) => {
-                assert_eq!(
-                    src_fields.len(),
-                    tgt_fields.len(),
-                    "Tuple field count mismatch in witness_lowering conversion"
-                );
-                let mut converted_elems = vec![];
-                for (i, (src_ft, tgt_ft)) in src_fields.iter().zip(tgt_fields.iter()).enumerate() {
-                    let proj = emitter.tuple_proj(value, i);
-                    let converted = self.emit_value_conversion(proj, src_ft, tgt_ft, emitter);
-                    converted_elems.push(converted);
-                }
-                emitter.mk_tuple(converted_elems, tgt_fields.clone())
-            }
+            (TypeExpr::Tuple(_), _) | (_, TypeExpr::Tuple(_)) => ice_non_elided_tuple(),
             (TypeExpr::WitnessOf(_), TypeExpr::WitnessOf(_)) => {
                 // Both source and target are WitnessOf — same runtime representation.
                 value
@@ -602,13 +575,7 @@ impl WitnessLowering {
                 b.cast_to_witness_of(dummy_field)
             }
             TypeExpr::Array(inner, size) => self.create_dummy_array(inner, *size, target_type, b),
-            TypeExpr::Tuple(fields) => {
-                let mut dummy_elems = vec![];
-                for field_type in fields.iter() {
-                    dummy_elems.push(self.create_dummy_value(field_type, b));
-                }
-                b.mk_tuple(dummy_elems, fields.clone())
-            }
+            TypeExpr::Tuple(_) => ice_non_elided_tuple(),
             TypeExpr::Field | TypeExpr::U(_) | TypeExpr::I(_) => {
                 b.field_const(ark_bn254::Fr::from(0u64))
             }
@@ -661,13 +628,7 @@ impl WitnessLowering {
             TypeExpr::Ref(inner) => self.witness_lowering_in_type(inner).ref_of(),
             TypeExpr::WitnessOf(_) => tp.clone(),
             TypeExpr::Function => tp.clone(),
-            TypeExpr::Tuple(elements) => {
-                let boxed_elements = elements
-                    .iter()
-                    .map(|elem| self.witness_lowering_in_type(elem))
-                    .collect();
-                Type::tuple_of(boxed_elements)
-            }
+            TypeExpr::Tuple(_) => ice_non_elided_tuple(),
         }
     }
 }

--- a/compiler/src/compiler/passes/witness_write_to_fresh.rs
+++ b/compiler/src/compiler/passes/witness_write_to_fresh.rs
@@ -2,6 +2,7 @@
 //! `WriteWitness` opcode into a `FreshWitness` opcode as the actual computed value cannot be known
 //! in this portion of the pipeline.
 
+use crate::compiler::util::ice_non_elided_tuple;
 use crate::compiler::{
     analysis::{flow_analysis::FlowAnalysis, types::TypeInfo},
     pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
@@ -90,12 +91,11 @@ impl WitnessWriteToFresh {
                         | OpCode::InitGlobal { .. }
                         | OpCode::DropGlobal { .. }
                         | OpCode::Todo { .. }
-                        | OpCode::TupleProj { .. }
-                        | OpCode::MkTuple { .. }
                         | OpCode::ValueOf { .. }
                         | OpCode::Spread { .. }
                         | OpCode::Unspread { .. }
                         | OpCode::Guard { .. } => instruction.clone(),
+                        OpCode::TupleProj { .. } | OpCode::MkTuple { .. } => ice_non_elided_tuple(),
                     };
                     *instruction = new_instruction;
                 }

--- a/compiler/src/compiler/ssa/hlssa_to_llssa.rs
+++ b/compiler/src/compiler/ssa/hlssa_to_llssa.rs
@@ -3,6 +3,7 @@
 //! Array types lower to heap-allocated RC'd structs behind `Ptr`. MkSeq, ArrayGet, ArraySet, and
 //! MemOp (Bump/Drop) are lowered to explicit memory operations.
 
+use crate::compiler::util::ice_non_elided_tuple;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     marker::PhantomData,
@@ -50,7 +51,7 @@ fn lower_type(ty: &HLType) -> LLType {
         HLTypeExpr::Array(..) => LLType::Ptr,
         // In the AD path, WitnessOf values are heap-allocated AD nodes
         HLTypeExpr::WitnessOf(_) => LLType::Ptr,
-        HLTypeExpr::Tuple(_) => LLType::Ptr,
+        HLTypeExpr::Tuple(_) => ice_non_elided_tuple(),
         HLTypeExpr::Ref(_) => LLType::Ptr,
         _ => panic!("Unsupported type in HLSSA->LLSSA lowering: {}", ty),
     }
@@ -70,7 +71,7 @@ fn elem_struct(ty: &HLType) -> LLStruct {
             LLStruct::new(vec![LLFieldType::Int(*bits as u32)])
         }
         HLTypeExpr::Array(..) => LLStruct::new(vec![LLFieldType::Ptr]),
-        HLTypeExpr::Tuple(_) => LLStruct::new(vec![LLFieldType::Ptr]),
+        HLTypeExpr::Tuple(_) => ice_non_elided_tuple(),
         HLTypeExpr::WitnessOf(_) => LLStruct::new(vec![LLFieldType::Ptr]),
         HLTypeExpr::Ref(_) => LLStruct::new(vec![LLFieldType::Ptr]),
         _ => panic!("Unsupported element type: {}", ty),
@@ -82,7 +83,7 @@ fn rc_array_struct(elem_type: &HLType, count: usize) -> LLStruct {
     LLStruct::rc_array(elem_struct(elem_type), count)
 }
 
-/// Convert an HLSSA element type to an LLFieldType for use in tuple struct layouts.
+/// Convert an HLSSA element type to an LLFieldType for use in RC'd cell struct layouts.
 fn tuple_field_type(ty: &HLType) -> LLFieldType {
     match &ty.expr {
         HLTypeExpr::Field => LLFieldType::Inline(LLStruct::field_elem()),
@@ -95,7 +96,7 @@ fn tuple_field_type(ty: &HLType) -> LLFieldType {
             LLFieldType::Int(*bits as u32)
         }
         HLTypeExpr::Array(..) => LLFieldType::Ptr,
-        HLTypeExpr::Tuple(_) => LLFieldType::Ptr,
+        HLTypeExpr::Tuple(_) => ice_non_elided_tuple(),
         HLTypeExpr::WitnessOf(_) => LLFieldType::Ptr,
         HLTypeExpr::Ref(_) => LLFieldType::Ptr,
         _ => panic!("Unsupported tuple element type: {}", ty),
@@ -108,16 +109,6 @@ fn rc_ref_cell_struct(inner_type: &HLType) -> LLStruct {
         LLFieldType::Inline(LLStruct::rc_header()),
         tuple_field_type(inner_type),
     ])
-}
-
-/// Build the LLStruct layout for a heap-allocated RC'd tuple.
-/// Layout: { Inline(RcHeader), field0, field1, ... }
-fn rc_tuple_struct(element_types: &[HLType]) -> LLStruct {
-    let mut fields = vec![LLFieldType::Inline(LLStruct::rc_header())];
-    for elem_ty in element_types {
-        fields.push(tuple_field_type(elem_ty));
-    }
-    LLStruct::new(fields)
 }
 
 /// Extract (element_type, count) from an HLSSA array type.
@@ -177,13 +168,7 @@ fn get_or_create_drop_fn(
                 get_or_create_drop_fn(inner, llssa, drop_fns, ad_fns);
             }
         }
-        HLTypeExpr::Tuple(elements) => {
-            for elem in elements {
-                if needs_drop(&elem.expr) {
-                    get_or_create_drop_fn(elem, llssa, drop_fns, ad_fns);
-                }
-            }
-        }
+        HLTypeExpr::Tuple(_) => ice_non_elided_tuple(),
         HLTypeExpr::Ref(inner) => {
             if needs_drop(&inner.expr) {
                 get_or_create_drop_fn(inner, llssa, drop_fns, ad_fns);
@@ -196,7 +181,7 @@ fn get_or_create_drop_fn(
     let fn_id = match &ty.expr {
         HLTypeExpr::WitnessOf(_) => ad_fns.get_drop_fn(llssa),
         HLTypeExpr::Array(_inner, _) => llssa.add_function(format!("drop_{}", ty)),
-        HLTypeExpr::Tuple(_) => llssa.add_function(format!("drop_{}", ty)),
+        HLTypeExpr::Tuple(_) => ice_non_elided_tuple(),
         HLTypeExpr::Ref(_) => llssa.add_function(format!("drop_{}", ty)),
         _ => panic!("{} is not supported yet", ty),
     };
@@ -1137,17 +1122,7 @@ fn lower_instruction(
             val_map.insert(*result_even, ll_even);
         }
 
-        OpCode::MkTuple {
-            result,
-            elems,
-            element_types,
-        } => {
-            lower_mk_tuple(e, val_map, *result, elems, element_types);
-        }
-
-        OpCode::TupleProj { result, tuple, idx } => {
-            lower_tuple_proj(e, val_map, fn_type_info, *result, *tuple, *idx);
-        }
+        OpCode::MkTuple { .. } | OpCode::TupleProj { .. } => ice_non_elided_tuple(),
 
         OpCode::Alloc { result, elem_type } => {
             lower_alloc(e, val_map, *result, elem_type);
@@ -1657,60 +1632,6 @@ fn lower_to_bytes(
     val_map.insert(result, arr);
 }
 
-/// Lower MkTuple to heap allocation + RC init + field stores.
-fn lower_mk_tuple(
-    e: &mut LLBlockEmitter<'_>,
-    val_map: &mut HashMap<ValueId, ValueId>,
-    result: ValueId,
-    elems: &[ValueId],
-    element_types: &[HLType],
-) {
-    let rc_struct = rc_tuple_struct(element_types);
-
-    // Allocate
-    let tuple_ptr = e.heap_alloc(rc_struct.clone(), None);
-
-    // Init RC to 1
-    let rc_hdr = e.struct_field_ptr(tuple_ptr, rc_struct.clone(), 0);
-    let rc_word = e.struct_field_ptr(rc_hdr, LLStruct::rc_header(), 0);
-    let one = e.emit_int_const(64, 1);
-    e.ll_store(rc_word, one);
-
-    // Store each element into its field (fields are at index 1, 2, 3, ...)
-    for (i, elem) in elems.iter().enumerate() {
-        let field_ptr = e.struct_field_ptr(tuple_ptr, rc_struct.clone(), i + 1);
-        let ll_elem = val_map[elem];
-        e.ll_store(field_ptr, ll_elem);
-    }
-
-    val_map.insert(result, tuple_ptr);
-}
-
-/// Lower TupleProj(Static) to StructFieldPtr + Load.
-fn lower_tuple_proj(
-    e: &mut LLBlockEmitter<'_>,
-    val_map: &mut HashMap<ValueId, ValueId>,
-    fn_type_info: &FunctionTypeInfo,
-    result: ValueId,
-    tuple: ValueId,
-    field_idx: usize,
-) {
-    let tuple_type = fn_type_info.get_value_type(tuple);
-    let element_types = tuple_type.get_tuple_elements();
-    let rc_struct = rc_tuple_struct(&element_types);
-
-    let ll_tuple = val_map[&tuple];
-
-    // Field is at index field_idx + 1 (field 0 is RC header)
-    let field_ptr = e.struct_field_ptr(ll_tuple, rc_struct, field_idx + 1);
-
-    // Load the field value
-    let field_ll_type = lower_type(&element_types[field_idx]);
-    let val = e.ll_load(field_ptr, field_ll_type);
-
-    val_map.insert(result, val);
-}
-
 /// Lower `Alloc { result, elem_type }` to heap_alloc of an RC'd ref cell.
 fn lower_alloc(
     e: &mut LLBlockEmitter<'_>,
@@ -1849,7 +1770,7 @@ fn lower_array_set(
     let inner_rc_struct = if elem_is_rc {
         Some(match &et.expr {
             HLTypeExpr::Array(inner, n) => rc_array_struct(inner, *n),
-            HLTypeExpr::Tuple(elements) => rc_tuple_struct(elements),
+            HLTypeExpr::Tuple(_) => ice_non_elided_tuple(),
             HLTypeExpr::WitnessOf(_) => LLStruct::ad_node_base(),
             _ => panic!("Unsupported RC element type: {}", et),
         })
@@ -1987,7 +1908,7 @@ fn lower_rc_bump(
 
     let rc_struct = match &val_type.expr {
         HLTypeExpr::Array(inner, count) => rc_array_struct(inner, *count),
-        HLTypeExpr::Tuple(elements) => rc_tuple_struct(elements),
+        HLTypeExpr::Tuple(_) => ice_non_elided_tuple(),
         HLTypeExpr::Ref(inner) => rc_ref_cell_struct(inner),
         _ => panic!("lower_rc_bump: unexpected type {}", val_type),
     };
@@ -2478,9 +2399,7 @@ fn generate_all_drop_functions(llssa: &mut LLSSA, drop_fns: &[DropFnEntry]) {
     for entry in drop_fns {
         let func = match &entry.ty.expr {
             HLTypeExpr::Array(..) => generate_drop_function_for_array(llssa, &entry.ty, drop_fns),
-            HLTypeExpr::Tuple(elements) => {
-                generate_drop_function_for_tuple(llssa, elements, &entry.ty, drop_fns)
-            }
+            HLTypeExpr::Tuple(_) => ice_non_elided_tuple(),
             HLTypeExpr::Ref(inner) => {
                 generate_drop_function_for_ref(llssa, inner, &entry.ty, drop_fns)
             }
@@ -2495,10 +2414,7 @@ fn generate_all_drop_functions(llssa: &mut LLSSA, drop_fns: &[DropFnEntry]) {
 fn needs_drop(expr: &HLTypeExpr) -> bool {
     matches!(
         expr,
-        HLTypeExpr::Array(..)
-            | HLTypeExpr::Tuple(..)
-            | HLTypeExpr::WitnessOf(..)
-            | HLTypeExpr::Ref(..)
+        HLTypeExpr::Array(..) | HLTypeExpr::WitnessOf(..) | HLTypeExpr::Ref(..)
     )
 }
 
@@ -2555,69 +2471,6 @@ fn generate_drop_function_for_array(
                     e.call(inner_drop_fn, vec![elem_val], 0);
                     vec![]
                 });
-            }
-            e.free(ptr);
-            vec![]
-        },
-        |_| vec![],
-    );
-
-    e.terminate_return(vec![]);
-    // LLBlockEmitter writes its block back and releases the `func` borrow in Drop.
-    drop(e);
-
-    func
-}
-
-/// Generate a drop function for an RC'd tuple.
-///
-/// Pseudocode:
-///   fn drop(ptr):
-///     rc = --ptr.header.rc
-///     if rc == 0:
-///       for each heap-allocated field i:
-///         drop_FieldType(ptr.field[i+1])
-///       free(ptr)
-///     return
-fn generate_drop_function_for_tuple(
-    llssa: &mut LLSSA,
-    element_types: &[HLType],
-    ty: &HLType,
-    drop_fns: &[DropFnEntry],
-) -> LLFunction {
-    let rc_struct = rc_tuple_struct(element_types);
-
-    let mut func = new_ll_function(llssa, format!("drop_{}", ty));
-    let entry = func.get_entry_id();
-
-    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
-    let ptr = e.add_parameter(LLType::Ptr);
-
-    // Decrement RC
-    let hdr = e.struct_field_ptr(ptr, rc_struct.clone(), 0);
-    let rc_ptr = e.struct_field_ptr(hdr, LLStruct::rc_header(), 0);
-    let new_rc = modify_rc(&mut e, rc_ptr, -1);
-
-    // If RC hit zero, drop inner heap-allocated elements and free
-    let zero = e.emit_int_const(64, 0);
-    let dead = e.int_eq(new_rc, zero);
-    e.build_if_else(
-        dead,
-        vec![],
-        |e| {
-            for (i, elem_ty) in element_types.iter().enumerate() {
-                if needs_drop(&elem_ty.expr) {
-                    let inner_drop_fn = drop_fns
-                        .iter()
-                        .find(|entry| entry.ty == *elem_ty)
-                        .expect("inner drop fn should exist for tuple element")
-                        .fn_id;
-
-                    // Field is at index i + 1 (field 0 is RC header)
-                    let field_ptr = e.struct_field_ptr(ptr, rc_struct.clone(), i + 1);
-                    let field_val = e.ll_load(field_ptr, LLType::Ptr);
-                    e.call(inner_drop_fn, vec![field_val], 0);
-                }
             }
             e.free(ptr);
             vec![]

--- a/compiler/src/compiler/untaint_control_flow.rs
+++ b/compiler/src/compiler/untaint_control_flow.rs
@@ -1,5 +1,6 @@
 //! Linearizes witness-dependent control flow into a form safe to lower into a ZK circuit.
 
+use crate::compiler::util::ice_non_elided_tuple;
 use std::collections::HashMap;
 
 use tracing::{Level, instrument};
@@ -149,27 +150,7 @@ impl UntaintControlFlow {
                             elem_type: apply_witness_type(tp, &r_wt),
                         }
                     }
-                    OpCode::MkTuple {
-                        result: r,
-                        elems: l,
-                        element_types: tps,
-                    } => {
-                        let r_wt = function_wt.get_value_witness_type(r);
-                        let child_wts = if let WitnessShape::Tuple(_, children) = r_wt {
-                            children
-                        } else {
-                            panic!("MkTuple result should have Tuple witness type")
-                        };
-                        OpCode::MkTuple {
-                            result: r,
-                            elems: l,
-                            element_types: tps
-                                .iter()
-                                .zip(child_wts.iter())
-                                .map(|(tp, wt)| apply_witness_type(tp.clone(), wt))
-                                .collect(),
-                        }
-                    }
+                    OpCode::MkTuple { .. } => ice_non_elided_tuple(),
                     OpCode::ReadGlobal {
                         result: r,
                         offset: l,
@@ -857,21 +838,7 @@ fn emit_value_conversion(
             );
             emit_unrolled_array_conversion(value, src_inner, tgt_inner, *src_size, builder)
         }
-        // Tuple: decompose, per-field recursive, recompose
-        (TypeExpr::Tuple(src_fields), TypeExpr::Tuple(tgt_fields)) => {
-            assert_eq!(
-                src_fields.len(),
-                tgt_fields.len(),
-                "Tuple field count mismatch in witness cast insertion"
-            );
-            let mut converted_elems = vec![];
-            for (i, (src_ft, tgt_ft)) in src_fields.iter().zip(tgt_fields.iter()).enumerate() {
-                let proj = builder.tuple_proj(value, i);
-                let converted = emit_value_conversion(proj, src_ft, tgt_ft, builder);
-                converted_elems.push(converted);
-            }
-            builder.mk_tuple(converted_elems, tgt_fields.clone())
-        }
+        (TypeExpr::Tuple(_), _) | (_, TypeExpr::Tuple(_)) => ice_non_elided_tuple(),
         _ => panic!(
             "witness cast insertion: unsupported conversion {:?} -> {:?}",
             source_type, target_type
@@ -933,17 +900,7 @@ fn emit_strip_witness(
                 *tgt_inner.clone(),
             )
         }
-        // Tuple: decompose, per-field recursive, recompose
-        (TypeExpr::Tuple(src_fields), TypeExpr::Tuple(tgt_fields)) => {
-            assert_eq!(src_fields.len(), tgt_fields.len());
-            let mut converted_elems = vec![];
-            for (i, (sf, tf)) in src_fields.iter().zip(tgt_fields.iter()).enumerate() {
-                let proj = builder.tuple_proj(value, i);
-                let converted = emit_strip_witness(proj, sf, tf, builder);
-                converted_elems.push(converted);
-            }
-            builder.mk_tuple(converted_elems, tgt_fields.clone())
-        }
+        (TypeExpr::Tuple(_), _) | (_, TypeExpr::Tuple(_)) => ice_non_elided_tuple(),
         _ => panic!(
             "emit_strip_witness: unsupported conversion {:?} -> {:?}",
             source_type, target_type
@@ -1006,42 +963,7 @@ fn emit_merge_select(
             });
             result
         }
-        TypeExpr::Tuple(result_fields) => {
-            let lhs_fields = match &lhs_type.expr {
-                TypeExpr::Tuple(f) => f,
-                _ => panic!(
-                    "emit_merge_select: expected tuple for lhs, got {:?}",
-                    lhs_type
-                ),
-            };
-            let rhs_fields = match &rhs_type.expr {
-                TypeExpr::Tuple(f) => f,
-                _ => panic!(
-                    "emit_merge_select: expected tuple for rhs, got {:?}",
-                    rhs_type
-                ),
-            };
-            let mut elems = Vec::with_capacity(result_fields.len());
-            for (i, ((rf, lf), rhsf)) in result_fields
-                .iter()
-                .zip(lhs_fields.iter())
-                .zip(rhs_fields.iter())
-                .enumerate()
-            {
-                let lhs_field = builder.tuple_proj(lhs, i);
-                let rhs_field = builder.tuple_proj(rhs, i);
-                let selected =
-                    emit_merge_select(builder, cond, lhs_field, rhs_field, None, rf, lf, rhsf);
-                elems.push(selected);
-            }
-            let result = result.unwrap_or_else(|| builder.fresh_value());
-            builder.push(OpCode::MkTuple {
-                result,
-                elems,
-                element_types: result_fields.clone(),
-            });
-            result
-        }
+        TypeExpr::Tuple(_) => ice_non_elided_tuple(),
         TypeExpr::WitnessOf(_) => {
             // Cast operands to WitnessOf if they aren't already
             let lhs = if !lhs_type.is_witness_of() {
@@ -1133,20 +1055,7 @@ fn apply_witness_type(typ: Type, wt: &WitnessShape) -> Type {
                 base
             }
         }
-        (TypeExpr::Tuple(child_types), WitnessShape::Tuple(top, child_wts)) => {
-            let base = Type::tuple_of(
-                child_types
-                    .iter()
-                    .zip(child_wts.iter())
-                    .map(|(child_type, child_wt)| apply_witness_type(child_type.clone(), child_wt))
-                    .collect(),
-            );
-            if top.is_witness() {
-                Type::witness_of(base)
-            } else {
-                base
-            }
-        }
+        (TypeExpr::Tuple(_), _) => ice_non_elided_tuple(),
         (tp, wt) => panic!("Unexpected type {:?} with witness type {:?}", tp, wt),
     }
 }

--- a/compiler/src/compiler/util.rs
+++ b/compiler/src/compiler/util.rs
@@ -2,6 +2,16 @@
 
 use crate::compiler::ssa::hlssa::MAX_SUPPORTED_UNSIGNED_BITS;
 
+/// Panic with the canonical ICE for a tuple surviving past the `ElideTuples` pass.
+///
+/// Everything downstream of `ElideTuples` operates on tuple-free IR; reaching a tuple opcode or
+/// tuple type there is a compiler bug. Call this from the (unreachable) tuple arms of downstream
+/// passes, analyses, and codegen.
+#[track_caller]
+pub fn ice_non_elided_tuple() -> ! {
+    panic!("ICE: Tuple encountered after ElideTuples pass")
+}
+
 pub fn spread_bits(v: u128, bits: usize) -> u128 {
     assert!(
         bits <= 64,


### PR DESCRIPTION
The work in #223 elided tuples from most of the compiler's front-end, but left much of the downstream code that was previously handling tuples to make it easier to review. This commit now removes all of that code, while ensuring that no functional regressions take place. It replaces explicit branches with ICEs in order to fail loudly should a tuple ever slip through.

Follow-up to #223. Closes #221.