### PR TITLE
Make compilation deterministic

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -67,6 +67,41 @@ jobs:
       - name: machete
         uses: bnjbvr/cargo-machete@main
 
+  determinism:
+    name: Check Compilation Determinism
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Download Nix Dependencies
+        run: nix develop
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build Test Runner
+        run: make build-test-runner
+
+      - name: Check Determinism
+        run: make determinism-check
+
   test:
     name: Run Tests
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,6 +2226,7 @@ dependencies = [
  "petgraph 0.6.5",
  "plotters",
  "rand 0.8.6",
+ "rustc-hash",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ suspicious = { level = "allow", priority = -1 }
 cast_slice_from_raw_parts = "deny"
 clone_on_copy = "deny"
 crosspointer_transmute = "deny"
+# Bans std's randomly-seeded hash collections (see clippy.toml): iteration order leaks into
+# emitted identifiers, breaking deterministic compilation. Use crate::collections instead.
+disallowed_types = "deny"
 drop_non_drop = "deny"
 expect_fun_call = "deny"
 for_kv_map = "deny"

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ unit-test: ## Run the unit tests
 func-test: ## Run the functional test harness
 	$(SHELL_WRAPPER) cargo run --release --bin test-runner -- --output STATUS.md
 
+.PHONY: determinism-check
+determinism-check: ## Check that compilation output is byte-identical across repeated runs.
+	$(SHELL_WRAPPER) cargo run --release --bin test-runner -- --check-determinism --jobs 4
+
 .PHONY: test
 test: unit-test func-test ## Run all the tests
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+disallowed-types = [
+  { path = "std::collections::HashMap", reason = "Iteration order is nondeterministic and leaks into compiler output; use crate::collections::HashMap (FxHash) or BTreeMap" },
+  { path = "std::collections::HashSet", reason = "Iteration order is nondeterministic and leaks into compiler output; use crate::collections::HashSet (FxHash) or BTreeSet" },
+  { path = "std::collections::hash_map::RandomState", reason = "Randomly seeded per process, which breaks deterministic compilation; use crate::collections::FxBuildHasher" },
+]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -32,6 +32,7 @@ num-traits = { version = "0.2" }
 petgraph = { version = "0.6.5" } # Cannot bump as it is currently required to be this version by a dependency
 plotters = { version = "0.3.5" }
 rand = { version = "0.8" }
+rustc-hash = { version = "2" }
 serde_json = { version = "1.0" }
 tempfile.workspace = true
 thiserror.workspace = true

--- a/compiler/src/bin/test_runner.rs
+++ b/compiler/src/bin/test_runner.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     env, fs,
     io::{BufRead, BufReader, Write},
     path::{Path, PathBuf},
@@ -11,6 +10,7 @@ use std::{
 };
 
 use cargo_metadata::MetadataCommand;
+use mavros_compiler::collections::HashMap;
 
 use ark_ff::UniformRand as _;
 use mavros_compiler::{
@@ -62,6 +62,16 @@ fn main() {
         let current = PathBuf::from(&args[3]);
         check_growth(&baseline, &current);
         return;
+    }
+
+    // Determinism check mode: --check-determinism [--runs N] [--jobs N] [test names...]
+    // Compiles each test several times in fresh processes and verifies the compiler
+    // output (SSA dumps, bytecode, R1CS shape) is byte-identical across runs.
+    if args.len() >= 2 && args[1] == "--check-determinism" {
+        let runs = parse_runs_arg(&args);
+        let jobs = parse_jobs_arg(&args);
+        let tests = parse_determinism_tests(&args);
+        std::process::exit(check_determinism(&tests, runs, jobs));
     }
 
     // Parent mode
@@ -1229,8 +1239,8 @@ fn ignored_test_result(name: &str) -> TestResult {
 }
 
 fn parse_child_output(name: &str, lines: &[String]) -> TestResult {
-    let mut started = HashMap::<String, bool>::new();
-    let mut ended = HashMap::<String, bool>::new();
+    let mut started = HashMap::<String, bool>::default();
+    let mut ended = HashMap::<String, bool>::default();
     let mut rows = None;
     let mut cols = None;
     let mut witgen_bytes = None;
@@ -1283,6 +1293,281 @@ fn parse_child_output(name: &str, lines: &[String]) -> TestResult {
         cols,
         witgen_bytes,
         ad_bytes,
+    }
+}
+
+// ── Determinism check ─────────────────────────────────────────────────
+
+/// Default subset for `--check-determinism`: small tests chosen to cover the passes where
+/// iteration order historically leaked into output (defunctionalize/fn-pointer interning,
+/// the specializer, globals lowering, tuple elision), plus one large composite (sha256).
+const DEFAULT_DETERMINISM_TESTS: &[&str] = &[
+    "higher_order_fns",
+    "lambda_array",
+    "recursion",
+    "power",
+    "array_lookup",
+    "struct_literals",
+    "sha256",
+];
+
+/// The dump files the driver writes under `mavros_debug/`, in pipeline-stage order, so the
+/// first divergent file names the stage that introduced the divergence.
+const DUMP_STAGE_ORDER: &[&str] = &[
+    "initial_ssa.txt",
+    "monomorphized_ssa.txt",
+    "untainted_ssa.txt",
+    "hlssa_before_lowering.txt",
+    "llssa_after_lowering.txt",
+    "witgen_bytecode.txt",
+    "ad_bytecode.txt",
+];
+
+fn parse_runs_arg(args: &[String]) -> usize {
+    let mut i = 1;
+    while i < args.len() {
+        if args[i] == "--runs" && i + 1 < args.len() {
+            let n: usize = args[i + 1]
+                .parse()
+                .expect("--runs requires a positive integer");
+            assert!(n >= 2, "--runs must be >= 2");
+            return n;
+        }
+        i += 1;
+    }
+    3
+}
+
+/// Positional arguments after `--check-determinism` (skipping flags and their values) name
+/// the tests to check; each is a directory name under `noir_tests/` or a path to a test.
+fn parse_determinism_tests(args: &[String]) -> Vec<String> {
+    let mut tests = Vec::new();
+    let mut i = 2;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--runs" | "--jobs" => i += 2,
+            name => {
+                tests.push(name.to_string());
+                i += 1;
+            }
+        }
+    }
+    if tests.is_empty() {
+        DEFAULT_DETERMINISM_TESTS
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    } else {
+        tests
+    }
+}
+
+/// What one `--run-single` execution produced, reduced to comparable form: a content hash
+/// per `mavros_debug` dump file, plus the non-WASM `START:`/`END:` lines from the child's
+/// stdout (which carry R1CS rows/cols, bytecode sizes, and pass/fail per stage).
+///
+/// WASM-lane outcomes are deliberately excluded: `llssa_to_llvm` has known pre-existing
+/// nondeterministic failures that are tracked separately, and including them here would
+/// mask regressions in the deterministic part of the pipeline behind known noise.
+struct RunFingerprint {
+    dump_hashes: std::collections::BTreeMap<String, u64>,
+    output_lines: Vec<String>,
+}
+
+/// Recursively copy a test project, skipping artifacts from previous runs.
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).expect("Cannot create destination dir");
+    for entry in fs::read_dir(src).expect("Cannot read source dir") {
+        let entry = entry.expect("Cannot read dir entry");
+        let name = entry.file_name();
+        if name == "mavros_debug" || name == "target" {
+            continue;
+        }
+        let src_path = entry.path();
+        let dst_path = dst.join(&name);
+        if src_path.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).expect("Cannot copy file");
+        }
+    }
+}
+
+/// Compile the test at `root` in a fresh child process and fingerprint the result.
+fn determinism_run(exe: &Path, wasm_runtime_lib: &Path, root: &Path) -> RunFingerprint {
+    use std::hash::{DefaultHasher, Hash, Hasher};
+
+    let mut child = Command::new(exe)
+        .args(["--run-single", root.to_str().unwrap()])
+        .env(wasm_runtime::WASM_RUNTIME_LIB_ENV, wasm_runtime_lib)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("Failed to spawn child");
+    let stdout = child.stdout.take().unwrap();
+    let output_lines: Vec<String> = BufReader::new(stdout)
+        .lines()
+        .map_while(Result::ok)
+        .filter(|line| {
+            (line.starts_with("START:") || line.starts_with("END:")) && !line.contains("WASM")
+        })
+        .collect();
+    let _ = child.wait();
+
+    let mut dump_hashes = std::collections::BTreeMap::new();
+    let debug_dir = root.join("mavros_debug");
+    if let Ok(entries) = fs::read_dir(&debug_dir) {
+        for entry in entries.filter_map(|e| e.ok()) {
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "txt") {
+                let contents = fs::read(&path).expect("Cannot read dump file");
+                let mut hasher = DefaultHasher::new();
+                contents.hash(&mut hasher);
+                dump_hashes.insert(
+                    path.file_name().unwrap().to_string_lossy().into_owned(),
+                    hasher.finish(),
+                );
+            }
+        }
+    }
+
+    RunFingerprint {
+        dump_hashes,
+        output_lines,
+    }
+}
+
+/// Compare `fp` against the reference run and name what diverged, in stage order.
+fn fingerprint_divergences(reference: &RunFingerprint, fp: &RunFingerprint) -> Vec<String> {
+    let mut divergent = Vec::new();
+    // Stage-ordered known dumps first, then anything unexpected.
+    let known = DUMP_STAGE_ORDER.iter().copied();
+    let extra = reference
+        .dump_hashes
+        .keys()
+        .chain(fp.dump_hashes.keys())
+        .map(|s| s.as_str())
+        .filter(|name| !DUMP_STAGE_ORDER.contains(name));
+    for name in known.chain(extra) {
+        if reference.dump_hashes.get(name) != fp.dump_hashes.get(name)
+            && !divergent.iter().any(|d| d == name)
+        {
+            divergent.push(name.to_string());
+        }
+    }
+    if reference.output_lines != fp.output_lines {
+        divergent.push("child stage output (R1CS shape / bytecode size / stage status)".into());
+    }
+    divergent
+}
+
+/// Run each test `runs` times in fresh processes (fresh process = fresh hash seeds, which is
+/// the property under test) and check all compiler output is byte-identical across runs.
+/// Returns the process exit code: 0 if everything is deterministic, 1 otherwise.
+fn check_determinism(tests: &[String], runs: usize, jobs: usize) -> i32 {
+    let resolved: Vec<TestEntry> = tests
+        .iter()
+        .map(|name| {
+            let path = if name.contains('/') {
+                PathBuf::from(name)
+            } else {
+                PathBuf::from("noir_tests").join(name)
+            };
+            assert!(
+                path.is_dir(),
+                "Test directory not found: {}",
+                path.display()
+            );
+            TestEntry {
+                path: fs::canonicalize(&path).unwrap(),
+                display_name: name.clone(),
+            }
+        })
+        .collect();
+
+    // Build the wasm runtime once and hand children the artifact path (see `run_parent`).
+    let wasm_runtime_lib = wasm_runtime::locate_or_build();
+    let exe = env::current_exe().expect("Cannot determine own exe path");
+
+    let scratch = tempfile::tempdir().expect("Cannot create scratch dir");
+    let total = resolved.len() * runs;
+    eprintln!(
+        "Checking determinism: {} test(s) x {runs} run(s), {jobs} parallel job(s)",
+        resolved.len()
+    );
+
+    // Copy every test x run into its own directory up front, then fingerprint them in
+    // parallel with the same worker-pool shape as `run_parent`.
+    let mut work: Vec<(usize, usize, PathBuf)> = Vec::new();
+    for (t, entry) in resolved.iter().enumerate() {
+        let test_dir_name = entry
+            .path
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        for r in 0..runs {
+            let dst = scratch.path().join(format!("{test_dir_name}-run{r}"));
+            copy_dir_recursive(&entry.path, &dst);
+            work.push((t, r, dst));
+        }
+    }
+
+    let next_idx = AtomicUsize::new(0);
+    let completed = AtomicUsize::new(0);
+    let slots: Vec<Mutex<Option<RunFingerprint>>> = (0..total).map(|_| Mutex::new(None)).collect();
+    std::thread::scope(|scope| {
+        for _ in 0..jobs {
+            scope.spawn(|| {
+                loop {
+                    let idx = next_idx.fetch_add(1, Ordering::SeqCst);
+                    if idx >= total {
+                        break;
+                    }
+                    let (t, r, dst) = &work[idx];
+                    let fp = determinism_run(&exe, &wasm_runtime_lib, dst);
+                    let n = completed.fetch_add(1, Ordering::SeqCst) + 1;
+                    eprintln!("[{n}/{total}] {} run {}", resolved[*t].display_name, r + 1);
+                    *slots[idx].lock().unwrap() = Some(fp);
+                }
+            });
+        }
+    });
+    let fingerprints: Vec<RunFingerprint> = slots
+        .into_iter()
+        .map(|m| m.into_inner().unwrap().expect("run slot unfilled"))
+        .collect();
+
+    let mut all_deterministic = true;
+    println!("| Test | Deterministic | First divergence |");
+    println!("|------|---------------|------------------|");
+    for (t, entry) in resolved.iter().enumerate() {
+        let base = t * runs;
+        let reference = &fingerprints[base];
+        let divergent: Vec<String> = (1..runs)
+            .flat_map(|r| fingerprint_divergences(reference, &fingerprints[base + r]))
+            .fold(Vec::new(), |mut acc, d| {
+                if !acc.contains(&d) {
+                    acc.push(d);
+                }
+                acc
+            });
+        if divergent.is_empty() {
+            println!("| {} | ✅ | |", entry.display_name);
+        } else {
+            all_deterministic = false;
+            println!("| {} | ❌ | {} |", entry.display_name, divergent.join(", "));
+        }
+    }
+
+    if all_deterministic {
+        eprintln!("All outputs deterministic across {runs} runs");
+        0
+    } else {
+        // Keep the scratch dir around so the divergent dumps can be diffed directly.
+        let kept = scratch.keep();
+        eprintln!("NONDETERMINISM DETECTED — dumps kept at {}", kept.display());
+        1
     }
 }
 

--- a/compiler/src/collections.rs
+++ b/compiler/src/collections.rs
@@ -1,0 +1,32 @@
+//! Customized collections for the compiler.
+//!
+//! # HashMap and HashSet
+//!
+//! `std`'s default [`RandomState`](std::collections::hash_map::RandomState) seeds every map
+//! differently per process, making iteration order nondeterministic. The compilation pipeline
+//! allocates identifiers from monotonic counters (e.g. `SSA::fresh_value`) *while iterating* such
+//! maps, so random iteration order leaks into emitted identifiers and ultimately into every dump
+//! and artifact. Since the pipeline is single-threaded, fixing the hasher makes compilation a pure
+//! function of its input.
+//!
+//! All compiler code must use these aliases instead of `std::collections::{HashMap, HashSet}`; this
+//! is enforced by `disallowed-types` in the workspace `clippy.toml`.
+//!
+//! Notes:
+//!
+//! - Construct with `HashMap::default()`, not `::new()` — the inherent `new` only exists for
+//!   the `RandomState` hasher.
+//! - FxHash output depends on the target word size, so iteration order may differ between 32- and
+//!   64-bit hosts. Run-to-run determinism on one host is the goal here; cross-architecture
+//!   reproducibility is out of scope.
+
+pub use rustc_hash::FxBuildHasher;
+
+// HASHED COLLECTIONS
+// ================================================================================================
+
+#[allow(clippy::disallowed_types)]
+pub type HashMap<K, V> = std::collections::HashMap<K, V, FxBuildHasher>;
+
+#[allow(clippy::disallowed_types)]
+pub type HashSet<T> = std::collections::HashSet<T, FxBuildHasher>;

--- a/compiler/src/compiler/analysis/flow_analysis.rs
+++ b/compiler/src/compiler/analysis/flow_analysis.rs
@@ -1,17 +1,19 @@
 //! Computes a robust graph analysis of the program, including a CFG, dominator tree, and general
 //! tools for recovery of structured control flow.
 
-use petgraph::Direction;
-use petgraph::algo::dominators::{self, Dominators};
-use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
-use petgraph::visit::{Bfs, DfsPostOrder, EdgeRef, Walker};
-use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
-use std::fs;
-use std::hash::Hash;
-use std::path::PathBuf;
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::ssa::{BlockId, FunctionId, Instruction, SSA, SSAType, Terminator},
+};
 
-use crate::compiler::ssa::{BlockId, FunctionId, Instruction, SSA, SSAType, Terminator};
+use petgraph::{
+    Direction,
+    algo::dominators::{self, Dominators},
+    graph::{DiGraph, EdgeIndex, NodeIndex},
+    visit::{Bfs, DfsPostOrder, EdgeRef, Walker},
+};
+
+use std::{fmt::Debug, fs, hash::Hash, path::PathBuf};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JumpType {
@@ -36,8 +38,8 @@ impl CFGData {
         let dominators = dominators::simple_fast(&cfg, entry);
         let mut preorder = Vec::new();
         let mut postorder = Vec::new();
-        let mut preorder_map = HashMap::new();
-        let mut postorder_map = HashMap::new();
+        let mut preorder_map = HashMap::default();
+        let mut postorder_map = HashMap::default();
         Self::compute_dominator_traversals(
             entry,
             &dominators,
@@ -67,7 +69,13 @@ impl CFGData {
     ) {
         preorder_map.insert(entry, preorder.len());
         preorder.push(entry);
-        for child in dominators.immediately_dominated_by(entry) {
+
+        // `immediately_dominated_by` iterates petgraph's internal randomly-seeded HashMap, so its
+        // order varies per process. The traversal orders block processing in several passes (and
+        // thus fresh ValueId allocation), so sort by node index to keep compilation deterministic.
+        let mut children: Vec<_> = dominators.immediately_dominated_by(entry).collect();
+        children.sort();
+        for child in children {
             if entry == child {
                 continue;
             }
@@ -101,7 +109,7 @@ impl CFGData {
     }
 
     pub fn get_dominance_frontier(&self, node: NodeIndex<u32>) -> HashSet<NodeIndex<u32>> {
-        let mut result = HashSet::new();
+        let mut result = HashSet::default();
         for candidate in self.cfg.node_indices() {
             if self.dominates(node, candidate) {
                 continue;
@@ -132,8 +140,8 @@ impl CFGBuilder {
         let return_node = cfg.add_node(());
         Self {
             cfg,
-            block_to_node: HashMap::new(),
-            node_to_block: HashMap::new(),
+            block_to_node: HashMap::default(),
+            node_to_block: HashMap::default(),
             entry_node,
             return_node,
         }
@@ -529,8 +537,8 @@ impl CallGraph {
     pub fn new() -> Self {
         CallGraph {
             call_graph: DiGraph::new(),
-            func_to_node: HashMap::new(),
-            node_to_func: HashMap::new(),
+            func_to_node: HashMap::default(),
+            node_to_func: HashMap::default(),
         }
     }
 
@@ -639,7 +647,7 @@ impl FlowAnalysis {
         ssa: &SSA<Op, Ty, C>,
     ) -> Self {
         let mut call_graph = CallGraph::new();
-        let mut function_cfgs = HashMap::new();
+        let mut function_cfgs = HashMap::default();
 
         for (func_id, _) in ssa.iter_functions() {
             call_graph.add_function(*func_id);

--- a/compiler/src/compiler/analysis/instrumenter.rs
+++ b/compiler/src/compiler/analysis/instrumenter.rs
@@ -5,27 +5,30 @@
 //! execution combined with an instrumenter for the circuit cost, and gives the compiler an idea of
 //! how much a function could be shrunk through specialization on concrete inputs.
 
-use crate::compiler::util::ice_non_elided_tuple;
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 
 use ark_ff::{AdditiveGroup, BigInt, BigInteger, PrimeField};
 use itertools::Itertools;
 use tracing::instrument;
 
-use crate::compiler::{
-    Field,
-    analysis::{
-        symbolic_executor::{self, SymbolicExecutor},
-        types::TypeInfo,
-    },
-    ssa::{
-        FunctionId,
-        hlssa::{
-            BinaryArithOpKind, CastTarget, CmpKind, Endianness, HLSSA, MAX_SUPPORTED_UNSIGNED_BITS,
-            Radix, RefCountOp, SequenceTargetType, SliceOpDir, Type, TypeExpr,
+use crate::{
+    collections::HashMap,
+    compiler::{
+        Field,
+        analysis::{
+            symbolic_executor::{self, SymbolicExecutor},
+            types::TypeInfo,
         },
+        ssa::{
+            FunctionId,
+            hlssa::{
+                BinaryArithOpKind, CastTarget, CmpKind, Endianness, HLSSA,
+                MAX_SUPPORTED_UNSIGNED_BITS, Radix, RefCountOp, SequenceTargetType, SliceOpDir,
+                Type, TypeExpr,
+            },
+        },
+        util::{ice_non_elided_tuple, spread_bits, unspread_bits},
     },
-    util::{spread_bits, unspread_bits},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1582,8 +1585,8 @@ impl Instrumenter {
     fn new() -> Self {
         Self {
             constraints: 0,
-            rangechecks: HashMap::new(),
-            lookups: HashMap::new(),
+            rangechecks: HashMap::default(),
+            lookups: HashMap::default(),
         }
     }
 }
@@ -1929,7 +1932,7 @@ impl CostAnalysis {
             self.stack.push((sig, Box::new(DummyInstrumenter {})));
         } else {
             let instrumenter = FunctionCost {
-                calls: HashMap::new(),
+                calls: HashMap::default(),
                 raw: Instrumenter::new(),
                 specialized: Instrumenter::new(),
             };
@@ -1982,7 +1985,7 @@ impl CostAnalysis {
 
     pub fn summarize(&self) -> Summary {
         let mut r = Summary {
-            functions: HashMap::new(),
+            functions: HashMap::default(),
             total_constraints: 0,
             total_savings_to_make: 0,
         };
@@ -2029,10 +2032,10 @@ impl CostEstimator {
     pub fn run(&self, ssa: &HLSSA, type_info: &TypeInfo) -> CostAnalysis {
         let main_sig = self.make_main_sig(ssa);
         let mut costs = CostAnalysis {
-            functions: HashMap::new(),
+            functions: HashMap::default(),
             stack: vec![],
             entry_point: Some(main_sig.clone()),
-            cache: HashMap::new(),
+            cache: HashMap::default(),
         };
 
         self.run_fn_from_signature(ssa, type_info, main_sig, &mut costs);

--- a/compiler/src/compiler/analysis/liveness.rs
+++ b/compiler/src/compiler/analysis/liveness.rs
@@ -1,16 +1,18 @@
 //! Computes the set of SSA values that are live-in and live-out for each block in the SSA using the
 //! conventional, block-based approach.
 
-use std::collections::{HashMap, HashSet, VecDeque};
-
 use itertools::Itertools;
+use std::collections::VecDeque;
 use tracing::{Level, instrument, trace};
 
-use crate::compiler::{
-    analysis::flow_analysis::{CFG, FlowAnalysis},
-    ssa::{
-        BlockId, FunctionId, Instruction, Terminator, ValueId,
-        hlssa::{HLFunction, HLSSA},
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        analysis::flow_analysis::{CFG, FlowAnalysis},
+        ssa::{
+            BlockId, FunctionId, Instruction, Terminator, ValueId,
+            hlssa::{HLFunction, HLSSA},
+        },
     },
 };
 
@@ -47,7 +49,7 @@ impl LivenessAnalysis {
     #[instrument(skip_all, name = "LivenessAnalysis::run")]
     pub fn run(&self, ssa: &HLSSA, cfg: &FlowAnalysis) -> Liveness {
         let mut result = Liveness {
-            function_liveness: HashMap::new(),
+            function_liveness: HashMap::default(),
         };
 
         for (function_id, function) in ssa.iter_functions() {
@@ -63,12 +65,12 @@ impl LivenessAnalysis {
 
     #[instrument(skip_all, level = Level::TRACE, name = "LivenessAnalysis::run_function", fields(function = function.get_name()))]
     fn run_function(&self, function: &HLFunction, cfg: &CFG) -> FunctionLiveness {
-        let mut gens = HashMap::<BlockId, HashSet<ValueId>>::new();
-        let mut kills = HashMap::<BlockId, HashSet<ValueId>>::new();
+        let mut gens = HashMap::<BlockId, HashSet<ValueId>>::default();
+        let mut kills = HashMap::<BlockId, HashSet<ValueId>>::default();
 
         for (block_id, block) in function.get_blocks() {
-            let mut k = HashSet::new();
-            let mut g = HashSet::new();
+            let mut k = HashSet::default();
+            let mut g = HashSet::default();
             match block.get_terminator().unwrap() {
                 Terminator::Return(vs) => {
                     for v in vs {
@@ -103,7 +105,7 @@ impl LivenessAnalysis {
             kills.insert(*block_id, k);
         }
 
-        let mut result = HashMap::<BlockId, BlockLiveness>::new();
+        let mut result = HashMap::<BlockId, BlockLiveness>::default();
         let mut queue = VecDeque::new();
 
         for ret in cfg.get_return_blocks() {
@@ -113,27 +115,27 @@ impl LivenessAnalysis {
         while let Some(block_id) = queue.pop_front() {
             let visited = result.contains_key(&block_id);
             result.entry(block_id).or_insert(BlockLiveness {
-                live_in: HashSet::new(),
-                live_out: HashSet::new(),
+                live_in: HashSet::default(),
+                live_out: HashSet::default(),
             });
             let original_live_in = &result.get(&block_id).unwrap().live_in;
 
-            let mut new_live_out: HashSet<ValueId> = HashSet::new();
+            let mut new_live_out: HashSet<ValueId> = HashSet::default();
 
             for block_id in cfg.get_successors(block_id) {
                 new_live_out.extend(
                     &result
                         .get(&block_id)
                         .unwrap_or(&BlockLiveness {
-                            live_in: HashSet::new(),
-                            live_out: HashSet::new(),
+                            live_in: HashSet::default(),
+                            live_out: HashSet::default(),
                         })
                         .live_in,
                 );
             }
 
             let mut new_live_in = new_live_out.clone();
-            new_live_in.extend(gens.get(&block_id).unwrap_or(&HashSet::new()));
+            new_live_in.extend(gens.get(&block_id).unwrap_or(&HashSet::default()));
             let kills = kills.get(&block_id).unwrap();
             new_live_in.retain(|v| !kills.contains(v));
 

--- a/compiler/src/compiler/analysis/symbolic_executor.rs
+++ b/compiler/src/compiler/analysis/symbolic_executor.rs
@@ -2,21 +2,22 @@
 //! into by providing their own `Value` and `Context` implementations that specialize it for their
 //! use-case.
 
-use crate::compiler::util::ice_non_elided_tuple;
-use std::collections::HashMap;
-
 use tracing::{Level, instrument};
 
-use crate::compiler::{
-    Field,
-    analysis::types::TypeInfo,
-    ssa::{
-        BlockId, FunctionId, Instruction, Terminator, ValueId,
-        hlssa::{
-            BinaryArithOpKind, CallTarget, CastTarget, CmpKind, Constant, Endianness, HLSSA,
-            HLSSAConstantsSnapshot, LookupTarget, OpCode, Radix, RefCountOp, SequenceTargetType,
-            SliceOpDir, Type, TypeExpr,
+use crate::{
+    collections::HashMap,
+    compiler::{
+        Field,
+        analysis::types::TypeInfo,
+        ssa::{
+            BlockId, FunctionId, Instruction, Terminator, ValueId,
+            hlssa::{
+                BinaryArithOpKind, CallTarget, CastTarget, CmpKind, Constant, Endianness, HLSSA,
+                HLSSAConstantsSnapshot, LookupTarget, OpCode, Radix, RefCountOp,
+                SequenceTargetType, SliceOpDir, Type, TypeExpr,
+            },
         },
+        util::ice_non_elided_tuple,
     },
 };
 
@@ -698,7 +699,7 @@ struct Scope<'c, V> {
 impl<'c, V> Scope<'c, V> {
     fn new(consts: &'c HashMap<ValueId, V>) -> Self {
         Self {
-            locals: HashMap::new(),
+            locals: HashMap::default(),
             consts,
         }
     }
@@ -732,7 +733,7 @@ fn materialize_constants<V, Ctx>(
 where
     V: Value<Ctx>,
 {
-    let mut consts = HashMap::new();
+    let mut consts = HashMap::default();
     for (vid, cv) in constants {
         let v = materialize_constant_value(cv.as_ref(), ctx);
         consts.insert(*vid, v);

--- a/compiler/src/compiler/analysis/types.rs
+++ b/compiler/src/compiler/analysis/types.rs
@@ -2,17 +2,18 @@
 //! perform detailed bookkeeping of type information whenever transforming the IR.
 
 use core::panic;
-use std::collections::HashMap;
-
 use tracing::{Level, instrument};
 
-use crate::compiler::{
-    analysis::flow_analysis::{CFG, FlowAnalysis},
-    ssa::{
-        FunctionId, ValueId,
-        hlssa::{
-            CallTarget, CastTarget, Constant, HLFunction, HLSSA, MAX_SUPPORTED_UNSIGNED_BITS,
-            OpCode, Type, TypeExpr,
+use crate::{
+    collections::HashMap,
+    compiler::{
+        analysis::flow_analysis::{CFG, FlowAnalysis},
+        ssa::{
+            FunctionId, ValueId,
+            hlssa::{
+                CallTarget, CastTarget, Constant, HLFunction, HLSSA, MAX_SUPPORTED_UNSIGNED_BITS,
+                OpCode, Type, TypeExpr,
+            },
         },
     },
 };
@@ -74,7 +75,7 @@ impl Types {
 
     pub fn run(&self, ssa: &HLSSA, cfg: &FlowAnalysis) -> TypeInfo {
         let mut type_info = TypeInfo {
-            functions: HashMap::new(),
+            functions: HashMap::default(),
         };
 
         let function_types = ssa

--- a/compiler/src/compiler/analysis/value_definitions.rs
+++ b/compiler/src/compiler/analysis/value_definitions.rs
@@ -9,11 +9,12 @@
 //! which is always up to date (including values minted mid-pass), so callers resolve them live via
 //! [`crate::compiler::ssa::SSA::get_const`] rather than from a stale snapshot.
 
-use std::collections::HashMap;
-
-use crate::compiler::ssa::{
-    BlockId, Instruction, ValueId,
-    hlssa::{HLFunction, OpCode, Type},
+use crate::{
+    collections::HashMap,
+    compiler::ssa::{
+        BlockId, Instruction, ValueId,
+        hlssa::{HLFunction, OpCode, Type},
+    },
 };
 
 pub enum ValueDefinition {
@@ -28,7 +29,7 @@ pub struct FunctionValueDefinitions {
 impl FunctionValueDefinitions {
     pub fn new() -> Self {
         Self {
-            definitions: HashMap::new(),
+            definitions: HashMap::default(),
         }
     }
 

--- a/compiler/src/compiler/analysis/value_range_analysis.rs
+++ b/compiler/src/compiler/analysis/value_range_analysis.rs
@@ -1,24 +1,25 @@
 //! Determines the smallest closed interval over which any numeric value in the SSA can range,
 //! uniformly across all integer types.
 
-use std::collections::HashMap;
-
 use ark_ff::PrimeField;
 use num_bigint::{BigInt, Sign};
 use num_traits::{One, Signed, Zero};
 use tracing::{Level, instrument};
 
-use crate::compiler::{
-    Field,
-    analysis::{
-        flow_analysis::{CFG, FlowAnalysis},
-        types::{FunctionTypeInfo, TypeInfo},
-    },
-    pass_manager::{Analysis, AnalysisId, AnalysisStore},
-    ssa::{
-        BlockId, FunctionId, Instruction, Terminator, ValueId,
-        hlssa::{
-            BinaryArithOpKind, CastTarget, Constant, HLFunction, HLSSA, OpCode, Type, TypeExpr,
+use crate::{
+    collections::HashMap,
+    compiler::{
+        Field,
+        analysis::{
+            flow_analysis::{CFG, FlowAnalysis},
+            types::{FunctionTypeInfo, TypeInfo},
+        },
+        pass_manager::{Analysis, AnalysisId, AnalysisStore},
+        ssa::{
+            BlockId, FunctionId, Instruction, Terminator, ValueId,
+            hlssa::{
+                BinaryArithOpKind, CastTarget, Constant, HLFunction, HLSSA, OpCode, Type, TypeExpr,
+            },
         },
     },
 };
@@ -433,7 +434,7 @@ impl ValueRangeAnalysis {
     #[instrument(skip_all, name = "ValueRangeAnalysis::run")]
     pub fn run(&self, ssa: &HLSSA, cfg: &FlowAnalysis, types: &TypeInfo) -> ValueRanges {
         let mut result = ValueRanges {
-            functions: HashMap::new(),
+            functions: HashMap::default(),
         };
 
         // Constants are module-level singletons; pre-compute their bounds once.

--- a/compiler/src/compiler/analysis/witness_info.rs
+++ b/compiler/src/compiler/analysis/witness_info.rs
@@ -1,7 +1,11 @@
 use itertools::Itertools;
 
-use crate::compiler::ssa::{BlockId, FunctionId, SSAAnotator, ValueId};
-use std::{collections::HashMap, fmt::Display};
+use std::fmt::Display;
+
+use crate::{
+    collections::HashMap,
+    compiler::ssa::{BlockId, FunctionId, SSAAnotator, ValueId},
+};
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
 pub enum WitnessType {

--- a/compiler/src/compiler/analysis/witness_type_inference.rs
+++ b/compiler/src/compiler/analysis/witness_type_inference.rs
@@ -1,17 +1,23 @@
 //! Performs whole program analysis to determine which values are potentially witness tainted, which
 //! are _only_ witnesses, and which are only non-witness values.
 
-use crate::compiler::util::ice_non_elided_tuple;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::VecDeque;
 
-use super::witness_info::{FunctionWitnessType, WitnessShape, WitnessType};
-use crate::compiler::{
-    analysis::flow_analysis::{self, FlowAnalysis},
-    ssa::{
-        BlockId, FunctionId, SSAAnotator, Terminator, ValueId,
-        hlssa::{
-            CallTarget, CastTarget, Constant, HLBlock, HLFunction, HLSSA, OpCode, Type, TypeExpr,
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        analysis::{
+            flow_analysis::{self, FlowAnalysis},
+            witness_info::{FunctionWitnessType, WitnessShape, WitnessType},
         },
+        ssa::{
+            BlockId, FunctionId, SSAAnotator, Terminator, ValueId,
+            hlssa::{
+                CallTarget, CastTarget, Constant, HLBlock, HLFunction, HLSSA, OpCode, Type,
+                TypeExpr,
+            },
+        },
+        util::ice_non_elided_tuple,
     },
 };
 
@@ -65,7 +71,7 @@ pub struct WitnessTypeInference {
 impl WitnessTypeInference {
     pub fn new() -> Self {
         WitnessTypeInference {
-            functions: HashMap::new(),
+            functions: HashMap::default(),
         }
     }
 
@@ -114,11 +120,11 @@ impl WitnessTypeInference {
         let main_specialized_id = ssa.duplicate_function(main_id);
         ssa.set_entry_point(main_specialized_id);
 
-        let mut specializations: HashMap<SpecKey, SpecValue> = HashMap::new();
+        let mut specializations: HashMap<SpecKey, SpecValue> = HashMap::default();
         let mut worklist: VecDeque<SpecKey> = VecDeque::new();
-        let mut queued: HashSet<SpecKey> = HashSet::new();
+        let mut queued: HashSet<SpecKey> = HashSet::default();
         // Track which specializations call which (for re-queuing callers)
-        let mut callers: HashMap<SpecKey, HashSet<SpecKey>> = HashMap::new();
+        let mut callers: HashMap<SpecKey, HashSet<SpecKey>> = HashMap::default();
 
         specializations.insert(
             main_key.clone(),
@@ -296,9 +302,9 @@ impl WitnessTypeInference {
         let block_queue: Vec<BlockId> = cfg.get_blocks_bfs().collect();
 
         // Inner state
-        let mut value_wt: HashMap<ValueId, WitnessShape> = HashMap::new();
-        let mut block_cfg: HashMap<BlockId, WitnessType> = HashMap::new();
-        let mut alloc_inner: HashMap<ValueId, WitnessShape> = HashMap::new();
+        let mut value_wt: HashMap<ValueId, WitnessShape> = HashMap::default();
+        let mut block_cfg: HashMap<BlockId, WitnessType> = HashMap::default();
+        let mut alloc_inner: HashMap<ValueId, WitnessShape> = HashMap::default();
 
         ssa.for_each_const(|vid, val| {
             let shape = match val.as_ref() {

--- a/compiler/src/compiler/codegen/bytecode/layout.rs
+++ b/compiler/src/compiler/codegen/bytecode/layout.rs
@@ -1,9 +1,7 @@
 //! Tools and utilities for computing layouts when generating bytecode.
 
-use crate::compiler::util::ice_non_elided_tuple;
-use std::collections::HashMap;
-
 use crate::{
+    collections::HashMap,
     compiler::{
         codegen::constants,
         ssa::{
@@ -12,6 +10,7 @@ use crate::{
                 HLSSA, MAX_SUPPORTED_SIGNED_BITS, MAX_SUPPORTED_UNSIGNED_BITS, Type, TypeExpr,
             },
         },
+        util::ice_non_elided_tuple,
     },
     vm::{self, bytecode},
 };
@@ -26,7 +25,7 @@ impl FrameLayouter {
     pub fn new() -> Self {
         Self {
             next_free: 2,
-            variables: HashMap::new(),
+            variables: HashMap::default(),
         }
     }
 
@@ -132,7 +131,7 @@ impl StructLayoutInterner {
     pub fn new() -> Self {
         Self {
             table: Vec::new(),
-            index: HashMap::new(),
+            index: HashMap::default(),
         }
     }
 

--- a/compiler/src/compiler/codegen/bytecode/mod.rs
+++ b/compiler/src/compiler/codegen/bytecode/mod.rs
@@ -2,10 +2,8 @@
 
 pub mod layout;
 
-use crate::compiler::util::ice_non_elided_tuple;
-use std::collections::HashMap;
-
 use crate::{
+    collections::HashMap,
     compiler::{
         analysis::{
             flow_analysis::{CFG, FlowAnalysis},
@@ -22,6 +20,7 @@ use crate::{
                 Type, TypeExpr,
             },
         },
+        util::ice_non_elided_tuple,
     },
     vm::{self, bytecode},
 };
@@ -37,7 +36,8 @@ fn materialize_constants(
     layouter: &mut FrameLayouter,
     emitter: &mut EmitterState,
 ) {
-    let mut referenced: std::collections::HashSet<ValueId> = std::collections::HashSet::new();
+    let mut referenced: crate::collections::HashSet<ValueId> =
+        crate::collections::HashSet::default();
     for (_, block) in function.get_blocks() {
         for instr in block.get_instructions() {
             for vid in instr.get_inputs() {
@@ -181,7 +181,7 @@ impl CodeGen {
 
         let mut functions = vec![function];
 
-        let mut function_ids = HashMap::new();
+        let mut function_ids = HashMap::default();
         function_ids.insert(ssa.get_main_id(), 0);
 
         let mut cur_fn_begin = functions[0].code.len();
@@ -1651,8 +1651,8 @@ impl EmitterState {
     fn new() -> Self {
         Self {
             code: Vec::new(),
-            block_entrances: HashMap::new(),
-            block_exits: HashMap::new(),
+            block_entrances: HashMap::default(),
+            block_exits: HashMap::default(),
         }
     }
 

--- a/compiler/src/compiler/codegen/llssa_to_llvm.rs
+++ b/compiler/src/compiler/codegen/llssa_to_llvm.rs
@@ -3,31 +3,33 @@
 //! Translates LLSSA into LLVM IR, which can then be compiled to WebAssembly.
 //! Operates on LLSSA + Type — types are explicit in the LLSSA ops, no TypeInfo needed.
 
-use std::collections::HashMap;
-use std::num::NonZeroU32;
-use std::path::Path;
+use std::{num::NonZeroU32, path::Path};
 
-use inkwell::AddressSpace;
-use inkwell::IntPredicate;
-use inkwell::OptimizationLevel;
-use inkwell::builder::Builder;
-use inkwell::context::Context;
-use inkwell::module::{Linkage, Module};
-use inkwell::targets::{
-    CodeModel, FileType, InitializationConfig, RelocMode, Target, TargetTriple,
-};
-use inkwell::types::{BasicMetadataTypeEnum, BasicType, BasicTypeEnum};
-use inkwell::values::{
-    BasicMetadataValueEnum, BasicValueEnum, FunctionValue, IntValue, PointerValue, StructValue,
+use inkwell::{
+    AddressSpace, IntPredicate, OptimizationLevel,
+    builder::Builder,
+    context::Context,
+    module::{Linkage, Module},
+    targets::{CodeModel, FileType, InitializationConfig, RelocMode, Target, TargetTriple},
+    types::{BasicMetadataTypeEnum, BasicType, BasicTypeEnum},
+    values::{
+        BasicMetadataValueEnum, BasicValueEnum, FunctionValue, IntValue, PointerValue, StructValue,
+    },
 };
 
-use crate::compiler::analysis::flow_analysis;
-use crate::compiler::analysis::flow_analysis::FlowAnalysis;
-use crate::compiler::ssa::llssa::{
-    Blob as LLBlob, Constant, FieldArithOp, IntArithOp, IntCmpOp, LLFieldType, LLFunction, LLOp,
-    LLSSA, LLStruct, Type,
+use crate::{
+    collections::HashMap,
+    compiler::{
+        analysis::flow_analysis::{self, FlowAnalysis},
+        ssa::{
+            BlockId, FunctionId, SSAConstantsSnapshot, Terminator, ValueId,
+            llssa::{
+                Blob as LLBlob, Constant, FieldArithOp, IntArithOp, IntCmpOp, LLFieldType,
+                LLFunction, LLOp, LLSSA, LLStruct, Type,
+            },
+        },
+    },
 };
-use crate::compiler::ssa::{BlockId, FunctionId, SSAConstantsSnapshot, Terminator, ValueId};
 
 const WASM_STACK_SIZE_BYTES: u32 = 256 * 1024;
 
@@ -109,10 +111,10 @@ impl<'ctx> LLVMCodeGen<'ctx> {
             context,
             module,
             builder,
-            value_map: HashMap::new(),
-            constants: HashMap::new(),
-            block_map: HashMap::new(),
-            function_map: HashMap::new(),
+            value_map: HashMap::default(),
+            constants: HashMap::default(),
+            block_map: HashMap::default(),
+            function_map: HashMap::default(),
             vm_ptr: None,
             field_mul_fn: None,
             field_add_fn: None,
@@ -611,7 +613,7 @@ impl<'ctx> LLVMCodeGen<'ctx> {
 
         // Track phi nodes
         let mut phi_nodes: HashMap<(BlockId, usize), inkwell::values::PhiValue<'ctx>> =
-            HashMap::new();
+            HashMap::default();
 
         // Generate code in dominator order
         for block_id in cfg.get_domination_pre_order() {

--- a/compiler/src/compiler/lowering/expression_converter.rs
+++ b/compiler/src/compiler/lowering/expression_converter.rs
@@ -1,23 +1,27 @@
 //! Converts monomorphized AST expressions to SSA instructions.
 
-use std::collections::{HashMap, HashSet};
-
-use noirc_frontend::ast::BinaryOpKind;
-use noirc_frontend::monomorphization::ast::{
-    Assign, Binary, Definition, Expression, For, FuncId as AstFuncId, GlobalId, Ident, If, Index,
-    LValue, Let, LocalId, Type as AstType, While,
-};
-
-use crate::compiler::ssa::{
-    BlockId, FunctionId, ValueId,
-    hlssa::{
-        Blob, CastTarget, Constant, Endianness, MAX_SUPPORTED_SIGNED_BITS, Radix,
-        SequenceTargetType, Type, TypeExpr,
-        builder::{HLEmitter, HLFunctionBuilder},
+use noirc_frontend::{
+    ast::BinaryOpKind,
+    monomorphization::ast::{
+        Assign, Binary, Definition, Expression, For, FuncId as AstFuncId, GlobalId, Ident, If,
+        Index, LValue, Let, LocalId, Type as AstType, While,
     },
 };
 
-use super::type_converter::TypeConverter;
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        lowering::type_converter::TypeConverter,
+        ssa::{
+            BlockId, FunctionId, ValueId,
+            hlssa::{
+                Blob, CastTarget, Constant, Endianness, MAX_SUPPORTED_SIGNED_BITS, Radix,
+                SequenceTargetType, Type, TypeExpr,
+                builder::{HLEmitter, HLFunctionBuilder},
+            },
+        },
+    },
+};
 
 /// Loop context for break/continue support.
 struct LoopContext {
@@ -69,8 +73,8 @@ impl<'a> ExpressionConverter<'a> {
         entry_block: BlockId,
     ) -> Self {
         Self {
-            bindings: HashMap::new(),
-            mutable_locals: HashSet::new(),
+            bindings: HashMap::default(),
+            mutable_locals: HashSet::default(),
             function_mapper,
             natively_unconstrained,
             type_converter: TypeConverter::new(),

--- a/compiler/src/compiler/lowering/mod.rs
+++ b/compiler/src/compiler/lowering/mod.rs
@@ -6,17 +6,18 @@
 mod expression_converter;
 mod type_converter;
 
-use std::collections::{HashMap, HashSet};
-
 use noirc_frontend::monomorphization::ast::{
     Definition, Expression, FuncId as AstFuncId, Function as AstFunction, GlobalId, Program,
 };
 
-use crate::compiler::ssa::{
-    FunctionId,
-    hlssa::{
-        HLFunction, HLSSA,
-        builder::{HLEmitter, HLFunctionBuilder, HLSSABuilder},
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::ssa::{
+        FunctionId,
+        hlssa::{
+            HLFunction, HLSSA,
+            builder::{HLEmitter, HLFunctionBuilder, HLSSABuilder},
+        },
     },
 };
 
@@ -47,10 +48,10 @@ pub struct SSAConverter {
 impl SSAConverter {
     pub fn new() -> Self {
         Self {
-            constrained_mapper: HashMap::new(),
-            unconstrained_mapper: HashMap::new(),
-            natively_unconstrained: HashSet::new(),
-            global_slots: HashMap::new(),
+            constrained_mapper: HashMap::default(),
+            unconstrained_mapper: HashMap::default(),
+            natively_unconstrained: HashSet::default(),
+            global_slots: HashMap::default(),
             type_converter: TypeConverter::new(),
         }
     }
@@ -197,15 +198,18 @@ impl SSAConverter {
 
         // Topological sort: process globals in dependency order.
         // Build adjacency: each global depends on other globals referenced in its initializer.
-        let all_ids: Vec<GlobalId> = program.globals.keys().copied().collect();
-        let mut visited = std::collections::HashSet::new();
-        let mut in_stack = std::collections::HashSet::new();
+        // `Program.globals` is a `BTreeMap`, so key order is already deterministic; the sort
+        // makes slot assignment robust even if that container ever changes.
+        let mut all_ids: Vec<GlobalId> = program.globals.keys().copied().collect();
+        all_ids.sort();
+        let mut visited = crate::collections::HashSet::default();
+        let mut in_stack = crate::collections::HashSet::default();
 
         fn topo_visit(
             gid: GlobalId,
             program: &Program,
-            visited: &mut std::collections::HashSet<GlobalId>,
-            in_stack: &mut std::collections::HashSet<GlobalId>,
+            visited: &mut crate::collections::HashSet<GlobalId>,
+            in_stack: &mut crate::collections::HashSet<GlobalId>,
             ordered: &mut Vec<GlobalId>,
         ) {
             if visited.contains(&gid) {

--- a/compiler/src/compiler/pass_manager.rs
+++ b/compiler/src/compiler/pass_manager.rs
@@ -1,15 +1,17 @@
 use std::{
     any::{Any, TypeId},
-    collections::HashMap,
     fmt::Debug,
     fs,
     hash::Hash,
     path::PathBuf,
 };
 
-use crate::compiler::ssa::{
-    DefaultSSAAnnotator, Instruction, SSA, SSAType,
-    hlssa::{Constant, OpCode, Type},
+use crate::{
+    collections::HashMap,
+    compiler::ssa::{
+        DefaultSSAAnnotator, Instruction, SSA, SSAType,
+        hlssa::{Constant, OpCode, Type},
+    },
 };
 
 // ---------------------------------------------------------------------------
@@ -112,8 +114,8 @@ pub struct AnalysisStore {
 impl AnalysisStore {
     pub fn new() -> Self {
         Self {
-            data: HashMap::new(),
-            deps: HashMap::new(),
+            data: HashMap::default(),
+            deps: HashMap::default(),
         }
     }
 
@@ -199,12 +201,12 @@ pub trait Pass<
 
 fn topo_sort(roots: Vec<AnalysisId>, store: &AnalysisStore) -> Vec<AnalysisId> {
     let mut result = Vec::new();
-    let mut visited = std::collections::HashSet::new();
+    let mut visited = crate::collections::HashSet::default();
 
     fn visit(
         id: AnalysisId,
         store: &AnalysisStore,
-        visited: &mut std::collections::HashSet<TypeId>,
+        visited: &mut crate::collections::HashSet<TypeId>,
         result: &mut Vec<AnalysisId>,
     ) {
         if store.contains_type(id.type_id) || !visited.insert(id.type_id) {
@@ -290,6 +292,33 @@ impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash + 'static> PassM
         self.output_debug_info(ssa, pass_index, pass.name());
         pass.run(ssa, &self.analyses);
         self.analyses.apply_preserved(&pass.preserves());
+        self.output_pass_ssa_snapshot(ssa, pass_index, pass.name());
+    }
+
+    /// When `MAVROS_DUMP_PASS_SSA` names a directory, write the SSA text after every pass to
+    /// `<dir>/<phase>_<index>_<pass>.txt`. Diffing two such runs bisects exactly which pass
+    /// introduced a divergence (used by determinism debugging; cheap no-op when unset).
+    fn output_pass_ssa_snapshot(&self, ssa: &SSA<Op, Ty, C>, pass_index: usize, pass_name: &str) {
+        let Ok(dir) = std::env::var("MAVROS_DUMP_PASS_SSA") else {
+            return;
+        };
+        let dir = PathBuf::from(dir);
+        fs::create_dir_all(&dir).unwrap();
+        // The fresh-value counter is part of the snapshot: a pass can mint values that die
+        // before the dump, and a counter divergence here surfaces as a text divergence only
+        // in some later pass.
+        fs::write(
+            dir.join(format!(
+                "{}_{:03}_{}.txt",
+                self.phase_label, pass_index, pass_name
+            )),
+            format!(
+                "next_value_id: {}\n{}",
+                ssa.value_num_bound(),
+                ssa.to_string(&DefaultSSAAnnotator)
+            ),
+        )
+        .unwrap();
     }
 
     fn output_debug_info(&mut self, ssa: &SSA<Op, Ty, C>, pass_index: usize, pass_name: &str) {

--- a/compiler/src/compiler/passes/common_subexpression_elimination.rs
+++ b/compiler/src/compiler/passes/common_subexpression_elimination.rs
@@ -3,22 +3,21 @@
 //! Does not float expressions across branches or otherwise move them outside the block in which
 //! they appear (#172).
 
-use crate::compiler::util::ice_non_elided_tuple;
-use std::collections::{HashMap, HashSet};
-
-use crate::compiler::{
-    analysis::flow_analysis::{CFG, FlowAnalysis},
-    ssa::{
-        BlockId, SSAConstantsSnapshot, ValueId,
-        hlssa::{
-            BinaryArithOpKind, CastTarget, CmpKind, Constant, Endianness, HLFunction, HLSSA,
-            LookupTarget, OpCode, Radix,
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        analysis::flow_analysis::{CFG, FlowAnalysis},
+        pass_manager::{AnalysisId, AnalysisStore, Pass},
+        passes::fix_double_jumps::ValueReplacements,
+        ssa::{
+            BlockId, SSAConstantsSnapshot, ValueId,
+            hlssa::{
+                BinaryArithOpKind, CastTarget, CmpKind, Constant, Endianness, HLFunction, HLSSA,
+                LookupTarget, OpCode, Radix,
+            },
         },
+        util::ice_non_elided_tuple,
     },
-};
-use crate::compiler::{
-    pass_manager::{AnalysisId, AnalysisStore, Pass},
-    passes::fix_double_jumps::ValueReplacements,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -385,7 +384,7 @@ impl CSE {
 
             // Side-effect dedup: same dominance grouping as the value loop,
             // but duplicates are dropped rather than redirected.
-            let mut to_remove: HashSet<(BlockId, usize)> = HashSet::new();
+            let mut to_remove: HashSet<(BlockId, usize)> = HashSet::default();
             for (_, occurrences) in assertions {
                 if occurrences.len() <= 1 {
                     continue;
@@ -473,13 +472,13 @@ impl CSE {
         HashMap<Assertion, Vec<(BlockId, usize)>>,
     ) {
         let mut interner = ExprInterner::default();
-        let mut result: HashMap<ExprId, Vec<(BlockId, usize, ValueId)>> = HashMap::new();
-        let mut assertions: HashMap<Assertion, Vec<(BlockId, usize)>> = HashMap::new();
+        let mut result: HashMap<ExprId, Vec<(BlockId, usize, ValueId)>> = HashMap::default();
+        let mut assertions: HashMap<Assertion, Vec<(BlockId, usize)>> = HashMap::default();
 
         // Seed the value->expr map with the SSA's constants so they can be referenced as operands.
         // They are not recorded into `result`: the constant store already dedups them, so CSE must
         // not try to dedup the constants themselves.
-        let mut exprs: HashMap<ValueId, ExprId> = HashMap::new();
+        let mut exprs: HashMap<ValueId, ExprId> = HashMap::default();
         for (vid, cv) in constants {
             let id = match cv.as_ref() {
                 Constant::U(bits, value) => interner.uconst(*bits, *value),

--- a/compiler/src/compiler/passes/dead_code_elimination.rs
+++ b/compiler/src/compiler/passes/dead_code_elimination.rs
@@ -6,17 +6,19 @@
 //!
 //! TODO Refactor to use the existing liveness analysis (#157).
 
-use crate::compiler::util::ice_non_elided_tuple;
-use std::collections::{HashMap, HashSet};
-
-use crate::compiler::{
-    analysis::flow_analysis::{CFG, FlowAnalysis},
-    pass_manager::{AnalysisId, AnalysisStore, Pass},
-    ssa::{
-        BlockId, FunctionId, Instruction, Terminator, ValueId,
-        hlssa::{CallTarget, HLFunction, HLSSA, OpCode},
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        analysis::flow_analysis::{CFG, FlowAnalysis},
+        pass_manager::{AnalysisId, AnalysisStore, Pass},
+        ssa::{
+            BlockId, FunctionId, Instruction, Terminator, ValueId,
+            hlssa::{CallTarget, HLFunction, HLSSA, OpCode},
+        },
+        util::ice_non_elided_tuple,
     },
 };
+
 pub struct DCE {
     config: Config,
 }
@@ -138,9 +140,9 @@ impl DCE {
         let function_ids: Vec<FunctionId> = ssa.get_function_ids().collect();
 
         let mut definitions_by_function: HashMap<FunctionId, HashMap<ValueId, ValueDefinition>> =
-            HashMap::new();
+            HashMap::default();
         let mut static_calls_by_callee: HashMap<FunctionId, Vec<(FunctionId, BlockId, usize)>> =
-            HashMap::new();
+            HashMap::default();
 
         for function_id in &function_ids {
             let function = ssa.get_function(*function_id);
@@ -163,14 +165,15 @@ impl DCE {
             }
         }
 
-        let mut live_values: HashMap<FunctionId, HashSet<ValueId>> = HashMap::new();
-        let mut live_blocks: HashMap<FunctionId, HashSet<BlockId>> = HashMap::new();
+        let mut live_values: HashMap<FunctionId, HashSet<ValueId>> = HashMap::default();
+        let mut live_blocks: HashMap<FunctionId, HashSet<BlockId>> = HashMap::default();
         let mut live_instructions: HashMap<FunctionId, HashMap<BlockId, HashSet<usize>>> =
-            HashMap::new();
-        let mut live_params: HashMap<FunctionId, HashMap<BlockId, HashSet<usize>>> = HashMap::new();
-        let mut live_entry_params: HashMap<FunctionId, HashSet<usize>> = HashMap::new();
-        let mut live_branches: HashMap<FunctionId, HashSet<BlockId>> = HashMap::new();
-        let mut live_return_slots: HashMap<FunctionId, HashSet<usize>> = HashMap::new();
+            HashMap::default();
+        let mut live_params: HashMap<FunctionId, HashMap<BlockId, HashSet<usize>>> =
+            HashMap::default();
+        let mut live_entry_params: HashMap<FunctionId, HashSet<usize>> = HashMap::default();
+        let mut live_branches: HashMap<FunctionId, HashSet<BlockId>> = HashMap::default();
+        let mut live_return_slots: HashMap<FunctionId, HashSet<usize>> = HashMap::default();
 
         let mut worklist: Vec<WorkItem> = vec![];
 
@@ -483,7 +486,7 @@ impl DCE {
                             let new_target = self.closest_live_post_dominator(
                                 function_cfg,
                                 block_id,
-                                live_blocks.get(&function_id).unwrap_or(&HashSet::new()),
+                                live_blocks.get(&function_id).unwrap_or(&HashSet::default()),
                             );
                             Terminator::Jmp(new_target, vec![])
                         }
@@ -491,7 +494,7 @@ impl DCE {
                     Some(Terminator::JmpIf(condition, then, otherwise)) => {
                         if live_branches
                             .get(&function_id)
-                            .unwrap_or(&HashSet::new())
+                            .unwrap_or(&HashSet::default())
                             .contains(&block_id)
                         {
                             Terminator::JmpIf(
@@ -499,12 +502,12 @@ impl DCE {
                                 self.closest_live_block(
                                     function_cfg,
                                     then,
-                                    live_blocks.get(&function_id).unwrap_or(&HashSet::new()),
+                                    live_blocks.get(&function_id).unwrap_or(&HashSet::default()),
                                 ),
                                 self.closest_live_block(
                                     function_cfg,
                                     otherwise,
-                                    live_blocks.get(&function_id).unwrap_or(&HashSet::new()),
+                                    live_blocks.get(&function_id).unwrap_or(&HashSet::default()),
                                 ),
                             )
                         } else {
@@ -512,7 +515,7 @@ impl DCE {
                                 self.closest_live_post_dominator(
                                     function_cfg,
                                     block_id,
-                                    live_blocks.get(&function_id).unwrap_or(&HashSet::new()),
+                                    live_blocks.get(&function_id).unwrap_or(&HashSet::default()),
                                 ),
                                 vec![],
                             )
@@ -563,7 +566,7 @@ impl DCE {
     }
 
     fn generate_definitions(&self, function: &HLFunction) -> HashMap<ValueId, ValueDefinition> {
-        let mut definitions = HashMap::new();
+        let mut definitions = HashMap::default();
 
         for (block_id, block) in function.get_blocks() {
             for (i, (val, _)) in block.get_parameters().enumerate() {
@@ -588,7 +591,7 @@ impl DCE {
     ) -> bool {
         live_blocks
             .get(&function_id)
-            .unwrap_or(&HashSet::new())
+            .unwrap_or(&HashSet::default())
             .contains(&block_id)
     }
 
@@ -602,7 +605,7 @@ impl DCE {
         live_instructions
             .get(&function_id)
             .and_then(|blocks| blocks.get(&block_id))
-            .unwrap_or(&HashSet::new())
+            .unwrap_or(&HashSet::default())
             .contains(&i)
     }
 
@@ -616,7 +619,7 @@ impl DCE {
         live_params
             .get(&function_id)
             .and_then(|blocks| blocks.get(&block_id))
-            .unwrap_or(&HashSet::new())
+            .unwrap_or(&HashSet::default())
             .contains(&i)
     }
 
@@ -628,7 +631,7 @@ impl DCE {
     ) -> bool {
         live_entry_params
             .get(&function_id)
-            .unwrap_or(&HashSet::new())
+            .unwrap_or(&HashSet::default())
             .contains(&i)
     }
 
@@ -640,7 +643,7 @@ impl DCE {
     ) -> bool {
         live_return_slots
             .get(&function_id)
-            .unwrap_or(&HashSet::new())
+            .unwrap_or(&HashSet::default())
             .contains(&i)
     }
 

--- a/compiler/src/compiler/passes/deduplicate_phis.rs
+++ b/compiler/src/compiler/passes/deduplicate_phis.rs
@@ -1,10 +1,11 @@
 //! Removes redundant traffic from phi inputs at join points, reducing value flow from N edges to 1.
 
-use std::collections::HashMap;
-
-use crate::compiler::{
-    pass_manager::{AnalysisId, AnalysisStore, Pass},
-    ssa::{BlockId, Terminator, ValueId, hlssa::HLSSA},
+use crate::{
+    collections::HashMap,
+    compiler::{
+        pass_manager::{AnalysisId, AnalysisStore, Pass},
+        ssa::{BlockId, Terminator, ValueId, hlssa::HLSSA},
+    },
 };
 
 pub struct DeduplicatePhis {}
@@ -30,7 +31,8 @@ impl DeduplicatePhis {
 
     pub fn do_run(&self, ssa: &mut HLSSA) {
         for (_, function) in ssa.iter_functions_mut() {
-            let mut unifications: HashMap<(BlockId, Vec<ValueId>), Vec<BlockId>> = HashMap::new();
+            let mut unifications: HashMap<(BlockId, Vec<ValueId>), Vec<BlockId>> =
+                HashMap::default();
             for (block_id, block) in function.get_blocks() {
                 if let Some(Terminator::Jmp(target, inputs)) = block.get_terminator() {
                     if inputs.len() > 0 {
@@ -42,8 +44,8 @@ impl DeduplicatePhis {
                 }
             }
 
-            // The iteration order is non-deterministic, but given block IDs shouldn't leak into
-            // anything user-facing this isn't really an issue.
+            // The iteration order is arbitrary but deterministic (FxHash), and block IDs don't
+            // leak into anything user-facing.
             for ((target, inputs), blocks) in unifications {
                 if blocks.len() <= 1 {
                     continue;

--- a/compiler/src/compiler/passes/defunctionalize.rs
+++ b/compiler/src/compiler/passes/defunctionalize.rs
@@ -9,16 +9,17 @@
 //!    params, dispatches to the right call, and then merges into a single return.
 //! 3. Rewrites the original call site to use this dispatch function.
 
-use std::collections::{HashMap, HashSet};
-
-use crate::compiler::{
-    pass_manager::{AnalysisStore, Pass},
-    passes::fix_double_jumps::ValueReplacements,
-    ssa::{
-        BlockId, FunctionId, Terminator, ValueId,
-        hlssa::{
-            CallTarget, Constant, HLSSA, OpCode, Type, TypeExpr,
-            builder::{HLEmitter, HLSSABuilder},
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        pass_manager::{AnalysisStore, Pass},
+        passes::fix_double_jumps::ValueReplacements,
+        ssa::{
+            BlockId, FunctionId, Terminator, ValueId,
+            hlssa::{
+                CallTarget, Constant, HLSSA, OpCode, Type, TypeExpr,
+                builder::{HLEmitter, HLSSABuilder},
+            },
         },
     },
 };
@@ -60,7 +61,7 @@ fn run_defunctionalize(ssa: &mut HLSSA) {
 
     // Phase 2: For each dynamic call site, build a dispatch function
     // with exactly the reachable targets
-    let mut call_site_dispatch: HashMap<(FunctionId, ValueId), FunctionId> = HashMap::new();
+    let mut call_site_dispatch: HashMap<(FunctionId, ValueId), FunctionId> = HashMap::default();
     let mut dispatch_counter = 0u32;
 
     let func_ids: Vec<FunctionId> = ssa.get_function_ids().collect();
@@ -117,7 +118,7 @@ fn run_defunctionalize(ssa: &mut HLSSA) {
     // FnPtr `ValueId` to its canonical U-typed `ValueId`, and remove the FnPtr entries. The
     // remap is applied globally in phase 3d below, after `Call::Dynamic` rewriting in 3b has
     // run on the still-original operands.
-    let fnptr_entries: Vec<(ValueId, FunctionId)> = ssa
+    let mut fnptr_entries: Vec<(ValueId, FunctionId)> = ssa
         .const_snapshot()
         .iter()
         .filter_map(|(vid, cv)| match cv.as_ref() {
@@ -125,6 +126,9 @@ fn run_defunctionalize(ssa: &mut HLSSA) {
             _ => None,
         })
         .collect();
+    // Sort so the canonical-constant interning order (and thus the assigned ValueIds) does not
+    // depend on the snapshot's iteration order.
+    fnptr_entries.sort_by_key(|(vid, _)| vid.0);
     let mut fnptr_remap = ValueReplacements::new();
     for (fnptr_vid, fn_id) in &fnptr_entries {
         let canon = ssa.add_const(Constant::U(32, fn_id.0 as u128));
@@ -244,7 +248,7 @@ fn run_defunctionalize(ssa: &mut HLSSA) {
 ///   - Static call return edges (callee returns → caller results)
 ///   - Dynamic call return edges (resolved target returns → caller results)
 fn compute_reaching_fn_ptrs(ssa: &HLSSA) -> ReachingFns {
-    let mut reaching: ReachingFns = HashMap::new();
+    let mut reaching: ReachingFns = HashMap::default();
     let func_ids: Vec<FunctionId> = ssa.get_function_ids().collect();
 
     // Check if a type contains Function anywhere (for alias-aware propagation)
@@ -265,7 +269,7 @@ fn compute_reaching_fn_ptrs(ssa: &HLSSA) -> ReachingFns {
 
     // Pre-compute which values are Refs containing Functions (need bidirectional propagation)
     // These come from: Alloc results, block parameters with Ref<...Function...> type
-    let mut is_ref_with_fn: HashSet<(FunctionId, ValueId)> = HashSet::new();
+    let mut is_ref_with_fn: HashSet<(FunctionId, ValueId)> = HashSet::default();
     for &fid in &func_ids {
         let func = ssa.get_function(fid);
         // Check Alloc instructions
@@ -310,7 +314,7 @@ fn compute_reaching_fn_ptrs(ssa: &HLSSA) -> ReachingFns {
     }
 
     // Pre-compute return values per function
-    let mut return_values: HashMap<FunctionId, Vec<ValueId>> = HashMap::new();
+    let mut return_values: HashMap<FunctionId, Vec<ValueId>> = HashMap::default();
     for &fid in &func_ids {
         let func = ssa.get_function(fid);
         for (_bid, block) in func.get_blocks() {
@@ -342,7 +346,7 @@ fn compute_reaching_fn_ptrs(ssa: &HLSSA) -> ReachingFns {
     }
 
     // Track fn_ptrs stored in global slots (keyed by global offset)
-    let mut global_slots: HashMap<usize, HashSet<FunctionId>> = HashMap::new();
+    let mut global_slots: HashMap<usize, HashSet<FunctionId>> = HashMap::default();
 
     // Fixpoint: propagate reaching sets through edges
     // Backward propagation only happens when source is_ref_with_fn (pointer aliasing)

--- a/compiler/src/compiler/passes/elide_tuples.rs
+++ b/compiler/src/compiler/passes/elide_tuples.rs
@@ -32,14 +32,15 @@
 //!    terminators using the `value_map`. Unreachable blocks (which the type snapshot never typed)
 //!    are dropped.
 
-use std::collections::{HashMap, HashSet};
-
-use crate::compiler::{
-    analysis::{flow_analysis::FlowAnalysis, types::TypeInfo},
-    pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
-    ssa::{
-        BlockId, FunctionId, Instruction, Terminator, ValueId,
-        hlssa::{HLSSA, OpCode, Type, TypeExpr},
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        analysis::{flow_analysis::FlowAnalysis, types::TypeInfo},
+        pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
+        ssa::{
+            BlockId, FunctionId, Instruction, Terminator, ValueId,
+            hlssa::{HLSSA, OpCode, Type, TypeExpr},
+        },
     },
 };
 
@@ -112,7 +113,7 @@ impl ElideTuples {
     ) -> HashMap<ValueId, Vec<ValueId>> {
         let func = ssa.get_function(fid);
         let fti = type_info.get_function(fid);
-        let mut value_map: HashMap<ValueId, Vec<ValueId>> = HashMap::new();
+        let mut value_map: HashMap<ValueId, Vec<ValueId>> = HashMap::default();
 
         // Sweep A: every block parameter gets its components, so all parameters are resolved before
         // any instruction (which may reference a dominating block's parameter) is visited.
@@ -888,7 +889,7 @@ mod tests {
         let old_global_types = vec![field(), tuple_global.clone(), u32t()];
         let global_offsets = vec![0usize, 1, 3];
 
-        let mut value_map: HashMap<ValueId, Vec<ValueId>> = HashMap::new();
+        let mut value_map: HashMap<ValueId, Vec<ValueId>> = HashMap::default();
         value_map.insert(ValueId(10), vec![ValueId(11), ValueId(12)]); // read result
         value_map.insert(ValueId(20), vec![ValueId(21), ValueId(22)]); // init value
 

--- a/compiler/src/compiler/passes/fix_double_jumps.rs
+++ b/compiler/src/compiler/passes/fix_double_jumps.rs
@@ -3,14 +3,15 @@
 //!
 //! This eliminates the need to jump (obviously), but also reduces block parameter traffic.
 
-use std::collections::HashMap;
-
-use crate::compiler::{
-    analysis::flow_analysis::FlowAnalysis,
-    pass_manager::{AnalysisId, AnalysisStore, Pass},
-    ssa::{
-        BlockId, Instruction, Terminator, ValueId,
-        hlssa::{HLFunction, HLSSA, OpCode},
+use crate::{
+    collections::HashMap,
+    compiler::{
+        analysis::flow_analysis::FlowAnalysis,
+        pass_manager::{AnalysisId, AnalysisStore, Pass},
+        ssa::{
+            BlockId, Instruction, Terminator, ValueId,
+            hlssa::{HLFunction, HLSSA, OpCode},
+        },
     },
 };
 
@@ -29,7 +30,7 @@ pub struct ValueReplacements {
 impl ValueReplacements {
     pub fn new() -> Self {
         Self {
-            replacements: HashMap::new(),
+            replacements: HashMap::default(),
         }
     }
 
@@ -119,7 +120,7 @@ impl FixDoubleJumps {
         for (function_id, function) in ssa.iter_functions_mut() {
             let cfg = flow_analysis.get_function_cfg(*function_id);
             let jumps = cfg.find_redundant_jumps();
-            let mut replacements = HashMap::<BlockId, BlockId>::new();
+            let mut replacements = HashMap::<BlockId, BlockId>::default();
             let mut value_replacements = ValueReplacements::new();
             for (mut source, mut target) in jumps {
                 while let Some(src) = replacements.get(&source) {

--- a/compiler/src/compiler/passes/mem2reg.rs
+++ b/compiler/src/compiler/passes/mem2reg.rs
@@ -5,20 +5,25 @@
 //! standard Cytron-style (TOPLAS '91) dominance-frontier iteration. Note that the escape analysis
 //! is currently extremely conservative, and can be improved.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::VecDeque;
 
 use tracing::{Level, debug, instrument};
 
-use crate::compiler::analysis::types::{FunctionTypeInfo, TypeInfo};
-use crate::compiler::passes::fix_double_jumps::ValueReplacements;
-use crate::compiler::{
-    analysis::flow_analysis::{CFG, FlowAnalysis},
-    pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
-    ssa::{
-        BlockId, Terminator, ValueId,
-        hlssa::{
-            HLFunction, HLSSA, OpCode, Type, TypeExpr,
-            builder::{HLFunctionBuilder, HLSSABuilder},
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        analysis::{
+            flow_analysis::{CFG, FlowAnalysis},
+            types::{FunctionTypeInfo, TypeInfo},
+        },
+        pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
+        passes::fix_double_jumps::ValueReplacements,
+        ssa::{
+            BlockId, Terminator, ValueId,
+            hlssa::{
+                HLFunction, HLSSA, OpCode, Type, TypeExpr,
+                builder::{HLFunctionBuilder, HLSSABuilder},
+            },
         },
     },
 };
@@ -82,7 +87,7 @@ impl Mem2Reg {
         cfg: &CFG,
         phi_map: &HashMap<BlockId, Vec<(ValueId, ValueId)>>,
     ) {
-        let mut ptr_values = HashMap::<BlockId, HashMap<ValueId, ValueId>>::new();
+        let mut ptr_values = HashMap::<BlockId, HashMap<ValueId, ValueId>>::default();
         let mut value_replacements = ValueReplacements::new();
 
         // Traverse the CFG in domination pre-order
@@ -94,10 +99,10 @@ impl Mem2Reg {
                 if let Some(parent_values) = ptr_values.get(&parent) {
                     parent_values.clone()
                 } else {
-                    HashMap::new()
+                    HashMap::default()
                 }
             } else {
-                HashMap::new()
+                HashMap::default()
             };
 
             // add phi parameters
@@ -201,7 +206,7 @@ impl Mem2Reg {
         phi_blocks: &HashMap<ValueId, HashSet<BlockId>>,
         type_info: &FunctionTypeInfo,
     ) -> HashMap<BlockId, Vec<(ValueId, ValueId)>> {
-        let mut result: HashMap<BlockId, Vec<(ValueId, ValueId)>> = HashMap::new();
+        let mut result: HashMap<BlockId, Vec<(ValueId, ValueId)>> = HashMap::default();
         for (value, blocks) in phi_blocks {
             for block in blocks {
                 let param = fb
@@ -220,8 +225,8 @@ impl Mem2Reg {
         HashMap<ValueId, HashSet<BlockId>>,
         HashMap<ValueId, BlockId>,
     ) {
-        let mut writes: HashMap<ValueId, HashSet<BlockId>> = HashMap::new();
-        let mut defs: HashMap<ValueId, BlockId> = HashMap::new();
+        let mut writes: HashMap<ValueId, HashSet<BlockId>> = HashMap::default();
+        let mut defs: HashMap<ValueId, BlockId> = HashMap::default();
         for (block_id, block) in function.get_blocks() {
             for instruction in block.get_instructions() {
                 match instruction {
@@ -247,11 +252,11 @@ impl Mem2Reg {
         defs: &HashMap<ValueId, BlockId>,
         cfg: &CFG,
     ) -> HashMap<ValueId, HashSet<BlockId>> {
-        let mut result: HashMap<ValueId, HashSet<BlockId>> = HashMap::new();
+        let mut result: HashMap<ValueId, HashSet<BlockId>> = HashMap::default();
 
         for (var, writes) in writes {
             let mut queue = VecDeque::<BlockId>::new();
-            let mut visited = HashSet::<BlockId>::new();
+            let mut visited = HashSet::<BlockId>::default();
             queue.extend(writes);
 
             while let Some(block) = queue.pop_front() {

--- a/compiler/src/compiler/passes/prepare_entry_point.rs
+++ b/compiler/src/compiler/passes/prepare_entry_point.rs
@@ -19,15 +19,16 @@
 //!    recurses into arrays and tuples. This ensures that we bind the untrusted/unconstrained
 //!    results into the constraint system.
 
-use std::collections::HashMap;
-
-use crate::compiler::{
-    pass_manager::{AnalysisStore, Pass},
-    ssa::{
-        BlockId, FunctionId, ValueId,
-        hlssa::{
-            CallTarget, CastTarget, HLSSA, OpCode, SequenceTargetType, Type, TypeExpr,
-            builder::{HLBlockEmitter, HLEmitter, HLSSABuilder},
+use crate::{
+    collections::HashMap,
+    compiler::{
+        pass_manager::{AnalysisStore, Pass},
+        ssa::{
+            BlockId, FunctionId, ValueId,
+            hlssa::{
+                CallTarget, CastTarget, HLSSA, OpCode, SequenceTargetType, Type, TypeExpr,
+                builder::{HLBlockEmitter, HLEmitter, HLSSABuilder},
+            },
         },
     },
 };
@@ -222,7 +223,7 @@ impl PrepareEntryPoint {
     /// rangecheck + reconstruct, and replace original results.
     fn process_unconstrained_calls(ssa: &mut HLSSA) {
         // Pre-collect callee return types (need immutable ssa access)
-        let mut callee_return_types: HashMap<FunctionId, Vec<Type>> = HashMap::new();
+        let mut callee_return_types: HashMap<FunctionId, Vec<Type>> = HashMap::default();
         let func_ids: Vec<FunctionId> = ssa.get_function_ids().collect();
         for &fid in &func_ids {
             for (_, block) in ssa.get_function(fid).get_blocks() {

--- a/compiler/src/compiler/passes/remove_unreachable_blocks.rs
+++ b/compiler/src/compiler/passes/remove_unreachable_blocks.rs
@@ -2,12 +2,13 @@
 //!
 //! TODO Check if we need this once we do our own SSA generation (#169).
 
-use std::collections::HashSet;
-
-use crate::compiler::{
-    analysis::flow_analysis::FlowAnalysis,
-    pass_manager::{AnalysisId, AnalysisStore, Pass},
-    ssa::{BlockId, hlssa::HLSSA},
+use crate::{
+    collections::HashSet,
+    compiler::{
+        analysis::flow_analysis::FlowAnalysis,
+        pass_manager::{AnalysisId, AnalysisStore, Pass},
+        ssa::{BlockId, hlssa::HLSSA},
+    },
 };
 
 pub struct RemoveUnreachableBlocks {}

--- a/compiler/src/compiler/passes/remove_unreachable_functions.rs
+++ b/compiler/src/compiler/passes/remove_unreachable_functions.rs
@@ -3,12 +3,13 @@
 //! This pass should run after defunctionalization, and entry point preparation. This ensures that
 //! all calls are static and hence avoids producing incorrect results.
 
-use std::collections::HashSet;
-
-use crate::compiler::{
-    analysis::flow_analysis::FlowAnalysis,
-    pass_manager::{AnalysisId, AnalysisStore, Pass},
-    ssa::hlssa::HLSSA,
+use crate::{
+    collections::HashSet,
+    compiler::{
+        analysis::flow_analysis::FlowAnalysis,
+        pass_manager::{AnalysisId, AnalysisStore, Pass},
+        ssa::hlssa::HLSSA,
+    },
 };
 
 pub struct RemoveUnreachableFunctions {}

--- a/compiler/src/compiler/passes/simplifier.rs
+++ b/compiler/src/compiler/passes/simplifier.rs
@@ -1,26 +1,27 @@
 //! Performs both peephole optimization and algebraic simplification on the SSA IR, running until it
 //! reaches an iteration limit or a fixed point.
 
-use std::collections::HashMap;
-
 use num_traits::{One, Zero};
 
-use crate::compiler::{
-    analysis::{
-        flow_analysis::FlowAnalysis,
-        types::{FunctionTypeInfo, Types, const_value_type},
-        value_definitions::{FunctionValueDefinitions, ValueDefinition},
-    },
-    pass_manager::{AnalysisId, AnalysisStore, Pass},
-    passes::fix_double_jumps::{ReplaceScope, ValueReplacements},
-    ssa::{
-        FunctionId, ValueId,
-        hlssa::{
-            BinaryArithOpKind, CastTarget, CmpKind, Constant, HLSSA, OpCode, Type, TypeExpr,
-            builder::{HLFunctionBuilder, HLSSABuilder},
+use crate::{
+    collections::HashMap,
+    compiler::{
+        analysis::{
+            flow_analysis::FlowAnalysis,
+            types::{FunctionTypeInfo, Types, const_value_type},
+            value_definitions::{FunctionValueDefinitions, ValueDefinition},
         },
+        pass_manager::{AnalysisId, AnalysisStore, Pass},
+        passes::fix_double_jumps::{ReplaceScope, ValueReplacements},
+        ssa::{
+            FunctionId, ValueId,
+            hlssa::{
+                BinaryArithOpKind, CastTarget, CmpKind, Constant, HLSSA, OpCode, Type, TypeExpr,
+                builder::{HLFunctionBuilder, HLSSABuilder},
+            },
+        },
+        util::bit_mask,
     },
-    util::bit_mask,
 };
 
 pub struct Simplifier {
@@ -114,7 +115,7 @@ impl Simplifier {
         let mut aliases = ValueReplacements::new();
         let mut changed = false;
 
-        let mut new_blocks = HashMap::new();
+        let mut new_blocks = HashMap::default();
         for (bid, mut block) in fb.function.take_blocks().into_iter() {
             let mut new_instructions = Vec::new();
             for instruction in block.take_instructions().into_iter() {
@@ -145,9 +146,9 @@ impl Simplifier {
         }
         fb.function.put_blocks(new_blocks);
 
-        // Apply aliases globally. Block iteration order is non-deterministic, so a block processed
-        // before its predecessor sees stale operands; sweep here to fix references the in-walk
-        // substitution missed.
+        // Apply aliases globally. Block iteration order is arbitrary (deterministic, but not a
+        // CFG order), so a block processed before its predecessor sees stale operands; sweep here
+        // to fix references the in-walk substitution missed.
         aliases.apply_to_function(fb.function, ReplaceScope::Inputs);
 
         changed

--- a/compiler/src/compiler/passes/simplify_asserts.rs
+++ b/compiler/src/compiler/passes/simplify_asserts.rs
@@ -5,17 +5,18 @@
 //! `x == y`) wherever possible. Field equalities `assert(a * b == c)` also become native R1CS
 //! constraints wherever possible.
 
-use std::collections::HashMap;
-
-use crate::compiler::{
-    analysis::{
-        flow_analysis::FlowAnalysis,
-        types::{FunctionTypeInfo, TypeInfo},
-    },
-    pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
-    ssa::{
-        Instruction, ValueId,
-        hlssa::{BinaryArithOpKind, CmpKind, HLSSA, OpCode, TypeExpr},
+use crate::{
+    collections::HashMap,
+    compiler::{
+        analysis::{
+            flow_analysis::FlowAnalysis,
+            types::{FunctionTypeInfo, TypeInfo},
+        },
+        pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
+        ssa::{
+            Instruction, ValueId,
+            hlssa::{BinaryArithOpKind, CmpKind, HLSSA, OpCode, TypeExpr},
+        },
     },
 };
 
@@ -45,7 +46,7 @@ impl SimplifyAsserts {
         for (function_id, function) in ssa.iter_functions_mut() {
             let function_type_info = type_info.get_function(*function_id);
 
-            let mut defs: HashMap<ValueId, OpCode> = HashMap::new();
+            let mut defs: HashMap<ValueId, OpCode> = HashMap::default();
             for (_, block) in function.get_blocks() {
                 for instruction in block.get_instructions() {
                     for result in instruction.get_results() {
@@ -54,7 +55,7 @@ impl SimplifyAsserts {
                 }
             }
 
-            let mut new_blocks = HashMap::new();
+            let mut new_blocks = HashMap::default();
             for (block_id, mut block) in function.take_blocks() {
                 let mut new_instructions = Vec::new();
                 for instruction in block.take_instructions().into_iter() {

--- a/compiler/src/compiler/passes/sparse_conditional_constant_propagation.rs
+++ b/compiler/src/compiler/passes/sparse_conditional_constant_propagation.rs
@@ -31,25 +31,25 @@
 //! backend's residue into all of them, so the op is instead left in place to fail (or wrap)
 //! exactly as it would have at runtime. Division by a constant zero is likewise left alone.
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::sync::Arc;
 
 use ark_ff::{PrimeField, Zero};
 
-use crate::compiler::{
-    Field,
-    pass_manager::{AnalysisStore, Pass},
-    passes::fix_double_jumps::{ReplaceScope, ValueReplacements},
-    ssa::{
-        BlockId, Instruction, Terminator, ValueId,
-        hlssa::{
-            BinaryArithOpKind, CastTarget, CmpKind, Constant, HLFunction, HLSSA,
-            HLSSAConstantsSnapshot, MAX_SUPPORTED_SIGNED_BITS, OpCode,
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        Field,
+        pass_manager::{AnalysisStore, Pass},
+        passes::fix_double_jumps::{ReplaceScope, ValueReplacements},
+        ssa::{
+            BlockId, Instruction, Terminator, ValueId,
+            hlssa::{
+                BinaryArithOpKind, CastTarget, CmpKind, Constant, HLFunction, HLSSA,
+                HLSSAConstantsSnapshot, MAX_SUPPORTED_SIGNED_BITS, OpCode,
+            },
         },
+        util::{bit_mask, decode_signed, encode_signed, fits_signed},
     },
-    util::{bit_mask, decode_signed, encode_signed, fits_signed},
 };
 
 pub struct SCCP {}
@@ -158,7 +158,7 @@ struct FunctionLattice<'f, 'c> {
 
 impl<'f, 'c> FunctionLattice<'f, 'c> {
     fn new(function: &'f HLFunction, consts: &'c HLSSAConstantsSnapshot) -> Self {
-        let mut uses: HashMap<ValueId, Vec<(BlockId, Option<usize>)>> = HashMap::new();
+        let mut uses: HashMap<ValueId, Vec<(BlockId, Option<usize>)>> = HashMap::default();
         for (bid, block) in function.get_blocks() {
             for (idx, instr) in block.get_instructions().enumerate() {
                 for input in instr.get_inputs() {
@@ -179,10 +179,10 @@ impl<'f, 'c> FunctionLattice<'f, 'c> {
         Self {
             function,
             consts,
-            lattice: HashMap::new(),
-            exec_edges: HashSet::new(),
-            exec_preds: HashMap::new(),
-            reachable: HashSet::new(),
+            lattice: HashMap::default(),
+            exec_edges: HashSet::default(),
+            exec_preds: HashMap::default(),
+            reachable: HashSet::default(),
             edge_worklist: Vec::new(),
             value_worklist: Vec::new(),
             uses,

--- a/compiler/src/compiler/passes/specializer.rs
+++ b/compiler/src/compiler/passes/specializer.rs
@@ -5,29 +5,30 @@
 //! in defunctionalization wherever needed. In some cases, we can call the specialized version
 //! directly instead.
 
-use std::collections::{HashMap, HashSet};
-
 use ark_ff::{AdditiveGroup, BigInteger, PrimeField};
 use tracing::{info, instrument};
 
-use crate::compiler::{
-    Field,
-    analysis::{
-        instrumenter::{FunctionSignature, SpecializationSummary, Summary, ValueSignature},
-        symbolic_executor::{self, SymbolicExecutor},
-        types::TypeInfo,
-    },
-    pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
-    ssa::{
-        BlockId, FunctionId, ValueId,
-        hlssa::{
-            BinaryArithOpKind, Blob, CastTarget, CmpKind, Constant, Endianness, HLFunction, HLSSA,
-            MAX_SUPPORTED_UNSIGNED_BITS, OpCode, Radix, RefCountOp, SequenceTargetType, Type,
-            TypeExpr,
-            builder::{HLEmitter, HLFunctionBuilder},
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        Field,
+        analysis::{
+            instrumenter::{FunctionSignature, SpecializationSummary, Summary, ValueSignature},
+            symbolic_executor::{self, SymbolicExecutor},
+            types::TypeInfo,
         },
+        pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
+        ssa::{
+            BlockId, FunctionId, ValueId,
+            hlssa::{
+                BinaryArithOpKind, Blob, CastTarget, CmpKind, Constant, Endianness, HLFunction,
+                HLSSA, MAX_SUPPORTED_UNSIGNED_BITS, OpCode, Radix, RefCountOp, SequenceTargetType,
+                Type, TypeExpr,
+                builder::{HLEmitter, HLFunctionBuilder},
+            },
+        },
+        util::{spread_bits, unspread_bits},
     },
-    util::{spread_bits, unspread_bits},
 };
 
 fn bit_mask(width: usize) -> Option<u128> {
@@ -781,7 +782,7 @@ impl symbolic_executor::Context<Val> for SpecializationState<'_> {
         // Build a mapping from old ValueIds to new ValueIds
         let orig_inputs: Vec<_> = inner.get_inputs().cloned().collect();
         let orig_results: Vec<_> = inner.get_results().cloned().collect();
-        let mut id_map: HashMap<ValueId, ValueId> = HashMap::new();
+        let mut id_map: HashMap<ValueId, ValueId> = HashMap::default();
         for (orig, new_val) in orig_inputs.iter().zip(inputs.iter()) {
             id_map.insert(*orig, new_val.0);
         }
@@ -817,8 +818,8 @@ impl Pass for Specializer {
 
     fn run(&self, ssa: &mut HLSSA, store: &AnalysisStore) {
         let summary = store.get::<Summary>();
-        let mut speculative_ids: HashSet<FunctionId> = HashSet::new();
-        let mut accepted_ids: HashSet<FunctionId> = HashSet::new();
+        let mut speculative_ids: HashSet<FunctionId> = HashSet::default();
+        let mut accepted_ids: HashSet<FunctionId> = HashSet::default();
 
         for (sig, summary) in summary.functions.iter() {
             if summary.specialization_total_savings > 0 {
@@ -899,7 +900,7 @@ impl Specializer {
         // (still `&mut ssa` here) so the constants for `Field`/`U`/`I` signature params are
         // interned eagerly.
         let mut call_params: Vec<Val> = vec![];
-        let mut const_vals: HashMap<ValueId, ConstVal> = HashMap::new();
+        let mut const_vals: HashMap<ValueId, ConstVal> = HashMap::default();
         for (param, sig) in original_param_types
             .iter()
             .zip(signature.get_params().iter())

--- a/compiler/src/compiler/passes/trivial_phi_elimination.rs
+++ b/compiler/src/compiler/passes/trivial_phi_elimination.rs
@@ -23,14 +23,15 @@
 //! Collapsing one merge can expose newly-trivial phis elsewhere (the agreement only becomes visible
 //! once an upstream substitution lands), so the sweep iterates to a fixpoint per function.
 
-use std::collections::{HashMap, HashSet};
-
-use crate::compiler::{
-    pass_manager::{AnalysisId, AnalysisStore, Pass},
-    passes::fix_double_jumps::{ReplaceScope, ValueReplacements},
-    ssa::{
-        BlockId, Terminator, ValueId,
-        hlssa::{HLFunction, HLSSA},
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        pass_manager::{AnalysisId, AnalysisStore, Pass},
+        passes::fix_double_jumps::{ReplaceScope, ValueReplacements},
+        ssa::{
+            BlockId, Terminator, ValueId,
+            hlssa::{HLFunction, HLSSA},
+        },
     },
 };
 
@@ -69,8 +70,8 @@ impl TrivialPhiElimination {
         // 1. Index the `Jmp` edges by target: every parameterized block is entered only via `Jmp`
         //    (a `JmpIf` carries no arguments), so record those targets separately to assert the
         //    invariant and to stay clear of them.
-        let mut incoming_args: HashMap<BlockId, Vec<Vec<ValueId>>> = HashMap::new();
-        let mut jmpif_targets: HashSet<BlockId> = HashSet::new();
+        let mut incoming_args: HashMap<BlockId, Vec<Vec<ValueId>>> = HashMap::default();
+        let mut jmpif_targets: HashSet<BlockId> = HashSet::default();
         for (_, block) in function.get_blocks() {
             match block.get_terminator() {
                 Some(Terminator::Jmp(target, args)) => {
@@ -86,7 +87,7 @@ impl TrivialPhiElimination {
 
         // 2. For each block, find the parameter slots whose incoming value agrees across all edges.
         let mut value_replacements = ValueReplacements::new();
-        let mut removed: HashMap<BlockId, HashSet<usize>> = HashMap::new();
+        let mut removed: HashMap<BlockId, HashSet<usize>> = HashMap::default();
         for (bid, block) in function.get_blocks() {
             // The entry block's parameters are supplied by the caller, not by edges, so they are
             // never phis.
@@ -106,7 +107,7 @@ impl TrivialPhiElimination {
                 bid.0
             );
 
-            let mut slots = HashSet::new();
+            let mut slots = HashSet::default();
             for (i, &p_i) in params.iter().enumerate() {
                 // The single value all predecessors agree on, or `None` while still unset. Edges
                 // that pass `p_i` back into itself (loop back-edges) don't count against agreement.

--- a/compiler/src/compiler/passes/witness_lowering.rs
+++ b/compiler/src/compiler/passes/witness_lowering.rs
@@ -1,19 +1,20 @@
 //! Lowers witness operations such that there are no more implicit mixed pure / witness operations
 //! and so that every value entering an R1CS cosntraint has been explicitly cast to `WitnessOf`.
 
-use crate::compiler::util::ice_non_elided_tuple;
-use std::collections::HashMap;
-
-use crate::compiler::{
-    analysis::{flow_analysis::FlowAnalysis, types::TypeInfo},
-    pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
-    passes::fix_double_jumps::ValueReplacements,
-    ssa::{
-        BlockId, Terminator, ValueId,
-        hlssa::{
-            BinaryArithOpKind, DMatrix, HLSSA, OpCode, SequenceTargetType, Type, TypeExpr,
-            builder::{HLBlockEmitter, HLEmitter, HLSSABuilder},
+use crate::{
+    collections::HashMap,
+    compiler::{
+        analysis::{flow_analysis::FlowAnalysis, types::TypeInfo},
+        pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
+        passes::fix_double_jumps::ValueReplacements,
+        ssa::{
+            BlockId, Terminator, ValueId,
+            hlssa::{
+                BinaryArithOpKind, DMatrix, HLSSA, OpCode, SequenceTargetType, Type, TypeExpr,
+                builder::{HLBlockEmitter, HLEmitter, HLSSABuilder},
+            },
         },
+        util::ice_non_elided_tuple,
     },
 };
 

--- a/compiler/src/compiler/ssa/hlssa_to_llssa.rs
+++ b/compiler/src/compiler/ssa/hlssa_to_llssa.rs
@@ -3,34 +3,32 @@
 //! Array types lower to heap-allocated RC'd structs behind `Ptr`. MkSeq, ArrayGet, ArraySet, and
 //! MemOp (Bump/Drop) are lowered to explicit memory operations.
 
-use crate::compiler::util::ice_non_elided_tuple;
-use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    marker::PhantomData,
-};
-
-use crate::compiler::{
-    analysis::{
-        flow_analysis::{self, FlowAnalysis},
-        types::{FunctionTypeInfo, TypeInfo},
-    },
-    ssa::{Instruction, hlssa::Endianness},
-};
-
-use super::{
-    BlockId, FunctionId, Terminator, ValueId,
-    hlssa::{
-        BinaryArithOpKind, CmpKind, Constant, DMatrix, HLFunction, HLSSA, HLSSAConstantsSnapshot,
-        MAX_SUPPORTED_SIGNED_BITS, MAX_SUPPORTED_UNSIGNED_BITS, Type as HLType,
-        TypeExpr as HLTypeExpr,
-    },
-    llssa::{
-        Blob as LLBlob, Constant as LLConstant, FieldArithOp, IntArithOp, IntCmpOp, LLFieldType,
-        LLFunction, LLOp, LLSSA, LLStruct, RC_IMMORTAL_OBJECT, Type as LLType,
-        builder::{LLBlockEmitter, LLEmitter},
-    },
-};
 use mavros_artifacts::{ConstraintsLayout, WitnessLayout};
+use std::{collections::BTreeMap, marker::PhantomData};
+
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        analysis::{
+            flow_analysis::{self, FlowAnalysis},
+            types::{FunctionTypeInfo, TypeInfo},
+        },
+        ssa::{
+            BlockId, FunctionId, Instruction, Terminator, ValueId,
+            hlssa::{
+                BinaryArithOpKind, CmpKind, Constant, DMatrix, Endianness, HLFunction, HLSSA,
+                HLSSAConstantsSnapshot, MAX_SUPPORTED_SIGNED_BITS, MAX_SUPPORTED_UNSIGNED_BITS,
+                Type as HLType, TypeExpr as HLTypeExpr,
+            },
+            llssa::{
+                Blob as LLBlob, Constant as LLConstant, FieldArithOp, IntArithOp, IntCmpOp,
+                LLFieldType, LLFunction, LLOp, LLSSA, LLStruct, RC_IMMORTAL_OBJECT, Type as LLType,
+                builder::{LLBlockEmitter, LLEmitter},
+            },
+        },
+        util::ice_non_elided_tuple,
+    },
+};
 
 // =============================================================================
 // Type helpers
@@ -476,7 +474,7 @@ fn lower_inner(
     let main_id = hlssa.get_main_id();
     let main_name = hlssa.get_main().get_name().to_string();
     let mut llssa = LLSSA::with_main(main_name);
-    let mut fn_map: HashMap<FunctionId, FunctionId> = HashMap::new();
+    let mut fn_map: HashMap<FunctionId, FunctionId> = HashMap::default();
     let mut drop_fns: Vec<DropFnEntry> = Vec::new();
     let mut ad_fns = AdFunctions::new();
     let mut lookup_fns = LookupFunctions::new();
@@ -561,7 +559,7 @@ fn lower_constants_llssa(
     llssa: &mut LLSSA,
     val_map: &mut HashMap<ValueId, ValueId>,
 ) {
-    let mut referenced = HashSet::new();
+    let mut referenced = HashSet::default();
     for (_, block) in function.get_blocks() {
         for instr in block.get_instructions() {
             for vid in instr.get_inputs() {
@@ -675,8 +673,8 @@ fn lower_function(
     constants: &HLSSAConstantsSnapshot,
 ) -> LLFunction {
     let mut ll_func = LLFunction::empty(function.get_name().to_string());
-    let mut val_map: HashMap<ValueId, ValueId> = HashMap::new();
-    let mut block_map: HashMap<BlockId, BlockId> = HashMap::new();
+    let mut val_map: HashMap<ValueId, ValueId> = HashMap::default();
+    let mut block_map: HashMap<BlockId, BlockId> = HashMap::default();
 
     let hl_entry_id = function.get_entry_id();
     let ll_entry_id = ll_func.get_entry_id();
@@ -4249,7 +4247,7 @@ mod tests {
 
         let mut llssa = LLSSA::with_main("felt_test".to_string());
         let mut ll_func = LLFunction::empty("felt_test".to_string());
-        let mut val_map = HashMap::new();
+        let mut val_map = HashMap::default();
         lower_constants_llssa(function, &constants, &mut ll_func, &mut llssa, &mut val_map);
 
         let dump = llssa.to_string(&DefaultSSAAnnotator);

--- a/compiler/src/compiler/ssa/mod.rs
+++ b/compiler/src/compiler/ssa/mod.rs
@@ -11,7 +11,6 @@ pub mod traits;
 use bimap::BiHashMap;
 use itertools::Itertools;
 use std::{
-    collections::HashMap,
     fmt::Debug,
     hash::Hash,
     sync::{
@@ -20,6 +19,8 @@ use std::{
     },
     vec,
 };
+
+use crate::collections::HashMap;
 
 pub use id::{BlockId, FunctionId, ValueId};
 pub use traits::{Instruction, SSAAnotator, SSAType};
@@ -34,7 +35,14 @@ pub use traits::{Instruction, SSAAnotator, SSAType};
 /// values are `Arc`-shared so reads can hand back owned handles without keeping the lock held. The
 /// lock is an implementation detail: all access goes through [`SSA`] methods that acquire and
 /// release it internally, so callers never see a guard.
-pub type SSAConstants<C> = RwLock<BiHashMap<ValueId, Arc<C>>>;
+pub type SSAConstants<C> = RwLock<
+    BiHashMap<
+        ValueId,
+        Arc<C>,
+        crate::collections::FxBuildHasher,
+        crate::collections::FxBuildHasher,
+    >,
+>;
 
 /// An owned, lock-free snapshot of the constants (the `ValueId -> value` direction only), handed
 /// out by [`SSA::const_snapshot`] so callers can iterate and look up constants without holding the
@@ -112,7 +120,7 @@ impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSA<Op, Ty, C> 
     pub fn with_main(name: String) -> Self {
         let main_function = Function::<Op, Ty>::empty(name);
         let main_id = FunctionId(0);
-        let mut functions = HashMap::new();
+        let mut functions = HashMap::default();
         functions.insert(main_id, main_function);
         SSA {
             functions,
@@ -122,7 +130,7 @@ impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSA<Op, Ty, C> 
             main_id,
             next_function_id: 1,
             next_value_id: AtomicU64::new(0),
-            constants: RwLock::new(BiHashMap::new()),
+            constants: RwLock::new(BiHashMap::default()),
         }
     }
 }
@@ -137,7 +145,7 @@ impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSA<Op, Ty, C> 
     ) {
         (
             SSA {
-                functions: HashMap::new(),
+                functions: HashMap::default(),
                 global_types: Vec::new(),
                 globals_init_fn: self.globals_init_fn,
                 globals_deinit_fn: self.globals_deinit_fn,
@@ -248,7 +256,7 @@ impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSA<Op, Ty, C> 
                 }
             }
         }
-        let mut remap: HashMap<ValueId, ValueId> = HashMap::new();
+        let mut remap: HashMap<ValueId, ValueId> = HashMap::default();
         for v in all_ids {
             if remap.contains_key(&v) || self.is_const(v) {
                 continue;
@@ -503,7 +511,7 @@ impl<Op: Instruction, Ty: SSAType> Function<Op, Ty> {
     pub fn empty(name: String) -> Self {
         let entry = Block::empty();
         let entry_id = BlockId(0);
-        let mut blocks = HashMap::new();
+        let mut blocks = HashMap::default();
         blocks.insert(entry_id, entry);
         Function {
             entry_block: BlockId(0),
@@ -518,7 +526,7 @@ impl<Op: Instruction, Ty: SSAType> Function<Op, Ty> {
         (
             Function {
                 entry_block: self.entry_block,
-                blocks: HashMap::new(),
+                blocks: HashMap::default(),
                 next_block: self.next_block,
                 name: self.name,
                 returns: vec![],
@@ -866,7 +874,7 @@ impl SSAAnotator for DefaultSSAAnnotator {}
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use crate::collections::HashMap;
 
     use crate::compiler::ssa::hlssa::{Constant, HLSSA};
 
@@ -877,7 +885,7 @@ mod tests {
         let a = ssa.add_const(Constant::U(8, 1));
         let b = ssa.add_const(Constant::U(8, 2));
 
-        let mut seen = HashMap::new();
+        let mut seen = HashMap::default();
         ssa.for_each_const(|vid, cv| {
             seen.insert(*vid, cv.as_ref().clone());
         });

--- a/compiler/src/compiler/untaint_control_flow.rs
+++ b/compiler/src/compiler/untaint_control_flow.rs
@@ -1,24 +1,25 @@
 //! Linearizes witness-dependent control flow into a form safe to lower into a ZK circuit.
 
-use crate::compiler::util::ice_non_elided_tuple;
-use std::collections::HashMap;
-
 use tracing::{Level, instrument};
 
-use crate::compiler::{
-    analysis::{
-        flow_analysis::{CFG, FlowAnalysis},
-        types::{FunctionTypeInfo, Types},
-        witness_info::{FunctionWitnessType, WitnessInfo, WitnessShape, WitnessType},
-        witness_type_inference::WitnessTypeInference,
-    },
-    ssa::{
-        BlockId, FunctionId, Terminator, ValueId,
-        hlssa::{
-            BinaryArithOpKind, CallTarget, HLBlock, HLFunction, HLSSA, OpCode, SequenceTargetType,
-            Type, TypeExpr,
-            builder::{HLBlockEmitter, HLEmitter, HLInstrBuilder, HLSSABuilder},
+use crate::{
+    collections::HashMap,
+    compiler::{
+        analysis::{
+            flow_analysis::{CFG, FlowAnalysis},
+            types::{FunctionTypeInfo, Types},
+            witness_info::{FunctionWitnessType, WitnessInfo, WitnessShape, WitnessType},
+            witness_type_inference::WitnessTypeInference,
         },
+        ssa::{
+            BlockId, FunctionId, Terminator, ValueId,
+            hlssa::{
+                BinaryArithOpKind, CallTarget, HLBlock, HLFunction, HLSSA, OpCode,
+                SequenceTargetType, Type, TypeExpr,
+                builder::{HLBlockEmitter, HLEmitter, HLInstrBuilder, HLSSABuilder},
+            },
+        },
+        util::ice_non_elided_tuple,
     },
 };
 
@@ -290,7 +291,7 @@ impl UntaintControlFlow {
 
         let return_types: Vec<Type> = function.get_returns().to_vec();
 
-        let mut block_taint_vars = HashMap::new();
+        let mut block_taint_vars = HashMap::default();
         for (block_id, _) in function.get_blocks() {
             block_taint_vars.insert(*block_id, cfg_witness_param);
         }

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod abi_helpers;
+pub mod collections;
 pub mod compiler;
 pub mod driver;
 pub mod error;

--- a/compiler/src/project.rs
+++ b/compiler/src/project.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashSet,
     fmt::Debug,
     path::{Path, PathBuf},
 };
@@ -12,15 +11,17 @@ use nargo::{
 };
 use nargo_toml::PackageSelection::All;
 use noirc_driver::stdlib_paths_with_source;
-use noirc_frontend::ast::{
-    BlockExpression, CallExpression, Expression, ExpressionKind, FunctionKind, Ident, NoirFunction,
-    Path as AstPath, PathKind, PathSegment, Pattern, Statement, StatementKind,
+use noirc_frontend::{
+    ast::{
+        BlockExpression, CallExpression, Expression, ExpressionKind, FunctionKind, Ident,
+        NoirFunction, Path as AstPath, PathKind, PathSegment, Pattern, Statement, StatementKind,
+    },
+    hir::ParsedFiles,
+    parser::{ItemKind, ParsedModule},
+    token::FunctionAttributeKind,
 };
-use noirc_frontend::hir::ParsedFiles;
-use noirc_frontend::parser::{ItemKind, ParsedModule};
-use noirc_frontend::token::FunctionAttributeKind;
 
-use crate::error::Error;
+use crate::{collections::HashSet, error::Error};
 
 pub struct Project {
     project_root: PathBuf,
@@ -68,7 +69,7 @@ const FOREIGN_REPLACEMENTS: &[&str] = &["blake3", "poseidon2_permutation", "sha2
 
 /// Rewrite all registered `#[foreign]` shims in the parsed files to call their replacements.
 fn replace_foreign_functions(parsed_files: &mut ParsedFiles) {
-    let mut replaced: HashSet<&'static str> = HashSet::new();
+    let mut replaced: HashSet<&'static str> = HashSet::default();
     for (module, _) in parsed_files.values_mut() {
         replace_foreign_functions_in_module(module, &mut replaced);
     }


### PR DESCRIPTION
This commit removes all of the places where the compiler was relying on unspecified iteration orders. They have all been replaced with fixed iteration orders to ensure that the compiler output is bit-for-bit identical across runs on identical input.

This also includes a new mode for the test runner which checks for non-deterministic compilation results on CI, and can also be run locally.

Closes #243