### PR TITLE
Add boundary expansion for arrays

### DIFF
--- a/compiler/src/compiler/analysis/points_to/array_cells.rs
+++ b/compiler/src/compiler/analysis/points_to/array_cells.rs
@@ -15,13 +15,19 @@
 //!   cells all alias the one source value until an `ArraySet` diverges them).
 //! - **`Collapsed`** — some collapse trigger fired (a dynamic or out-of-bounds index, a slice or any
 //!   non-fixed-array result, a `MkRepeated` of a ref/array element, an array stored/loaded through a
-//!   `Ref`, or any boundary crossing: a parameter, a `Call` arg/result, a
-//!   `Return`/`InitGlobal`/`ReadGlobal`). The group keeps the single `Elem(AllElems)` cell — today's
-//!   sound behavior.
+//!   `Ref`, a call-boundary crossing — a parameter, a `Call` arg/result, or a `Return` — or a global
+//!   store/load via `InitGlobal`/`ReadGlobal`). The group keeps the single `Elem(AllElems)` cell —
+//!   today's sound behavior.
 //!
 //! Because every boundary-crossing or through-`Ref` array is `Collapsed`, the builder's `AllElems`
 //! paths (parameter seeding, summary instantiation, `Store`/`Load`) never touch a `Split` group, so
 //! there is no seeding/reading mismatch — see [`super::builder`].
+//!
+//! A `Collapsed` group is further classified by *why* it collapsed (a `Collapse`): a *severable call
+//! boundary* (a `BoundaryKind`) versus a *hard* obstacle. Whole-program array boundary expansion (the
+//! `passes::array_boundary_expansion` pass) consumes the boundary case — via
+//! [`ArrayCells::boundary_splittable_param`] and its siblings — to decide which call boundaries it can
+//! sever, after which a re-run can `Split` the now-local array.
 //!
 //! Construction is **two-pass**. Pass 1 records every union edge and every observation
 //! `(value, Index(k) | Collapse)` while pass 2 folds each observation onto its value's *final*
@@ -39,7 +45,7 @@ use crate::{
     },
 };
 
-// PUBLIC RESULT
+// ARRAY CELLS RESULT
 // ================================================================================================
 
 /// The array-cell flow-group classification for one function.
@@ -52,26 +58,67 @@ pub struct ArrayCells {
     facts: HashMap<ValueId, GroupFacts>,
 }
 
-#[derive(Debug, Clone, Default)]
-struct GroupFacts {
-    /// Constant indices observed on the group (array literal positions + constant get/set indices).
-    indices: HashSet<usize>,
-
-    /// Whether any collapse trigger fired for the group.
-    collapsed: bool,
-}
-
 impl ArrayCells {
     /// The live constant indices of `v`'s flow-group if it is `Split` (cell-precise), or `None` if
     /// it is `Collapsed` (use `Elem(AllElems)`) or `v` is not a tracked array value.
     pub fn split_indices(&self, v: ValueId) -> Option<&HashSet<usize>> {
         let rep = self.rep.get(&v)?;
         let facts = self.facts.get(rep)?;
-        if facts.collapsed {
+        if facts.collapse.is_collapsed() {
             None
         } else {
             Some(&facts.indices)
         }
+    }
+
+    /// Whether `v`'s flow-group would be `Split` were its only obstacle the `allowed` call
+    /// boundary — i.e. no *hard* trigger fired and every boundary crossing on the group is
+    /// `allowed`.
+    ///
+    /// This is the "splittable modulo a single severable boundary" predicate that whole-program
+    /// array boundary expansion gates on; the caller still confirms `v` is a fixed-size array (so
+    /// the post-expansion reconstruction is dense `0..N`). Returns `false` for an untracked value.
+    ///
+    /// Sound by construction: a missed *hard* reason can only ever promote a group to
+    /// `Collapse::Hard` (blocking expansion), never enable a bad one.
+    ///
+    /// A group with no boundary crossing satisfies the relaxability check vacuously, so this is
+    /// only meaningful when `v` actually plays the `allowed` boundary role — which every public
+    /// wrapper below guarantees (a param for `EntryParam`, a call arg for `CallArg`, etc.).
+    fn boundary_only(&self, v: ValueId, allowed: BoundaryKind) -> bool {
+        let Some(rep) = self.rep.get(&v) else {
+            return false;
+        };
+        let Some(facts) = self.facts.get(rep) else {
+            return false;
+        };
+        facts.collapse.relaxable_with(allowed)
+    }
+
+    /// Whether array parameter `v` would be `Split` if it weren't an entry formal — the callee-side
+    /// precondition for expanding it into per-cell parameters.
+    pub fn boundary_splittable_param(&self, v: ValueId) -> bool {
+        self.boundary_only(v, BoundaryKind::EntryParam)
+    }
+
+    /// Whether a returned array value `v` would be `Split` if it weren't returned — the callee-side
+    /// precondition for expanding the return into per-cell returns.
+    pub fn boundary_splittable_return(&self, v: ValueId) -> bool {
+        self.boundary_only(v, BoundaryKind::Return)
+    }
+
+    /// Whether a call-argument array value `v` would be `Split` if it weren't passed to the call —
+    /// the caller-side profitability guard ensuring the inserted per-cell `ArrayGet`s peel rather
+    /// than widening the boundary.
+    pub fn boundary_splittable_arg(&self, v: ValueId) -> bool {
+        self.boundary_only(v, BoundaryKind::CallArg)
+    }
+
+    /// Whether a call-result array value `v` would be `Split` if it weren't a call result — the
+    /// caller-side profitability guard for expanding a callee's return, ensuring the reconstructing
+    /// `MkSeq` the caller emits itself peels.
+    pub fn boundary_splittable_result(&self, v: ValueId) -> bool {
+        self.boundary_only(v, BoundaryKind::CallResult)
     }
 
     /// Compute the classification for one function.
@@ -104,8 +151,7 @@ impl ArrayCells {
         // A parameter array is caller memory (a boundary): collapse.
         for (value, ty) in func.get_entry().get_parameters() {
             if ty.peel_witness().is_array_or_slice() {
-                uf.add(*value);
-                obs.push((*value, Obs::Collapse));
+                collapse_boundary(&mut uf, &mut obs, *value, BoundaryKind::EntryParam);
             }
         }
 
@@ -127,8 +173,7 @@ impl ArrayCells {
                 Some(Terminator::Return(values)) => {
                     for v in values {
                         if is_arr(*v) {
-                            uf.add(*v);
-                            obs.push((*v, Obs::Collapse));
+                            collapse_boundary(&mut uf, &mut obs, *v, BoundaryKind::Return);
                         }
                     }
                 }
@@ -145,7 +190,7 @@ impl ArrayCells {
                 Obs::Index(k) => {
                     f.indices.insert(k);
                 }
-                Obs::Collapse => f.collapsed = true,
+                Obs::Collapse(reason) => f.collapse.observe(reason),
             }
         }
 
@@ -157,6 +202,88 @@ impl ArrayCells {
     }
 }
 
+// COLLAPSES AND BOUNDARIES
+// ================================================================================================
+
+/// The collapse state of an array flow-group.
+///
+/// A three-level lattice `None ⊑ Boundary ⊑ Hard`, joined as observations accrue (`Hard` is top).
+/// `None` means the group is `Split`.
+#[derive(Debug, Clone, Copy, Default)]
+enum Collapse {
+    /// No collapse trigger fired — the group is `Split` (cell-precise).
+    #[default]
+    None,
+
+    /// Collapsed at exactly one kind of call boundary, which whole-program expansion can sever.
+    Boundary(BoundaryKind),
+
+    /// Irreparably collapsed — never relaxable by severing a single boundary.
+    ///
+    /// Either a *hard* trigger fired (a dynamic/out-of-bounds index, a slice, a `Ref<Array>`
+    /// store/load, a deeper array level, a global, or any opaque consumer), or the group crosses
+    /// ≥2 *distinct* boundary kinds (which no single severance could relax — equivalent to a hard
+    /// collapse for every query).
+    Hard,
+}
+
+impl Collapse {
+    /// Fold one observed collapse in (a semilattice join; `Hard` is top, `None` is identity). Two
+    /// *distinct* boundary kinds join to `Hard`, since no single severance can relax both.
+    fn observe(&mut self, other: Collapse) {
+        *self = match (*self, other) {
+            (Collapse::Hard, _) | (_, Collapse::Hard) => Collapse::Hard,
+            (Collapse::None, c) | (c, Collapse::None) => c,
+            (Collapse::Boundary(a), Collapse::Boundary(b)) => {
+                if a == b {
+                    Collapse::Boundary(a)
+                } else {
+                    Collapse::Hard
+                }
+            }
+        };
+    }
+
+    /// Whether any collapse trigger fired (i.e. the group is not `Split`).
+    fn is_collapsed(&self) -> bool {
+        !matches!(self, Collapse::None)
+    }
+
+    /// Whether the group's *only* obstacle to `Split` is the single `allowed` boundary kind — no
+    /// hard trigger fired and the one boundary crossing on the group is `allowed`.
+    ///
+    /// `None` satisfies this vacuously (no obstacle at all), so it is meaningful only when the
+    /// queried value actually plays the `allowed` boundary role (which every
+    /// `boundary_splittable_*` wrapper guarantees).
+    fn relaxable_with(&self, allowed: BoundaryKind) -> bool {
+        match self {
+            Collapse::None => true,
+            Collapse::Boundary(k) => *k == allowed,
+            Collapse::Hard => false,
+        }
+    }
+}
+
+/// The kind of call-boundary crossing that collapsed an array flow-group.
+///
+/// These are the collapse triggers that whole-program array boundary expansion can *sever* (by
+/// passing/returning the array as its cells), as opposed to the [`Collapse::Hard`] triggers
+/// that always block splitting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BoundaryKind {
+    /// The array is an entry-block formal (caller-supplied memory).
+    EntryParam,
+
+    /// The array is passed as a `Call` argument.
+    CallArg,
+
+    /// The array is received as a `Call` result.
+    CallResult,
+
+    /// The array is returned from the function.
+    Return,
+}
+
 // CONSTRUCTION
 // ================================================================================================
 
@@ -165,8 +292,29 @@ enum Obs {
     /// A constant index `k` is accessed on the group.
     Index(usize),
 
-    /// A collapse trigger fired.
-    Collapse,
+    /// A collapse trigger fired, tagged with why (a severable call boundary vs. a hard obstacle).
+    /// Observations are always `Collapse::Boundary`/`Collapse::Hard` — never `Collapse::None`.
+    Collapse(Collapse),
+}
+
+/// Record `v` as *hard*-collapsed, entering it into the union-find first. Idempotent in `v`
+/// (`UnionFind::add` is a no-op when present, and a duplicate observation folds harmlessly), so it
+/// is safe even where `v` was already added or unioned.
+fn collapse_hard(uf: &mut UnionFind<ValueId>, obs: &mut Vec<(ValueId, Obs)>, v: ValueId) {
+    uf.add(v);
+    obs.push((v, Obs::Collapse(Collapse::Hard)));
+}
+
+/// Record `v` as collapsed at the severable call boundary `kind`, entering it into the union-find
+/// first (idempotent, as in [`collapse_hard`]).
+fn collapse_boundary(
+    uf: &mut UnionFind<ValueId>,
+    obs: &mut Vec<(ValueId, Obs)>,
+    v: ValueId,
+    kind: BoundaryKind,
+) {
+    uf.add(v);
+    obs.push((v, Obs::Collapse(Collapse::Boundary(kind))));
 }
 
 /// Process one instruction: union wholesale-copy edges and record observations.
@@ -198,7 +346,7 @@ fn process_instr(
                     obs.push((*result, Obs::Index(i)));
                 }
             } else {
-                obs.push((*result, Obs::Collapse));
+                collapse_hard(uf, obs, *result);
             }
 
             // An array-typed element flows into a cell of `result` (array-of-arrays): it is a
@@ -211,8 +359,7 @@ fn process_instr(
             // `result`'s (kept or peeled) constructor.
             for elem in elems {
                 if is_arr(*elem) {
-                    uf.add(*elem);
-                    obs.push((*elem, Obs::Collapse));
+                    collapse_hard(uf, obs, *elem);
                 }
             }
         }
@@ -235,13 +382,12 @@ fn process_instr(
                         obs.push((*result, Obs::Index(i)));
                     }
                 }
-                _ => obs.push((*result, Obs::Collapse)),
+                _ => collapse_hard(uf, obs, *result),
             }
 
             // An array-typed repeated element is a deeper array level — collapse it.
             if is_arr(*element) {
-                uf.add(*element);
-                obs.push((*element, Obs::Collapse));
+                collapse_hard(uf, obs, *element);
             }
         }
         OpCode::MkSeqOfBlob { result, blob, .. } => {
@@ -256,7 +402,7 @@ fn process_instr(
                         obs.push((*result, Obs::Index(i)));
                     }
                 }
-                _ => obs.push((*result, Obs::Collapse)),
+                _ => collapse_hard(uf, obs, *result),
             }
         }
 
@@ -269,8 +415,7 @@ fn process_instr(
             record_index(ssa, arr_size, obs, *array, *index);
             // A nested inner array extracted from a cell is tracked separately and collapsed.
             if is_arr(*result) {
-                uf.add(*result);
-                obs.push((*result, Obs::Collapse));
+                collapse_hard(uf, obs, *result);
             }
         }
         OpCode::ArraySet {
@@ -284,8 +429,7 @@ fn process_instr(
             // A stored inner array (array-of-arrays) flows into a cell; track it separately,
             // collapsed.
             if is_arr(*value) {
-                uf.add(*value);
-                obs.push((*value, Obs::Collapse));
+                collapse_hard(uf, obs, *value);
             }
         }
 
@@ -298,7 +442,7 @@ fn process_instr(
             // A slice `Select` is not peelable (branches share the result's type); collapse so a
             // slice never lands in a `Split` group.
             if arr_size(*result).is_none() {
-                obs.push((*result, Obs::Collapse));
+                collapse_hard(uf, obs, *result);
             }
         }
         OpCode::Cast { result, value, .. } if is_arr(*result) => {
@@ -308,18 +452,16 @@ fn process_instr(
             // the array peelable while the `Cast` consuming it is kept, tripping `single()` in the
             // client's fallback arm.
             if arr_size(*result).is_none() || arr_size(*value).is_none() {
-                obs.push((*result, Obs::Collapse));
+                collapse_hard(uf, obs, *result);
             }
         }
 
         // Through-`Ref` and slice flow: collapse.
         OpCode::Store { value, .. } if is_arr(*value) => {
-            uf.add(*value);
-            obs.push((*value, Obs::Collapse));
+            collapse_hard(uf, obs, *value);
         }
         OpCode::Load { result, .. } if is_arr(*result) => {
-            uf.add(*result);
-            obs.push((*result, Obs::Collapse));
+            collapse_hard(uf, obs, *result);
         }
         OpCode::SlicePush {
             result,
@@ -327,34 +469,36 @@ fn process_instr(
             values,
             ..
         } => {
-            uf.add(*result);
-            obs.push((*result, Obs::Collapse));
-            uf.add(*slice);
-            obs.push((*slice, Obs::Collapse));
+            collapse_hard(uf, obs, *result);
+            collapse_hard(uf, obs, *slice);
             for v in values {
                 if is_arr(*v) {
-                    uf.add(*v);
-                    obs.push((*v, Obs::Collapse));
+                    collapse_hard(uf, obs, *v);
                 }
             }
         }
 
-        // Boundary crossings: collapse every array arg/result/value.
+        // Call boundary crossings: collapse every array arg/result, tagged by direction so
+        // whole-program boundary expansion can tell an argument (caller-side severable) from a
+        // result (callee-return severable).
         OpCode::Call { results, args, .. } => {
-            for v in args.iter().chain(results.iter()) {
+            for v in args {
                 if is_arr(*v) {
-                    uf.add(*v);
-                    obs.push((*v, Obs::Collapse));
+                    collapse_boundary(uf, obs, *v, BoundaryKind::CallArg);
+                }
+            }
+            for v in results {
+                if is_arr(*v) {
+                    collapse_boundary(uf, obs, *v, BoundaryKind::CallResult);
                 }
             }
         }
+        // Globals are out of scope for boundary expansion, so they collapse hard.
         OpCode::InitGlobal { value, .. } if is_arr(*value) => {
-            uf.add(*value);
-            obs.push((*value, Obs::Collapse));
+            collapse_hard(uf, obs, *value);
         }
         OpCode::ReadGlobal { result, .. } if is_arr(*result) => {
-            uf.add(*result);
-            obs.push((*result, Obs::Collapse));
+            collapse_hard(uf, obs, *result);
         }
 
         // Delegate guards to their inner op (mirrors `builder::FnBuilder::build_instr`); guards do
@@ -375,13 +519,27 @@ fn process_instr(
         other => {
             for v in other.get_inputs().chain(other.get_results()) {
                 if is_arr(*v) {
-                    uf.add(*v);
-                    obs.push((*v, Obs::Collapse));
+                    collapse_hard(uf, obs, *v);
                 }
             }
         }
     }
 }
+
+// GROUP FACTS
+// ================================================================================================
+
+#[derive(Debug, Clone, Default)]
+struct GroupFacts {
+    /// Constant indices observed on the group (array literal positions + constant get/set indices).
+    indices: HashSet<usize>,
+
+    /// The group's collapse state (`Collapse::None` ⇒ `Split`).
+    collapse: Collapse,
+}
+
+// UTILITIES
+// ================================================================================================
 
 /// Record a constant in-bounds index as an `Index(k)` observation, else collapse the group.
 ///
@@ -398,7 +556,7 @@ fn record_index(
 ) {
     match const_index(ssa, index) {
         Some(k) if arr_size(array).map_or(false, |n| k < n) => obs.push((array, Obs::Index(k))),
-        _ => obs.push((array, Obs::Collapse)),
+        _ => obs.push((array, Obs::Collapse(Collapse::Hard))),
     }
 }
 

--- a/compiler/src/compiler/analysis/points_to/mod.rs
+++ b/compiler/src/compiler/analysis/points_to/mod.rs
@@ -339,6 +339,44 @@ impl PointsTo {
             .map_or(false, |ac| ac.split_indices(v).is_some())
     }
 
+    /// Whether the array parameter `v` of `f` would be `Split` were it not an entry formal.
+    ///
+    /// The callee-side precondition for whole-program *array boundary expansion* to peel it (see
+    /// [`ArrayCells::boundary_splittable_param`]). The caller confirms `v` is a fixed-size array.
+    pub fn boundary_splittable_param(&self, f: FunctionId, v: ValueId) -> bool {
+        self.array_cells
+            .get(&f)
+            .map_or(false, |ac| ac.boundary_splittable_param(v))
+    }
+
+    /// Whether the returned array value `v` of `f` would be `Split` were it not returned.
+    ///
+    /// The callee-side precondition for expanding a return into per-cell returns.
+    pub fn boundary_splittable_return(&self, f: FunctionId, v: ValueId) -> bool {
+        self.array_cells
+            .get(&f)
+            .map_or(false, |ac| ac.boundary_splittable_return(v))
+    }
+
+    /// Whether the call-argument array value `v` in `f` would be `Split` were it not passed to the
+    /// call.
+    ///
+    /// The caller-side profitability guard for expanding a callee's array parameter.
+    pub fn boundary_splittable_arg(&self, f: FunctionId, v: ValueId) -> bool {
+        self.array_cells
+            .get(&f)
+            .map_or(false, |ac| ac.boundary_splittable_arg(v))
+    }
+
+    /// Whether the call-result array value `v` in `f` would be `Split` were it not a call result.
+    ///
+    /// The caller-side profitability guard for expanding a callee's array return.
+    pub fn boundary_splittable_result(&self, f: FunctionId, v: ValueId) -> bool {
+        self.array_cells
+            .get(&f)
+            .map_or(false, |ac| ac.boundary_splittable_result(v))
+    }
+
     /// Walk function `f`'s body and report every pointer use, paired with the points-to set at that
     /// site (see [`PointerUse`]).
     ///

--- a/compiler/src/compiler/passes/array_boundary_expansion.rs
+++ b/compiler/src/compiler/passes/array_boundary_expansion.rs
@@ -1,0 +1,1124 @@
+//! Interprocedural array boundary expansion, performing whole-program scalar replacement of array
+//! aggregates across call boundaries.
+//!
+//! Where array SROA peels a fixed-size array into one value per cell, it only does this for arrays
+//! that never cross a function boundary: a parameter, a `Call` arg/result, or a `Return` is a
+//! *collapse trigger*, so an array passed into a helper or returned from one is never
+//! scalar-replaced even when both sides only ever constant-index it. This pass severs those call
+//! boundaries so the existing intra-function passes can finish the job.
+//!
+//! ## Why this is a Separate Pass
+//!
+//! This is deliberately a *separate* pass rather than an extension of `array_sroa`, for the same
+//! reason `arg_promotion` is separate from `mem2reg`.
+//!
+//! `array_sroa`'s correctness rests on a **boundary guarantee**: a `Split` value never appears at a
+//! parameter, `Call`, `Return`, or global, which is what lets it be a simple one-level
+//! intra-function value rewriter (its `single()` tripwire panics if that guarantee is ever
+//! violated).
+//!
+//! Teaching `array_sroa` to rewrite signatures, call sites and returns directly would dismantle
+//! that invariant and reinvent the caller/callee coordination this pass performs. Instead, this
+//! pass *only severs boundaries* — emitting local `MkSeq`/`ArrayGet` so the array still exists
+//! locally but no longer crosses the boundary — and leaves the actual peeling to a downstream
+//! `ArraySroa`, with `dce` reclaiming any cells that turn out unused. Each pass stays simple and
+//! composable.
+//!
+//! ## Reuse, not Re-Threading
+//!
+//! Like `arg_promotion`, this pass rewrites only the *boundary* of procedures; it reconstructs the
+//! original array value locally so the bodies in the middle are untouched and still typecheck.
+//!
+//! - **Callee (Parameter):** The `Array<T, N>` formal `i` of `g` becomes `N` by-value `T` formals;
+//!   a `MkSeq` of those `N` cells, *reusing the original parameter id as its result*, is prepended
+//!   at entry. The reconstructed array is now purely local and constant-indexed, so the follow-up
+//!   `ArraySroa` reclassifies it `Split` and peels it.
+//! - **Callee (Return):** Before each `Return`, the `N` cells of the returned array are `ArrayGet`d
+//!   and returned as `N` scalars; the return-type signature is widened to match.
+//! - **Caller (Argument):** At every `Call{Static(g)}` site, the argument array's `N` cells are
+//!   `ArrayGet`d before the call and passed by value.
+//! - **Caller (Result):** the call's expanded result is `MkSeq`d back into the original result id
+//!   after the call.
+//!
+//! A trailing `ArraySroa` then peels both reconstructions, and a trailing `DCE` drops any cell a
+//! side never used (a dead by-value formal, its matching call argument at every site, and the dead
+//! caller-side `ArrayGet`) on an interprocedural level.
+//!
+//! ## Parameter and Return Expansion
+//!
+//! Expansion fires only where the points-to layer proves it both safe and profitable, as given by
+//! the following conditions.
+//!
+//! - **Owned & Enumerable:** `g` is type-analyzable, not an entry point, not the globals init or
+//!   deinit function, not address-taken, and has at least one static call site — so *every* call
+//!   site is a `Call{Static(g)}` this pass rewrites.
+//! - **Shape:** A *bare* (non-witnessed) fixed-size `Array<T, N>` of bare *scalar* cells
+//!   (`Field`/`u*`/`i*`), with `MIN_CELLS <= N <= SIZE_CAP`.
+//! - **Callee-Side Splittability:** The parameter (respectively, every `Return`'s value at that
+//!   position) would be `Split` were it not for crossing *this* boundary — i.e. it hits no *hard*
+//!   collapse trigger and no *other* boundary.
+//! - **Caller-Side Profitability:** At every site the array would itself be `Split` once the call
+//!   boundary is severed — for a parameter, the argument array
+//!   ([`PointsTo::boundary_splittable_arg`]) so the inserted per-cell `ArrayGet`s peel; for a
+//!   return, the result array ([`PointsTo::boundary_splittable_result`]) so the reconstructing
+//!   `MkSeq` peels. Without this an expansion would *widen* the boundary (extra `ArrayGet`s / a
+//!   surviving `MkSeq`) for no net peel.
+//!
+//! Because array values are value-semantic, there is no caller co-argument aliasing hazard (the one
+//! `arg_promotion`'s C4 guards against for refs), so no aliasing check is needed here.
+//!
+//! ## Deferred Improvements
+//!
+//! The following are deferred improvements for future work.
+//!
+//! - **Composition:** A parameter forwarded onward to another expandable call, or a returned value
+//!   that is itself a parameter, needs a call-graph fixpoint; blocked by the single-boundary
+//!   condition.
+//! - **Witnessed / Nested / Ref-Cell Arrays:** Blocked by the shape condition.
+//! - **Globals:** Array-typed globals are a separate module-level effort; they remain hard collapse
+//!   triggers here.
+//! - **Multi-Consumer Args:** an argument array also passed to a *non-expanded* call survives as a
+//!   second consumer, so its caller `MkSeq` does not fully peel and bytecode can still grow
+//!   slightly. The caller-side guards bound this to a latent size risk, never an unsoundness;
+//!   tightening to "every consumer is expanded" is a follow-up.
+
+use itertools::Itertools;
+
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        analysis::{points_to::PointsTo, types::TypeInfo},
+        pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
+        ssa::{
+            BlockId, FunctionId, Terminator, ValueId,
+            hlssa::{
+                CallTarget, Constant, HLFunction, HLSSA, OpCode, SequenceTargetType, Type, TypeExpr,
+            },
+        },
+    },
+};
+
+// CONSTANTS
+// ================================================================================================
+
+/// Smallest cell count worth expanding (`N < 2` is pure churn — one arg for one arg).
+const MIN_CELLS: usize = 2;
+
+/// Largest cell count worth expanding, bounding signature/argument-list blow-up.
+const SIZE_CAP: usize = 16;
+
+// ARRAY BOUNDARY EXPANSION PASS
+// ================================================================================================
+
+pub struct ArrayBoundaryExpansion {}
+
+impl ArrayBoundaryExpansion {
+    pub fn new() -> Self {
+        ArrayBoundaryExpansion {}
+    }
+}
+
+impl Pass for ArrayBoundaryExpansion {
+    fn name(&self) -> &'static str {
+        "array_boundary_expansion"
+    }
+
+    fn needs(&self) -> Vec<AnalysisId> {
+        // `PointsTo` pulls in `FlowAnalysis`/`TypeInfo` transitively (its `dependencies()`).
+        vec![TypeInfo::id(), PointsTo::id()]
+    }
+
+    fn run(&self, ssa: &mut HLSSA, store: &AnalysisStore) {
+        self.do_run(ssa, store.get::<TypeInfo>(), store.get::<PointsTo>());
+    }
+
+    fn preserves(&self) -> Vec<AnalysisId> {
+        // New params, returns, and call-site instructions invalidate every cached analysis.
+        vec![]
+    }
+}
+
+impl ArrayBoundaryExpansion {
+    pub fn do_run(&self, ssa: &mut HLSSA, types: &TypeInfo, points_to: &PointsTo) {
+        let selection = select(ssa, types, points_to);
+        if selection.is_empty() {
+            return;
+        }
+        let plan = build_plan(ssa, &selection);
+        apply(ssa, &plan);
+    }
+}
+
+// PHASE 0: SELECTION
+// ================================================================================================
+
+/// The expandable `(callee, slot) -> (cell count, element type)` sets, for parameters and returns.
+#[derive(Default)]
+struct Selection {
+    /// Per callee, `param index -> (N, element type)`.
+    params: HashMap<FunctionId, HashMap<usize, (usize, Type)>>,
+
+    /// Per callee, `return position -> (N, element type)`.
+    returns: HashMap<FunctionId, HashMap<usize, (usize, Type)>>,
+}
+
+impl Selection {
+    fn is_empty(&self) -> bool {
+        self.params.is_empty() && self.returns.is_empty()
+    }
+}
+
+/// `Some((element type, N))` iff `ty` is a bare fixed-size array of bare scalar cells within the
+/// size bounds — the only shape v1 expands.
+fn expandable_array(ty: &Type) -> Option<(Type, usize)> {
+    let TypeExpr::Array(_, n) = &ty.expr else {
+        return None;
+    };
+    let n = *n;
+    if !(MIN_CELLS..=SIZE_CAP).contains(&n) {
+        return None;
+    }
+    let elem = ty.get_array_element();
+    if matches!(elem.expr, TypeExpr::Field | TypeExpr::U(_) | TypeExpr::I(_)) {
+        Some((elem, n))
+    } else {
+        None
+    }
+}
+
+/// Whether `g` returns at `pos` from at least one `Return`, and every such returned value is
+/// splittable-modulo-the-return-boundary.
+fn returns_all_splittable(
+    func: &HLFunction,
+    points_to: &PointsTo,
+    g: FunctionId,
+    pos: usize,
+) -> bool {
+    let mut saw_return = false;
+    for (_, block) in func.get_blocks() {
+        if let Some(Terminator::Return(values)) = block.get_terminator() {
+            saw_return = true;
+            match values.get(pos) {
+                Some(v) if points_to.boundary_splittable_return(g, *v) => {}
+                _ => return false,
+            }
+        }
+    }
+    saw_return
+}
+
+/// Move each callee's surviving slots from `cands` into `out`: skip a callee with no static call
+/// site, and drop any `(callee, slot)` in `drops`. Shared by parameter and return selection.
+fn retain_kept(
+    cands: HashMap<FunctionId, HashMap<usize, (usize, Type)>>,
+    drops: &HashSet<(FunctionId, usize)>,
+    has_site: &HashSet<FunctionId>,
+    out: &mut HashMap<FunctionId, HashMap<usize, (usize, Type)>>,
+) {
+    for (g, slots) in cands {
+        if !has_site.contains(&g) {
+            continue;
+        }
+        let kept: HashMap<usize, (usize, Type)> = slots
+            .into_iter()
+            .filter(|(slot, _)| !drops.contains(&(g, *slot)))
+            .collect();
+        if !kept.is_empty() {
+            out.insert(g, kept);
+        }
+    }
+}
+
+fn select(ssa: &HLSSA, types: &TypeInfo, points_to: &PointsTo) -> Selection {
+    let entry_points: HashSet<FunctionId> = ssa.get_entry_points().iter().copied().collect();
+    let globals_init = ssa.get_globals_init_fn();
+    let globals_deinit = ssa.get_globals_deinit_fn();
+
+    // A function whose pointer is taken cannot have all its call sites enumerated (and could be
+    // reached via a dynamic call), so it is never expanded.
+    let mut address_taken: HashSet<FunctionId> = HashSet::default();
+    ssa.for_each_const(|_, cv| {
+        if let Constant::FnPtr(g) = &**cv {
+            address_taken.insert(*g);
+        }
+    });
+    let excluded = |g: FunctionId| {
+        !types.has_function(g)
+            || entry_points.contains(&g)
+            || address_taken.contains(&g)
+            || Some(g) == globals_init
+            || Some(g) == globals_deinit
+    };
+
+    // Callee-local candidates.
+    let mut cand_params: HashMap<FunctionId, HashMap<usize, (usize, Type)>> = HashMap::default();
+    let mut cand_returns: HashMap<FunctionId, HashMap<usize, (usize, Type)>> = HashMap::default();
+    for g in ssa.get_function_ids() {
+        if excluded(g) {
+            continue;
+        }
+        let func = ssa.get_function(g);
+
+        let mut pmap: HashMap<usize, (usize, Type)> = HashMap::default();
+        for (i, (pid, ty)) in func.get_entry().get_parameters().enumerate() {
+            if let Some((elem, n)) = expandable_array(ty) {
+                if points_to.boundary_splittable_param(g, *pid) {
+                    pmap.insert(i, (n, elem));
+                }
+            }
+        }
+        if !pmap.is_empty() {
+            cand_params.insert(g, pmap);
+        }
+
+        let mut rmap: HashMap<usize, (usize, Type)> = HashMap::default();
+        for (pos, ty) in func.get_returns().iter().enumerate() {
+            if let Some((elem, n)) = expandable_array(ty) {
+                if returns_all_splittable(func, points_to, g, pos) {
+                    rmap.insert(pos, (n, elem));
+                }
+            }
+        }
+        if !rmap.is_empty() {
+            cand_returns.insert(g, rmap);
+        }
+    }
+
+    if cand_params.is_empty() && cand_returns.is_empty() {
+        return Selection::default();
+    }
+
+    // Call-site agreement: every static call site is scanned. A parameter is dropped if any site's
+    // argument would not itself peel (or its caller is un-analyzable); a callee with no static call
+    // site is dropped entirely. Return expansion is structurally sound regardless of the caller,
+    // but each site still gets a caller-side *profitability* check (`boundary_splittable_result`,
+    // so the reconstructing `MkSeq` peels rather than widening the boundary) plus a defensive arity
+    // check.
+    let mut param_drop: HashSet<(FunctionId, usize)> = HashSet::default();
+    let mut return_drop: HashSet<(FunctionId, usize)> = HashSet::default();
+    let mut has_site: HashSet<FunctionId> = HashSet::default();
+    for f in ssa.get_function_ids() {
+        let analyzable = types.has_function(f);
+        for (_, block) in ssa.get_function(f).get_blocks() {
+            for instr in block.get_instructions() {
+                let OpCode::Call {
+                    function: CallTarget::Static(g),
+                    args,
+                    results,
+                    ..
+                } = instr
+                else {
+                    continue;
+                };
+                let pcand = cand_params.get(g);
+                let rcand = cand_returns.get(g);
+                if pcand.is_none() && rcand.is_none() {
+                    continue;
+                }
+                has_site.insert(*g);
+                if let Some(pmap) = pcand {
+                    for &i in pmap.keys() {
+                        let ok = analyzable
+                            && i < args.len()
+                            && points_to.boundary_splittable_arg(f, args[i]);
+                        if !ok {
+                            param_drop.insert((*g, i));
+                        }
+                    }
+                }
+                if let Some(rmap) = rcand {
+                    for &pos in rmap.keys() {
+                        // Profitability: the reconstructing `MkSeq` the caller emits must itself
+                        // peel, i.e. the call-result array is only constant-indexed in the caller.
+                        let ok = analyzable
+                            && pos < results.len()
+                            && points_to.boundary_splittable_result(f, results[pos]);
+                        if !ok {
+                            return_drop.insert((*g, pos));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let mut sel = Selection::default();
+    retain_kept(cand_params, &param_drop, &has_site, &mut sel.params);
+    retain_kept(cand_returns, &return_drop, &has_site, &mut sel.returns);
+    sel
+}
+
+// PHASE 1: PLAN CONSTRUCTION
+// ================================================================================================
+
+/// The whole-program expansion plan, with every fresh id pre-minted (so the mutation phase holds
+/// `&mut` without needing to mint) in a deterministic structural order.
+#[derive(Default)]
+struct Plan {
+    /// Pre-minted constant `u32` index values: `index_consts[k]` is the constant `k`. Minted here
+    /// because constant interning needs `&HLSSA`, unavailable while `apply` holds `&mut`.
+    index_consts: Vec<ValueId>,
+
+    /// Per expanded callee, its parameter/return rewrites and per-`Return`-block cell ids.
+    callees: HashMap<FunctionId, CalleePlan>,
+
+    /// Per `(caller, block)`, the call-site rewrites in instruction order.
+    callers: HashMap<(FunctionId, BlockId), Vec<CallRewrite>>,
+}
+
+struct CalleePlan {
+    /// Expanded parameters, ascending by index.
+    params: Vec<ParamExpand>,
+
+    /// Expanded return positions, ascending.
+    returns: Vec<ReturnExpand>,
+
+    /// Per `Return` block, the fresh per-cell `ArrayGet` result ids: the outer `Vec` is aligned
+    /// with `returns` (ascending position), each inner `Vec` of length that position's `N`.
+    return_cells: HashMap<BlockId, Vec<Vec<ValueId>>>,
+}
+
+struct ParamExpand {
+    index: usize,
+    n: usize,
+    elem: Type,
+
+    /// Fresh ids for the `N` new by-value formals (cell order `0..N`).
+    cells: Vec<ValueId>,
+}
+
+struct ReturnExpand {
+    position: usize,
+    n: usize,
+    elem: Type,
+}
+
+struct CallRewrite {
+    /// The expanded callee (matched against the call during the mutation sweep).
+    callee: FunctionId,
+
+    /// Expanded arguments, ascending by parameter index.
+    args: Vec<ArgExpand>,
+
+    /// Expanded results, ascending by return position.
+    results: Vec<ResultExpand>,
+}
+
+struct ArgExpand {
+    index: usize,
+    n: usize,
+    /// Fresh ids for the pre-call per-cell `ArrayGet` results (the new by-value arguments).
+    cells: Vec<ValueId>,
+}
+
+struct ResultExpand {
+    position: usize,
+    n: usize,
+    elem: Type,
+    /// Fresh ids for the per-cell call results (reconstructed into the original result id after).
+    cells: Vec<ValueId>,
+}
+
+fn build_plan(ssa: &HLSSA, sel: &Selection) -> Plan {
+    let mut plan = Plan::default();
+
+    // Pre-mint index constants up to the largest expansion.
+    let max_n = sel
+        .params
+        .values()
+        .chain(sel.returns.values())
+        .flat_map(|m| m.values().map(|(n, _)| *n))
+        .max()
+        .unwrap_or(0);
+    plan.index_consts = (0..max_n)
+        .map(|k| ssa.add_const(Constant::U(32, k as u128)))
+        .collect();
+
+    // Callee plans (sorted callees; within each, params then return cells).
+    for g in sel
+        .params
+        .keys()
+        .chain(sel.returns.keys())
+        .copied()
+        .sorted_unstable()
+        .dedup()
+    {
+        let func = ssa.get_function(g);
+
+        let mut params: Vec<ParamExpand> = Vec::new();
+        if let Some(pmap) = sel.params.get(&g) {
+            for i in pmap.keys().copied().sorted_unstable() {
+                let (n, elem) = pmap[&i].clone();
+                let cells = ssa.fresh_values(n);
+                params.push(ParamExpand {
+                    index: i,
+                    n,
+                    elem,
+                    cells,
+                });
+            }
+        }
+
+        let mut returns: Vec<ReturnExpand> = Vec::new();
+        if let Some(rmap) = sel.returns.get(&g) {
+            for pos in rmap.keys().copied().sorted_unstable() {
+                let (n, elem) = rmap[&pos].clone();
+                returns.push(ReturnExpand {
+                    position: pos,
+                    n,
+                    elem,
+                });
+            }
+        }
+
+        let mut return_cells: HashMap<BlockId, Vec<Vec<ValueId>>> = HashMap::default();
+        if !returns.is_empty() {
+            let return_blocks = func
+                .get_blocks()
+                .filter(|(_, b)| matches!(b.get_terminator(), Some(Terminator::Return(_))))
+                .map(|(bid, _)| *bid)
+                .sorted_unstable();
+            for bid in return_blocks {
+                let per_pos: Vec<Vec<ValueId>> =
+                    returns.iter().map(|re| ssa.fresh_values(re.n)).collect();
+                return_cells.insert(bid, per_pos);
+            }
+        }
+
+        plan.callees.insert(
+            g,
+            CalleePlan {
+                params,
+                returns,
+                return_cells,
+            },
+        );
+    }
+
+    // Caller plans (sorted functions, blocks, instructions in order).
+    for f in ssa.get_function_ids().sorted_unstable() {
+        let func = ssa.get_function(f);
+        for bid in func.get_blocks().map(|(bid, _)| *bid).sorted_unstable() {
+            let mut rewrites: Vec<CallRewrite> = Vec::new();
+            for instr in func.get_block(bid).get_instructions() {
+                let OpCode::Call {
+                    function: CallTarget::Static(g),
+                    ..
+                } = instr
+                else {
+                    continue;
+                };
+                let pmap = sel.params.get(g);
+                let rmap = sel.returns.get(g);
+                if pmap.is_none() && rmap.is_none() {
+                    continue;
+                }
+
+                let mut args: Vec<ArgExpand> = Vec::new();
+                if let Some(pmap) = pmap {
+                    for i in pmap.keys().copied().sorted_unstable() {
+                        let (n, _) = pmap[&i];
+                        let cells = ssa.fresh_values(n);
+                        args.push(ArgExpand { index: i, n, cells });
+                    }
+                }
+                let mut results: Vec<ResultExpand> = Vec::new();
+                if let Some(rmap) = rmap {
+                    for pos in rmap.keys().copied().sorted_unstable() {
+                        let (n, elem) = rmap[&pos].clone();
+                        let cells = ssa.fresh_values(n);
+                        results.push(ResultExpand {
+                            position: pos,
+                            n,
+                            elem,
+                            cells,
+                        });
+                    }
+                }
+                rewrites.push(CallRewrite {
+                    callee: *g,
+                    args,
+                    results,
+                });
+            }
+            if !rewrites.is_empty() {
+                plan.callers.insert((f, bid), rewrites);
+            }
+        }
+    }
+
+    plan
+}
+
+// PHASE 2: APPLY TRANSFORM
+// ================================================================================================
+
+fn apply(ssa: &mut HLSSA, plan: &Plan) {
+    for g in plan.callees.keys().copied().sorted_unstable() {
+        rewrite_callee(
+            ssa.get_function_mut(g),
+            &plan.callees[&g],
+            &plan.index_consts,
+        );
+    }
+
+    for (f, bid) in plan.callers.keys().copied().sorted_unstable() {
+        rewrite_caller_block(
+            ssa.get_function_mut(f),
+            bid,
+            &plan.callers[&(f, bid)],
+            &plan.index_consts,
+        );
+    }
+}
+
+/// Expand a callee's array parameters (into per-cell formals reconstructed at entry) and array
+/// returns (into per-cell returns loaded before each `Return`).
+fn rewrite_callee(func: &mut HLFunction, cp: &CalleePlan, index_consts: &[ValueId]) {
+    // 1. Parameters: replace each array formal with its `N` cells, and prepend a reconstructing
+    //    `MkSeq` whose result is the original parameter id (so every body use stays valid).
+    if !cp.params.is_empty() {
+        let entry_id = func.get_entry_id();
+        let entry = func.get_block_mut(entry_id);
+        let old_params = entry.take_parameters();
+        let mut new_params = Vec::with_capacity(old_params.len());
+        let mut reconstructs: Vec<OpCode> = Vec::with_capacity(cp.params.len());
+        for (idx, (pid, ty)) in old_params.into_iter().enumerate() {
+            if let Some(pe) = cp.params.iter().find(|p| p.index == idx) {
+                for cell in &pe.cells {
+                    new_params.push((*cell, pe.elem.clone()));
+                }
+                reconstructs.push(OpCode::MkSeq {
+                    result: pid,
+                    elems: pe.cells.clone(),
+                    seq_type: SequenceTargetType::Array(pe.n),
+                    elem_type: pe.elem.clone(),
+                });
+            } else {
+                new_params.push((pid, ty));
+            }
+        }
+        entry.put_parameters(new_params);
+
+        let old_instrs = entry.take_instructions();
+        let mut new_instrs = Vec::with_capacity(old_instrs.len() + reconstructs.len());
+        new_instrs.extend(reconstructs);
+        new_instrs.extend(old_instrs);
+        entry.put_instructions(new_instrs);
+    }
+
+    // 2. Returns: at every `Return` block, load each cell of every expanded returned array and
+    //    splice them into the return list; then widen the return-type signature.
+    if !cp.returns.is_empty() {
+        for bid in cp.return_cells.keys().copied().sorted_unstable() {
+            let cells_per_pos = &cp.return_cells[&bid];
+            let block = func.get_block_mut(bid);
+
+            // Snapshot the returned values before mutating the block.
+            let values = match block.get_terminator() {
+                Some(Terminator::Return(vals)) => vals.clone(),
+                _ => unreachable!("return_cells recorded only for Return blocks"),
+            };
+
+            // Emit per-cell `ArrayGet`s from each expanded returned array (defined earlier in the
+            // block, so it is in scope here at the end of the body).
+            for (pos_idx, re) in cp.returns.iter().enumerate() {
+                let arr = values[re.position];
+                let cells = &cells_per_pos[pos_idx];
+                for k in 0..re.n {
+                    block.push_instruction(OpCode::ArrayGet {
+                        result: cells[k],
+                        array: arr,
+                        index: index_consts[k],
+                    });
+                }
+            }
+
+            // Rebuild the `Return` value list in declared order, splicing each expanded position.
+            let mut new_vals: Vec<ValueId> = Vec::with_capacity(values.len());
+            for (pos, v) in values.iter().enumerate() {
+                if let Some(pos_idx) = cp.returns.iter().position(|re| re.position == pos) {
+                    new_vals.extend(cells_per_pos[pos_idx].iter().copied());
+                } else {
+                    new_vals.push(*v);
+                }
+            }
+            match block.get_terminator_mut() {
+                Terminator::Return(vals) => *vals = new_vals,
+                _ => unreachable!("snapshot proved this is a Return block"),
+            }
+        }
+
+        // Widen the function's return-type vector: each expanded position becomes `N` cell types.
+        let old_returns = func.take_returns();
+        for (pos, ty) in old_returns.into_iter().enumerate() {
+            if let Some(re) = cp.returns.iter().find(|r| r.position == pos) {
+                for _ in 0..re.n {
+                    func.add_return_type(re.elem.clone());
+                }
+            } else {
+                func.add_return_type(ty);
+            }
+        }
+    }
+}
+
+/// Rewrite the expanded-callee call sites in one caller block, in instruction order.
+fn rewrite_caller_block(
+    func: &mut HLFunction,
+    bid: BlockId,
+    rewrites: &[CallRewrite],
+    index_consts: &[ValueId],
+) {
+    let block = func.get_block_mut(bid);
+    let old = block.take_instructions();
+    let mut new_instrs = Vec::with_capacity(old.len());
+    let mut next = 0;
+    for instr in old {
+        if let OpCode::Call {
+            function: CallTarget::Static(g),
+            ..
+        } = &instr
+        {
+            // The recorded rewrites cover exactly the expanded-callee calls, in this order. Order
+            // matching is sound because the callee-rewrite phase (run before any caller rewrite in
+            // `apply`) only ever *inserts* `MkSeq`/`ArrayGet`, never a `Call`, so the `Call`
+            // subsequence of every block is identical to the one `build_plan` recorded against.
+            if next < rewrites.len() && rewrites[next].callee == *g {
+                apply_call_rewrite(instr, &rewrites[next], index_consts, &mut new_instrs);
+                next += 1;
+                continue;
+            }
+        }
+        new_instrs.push(instr);
+    }
+    debug_assert_eq!(
+        next,
+        rewrites.len(),
+        "all recorded array-expansion call rewrites consumed"
+    );
+    block.put_instructions(new_instrs);
+}
+
+/// Emit pre-call `ArrayGet`s / the spliced `Call` / post-call `MkSeq`s for one expanded call.
+fn apply_call_rewrite(
+    instr: OpCode,
+    cr: &CallRewrite,
+    index_consts: &[ValueId],
+    out: &mut Vec<OpCode>,
+) {
+    let OpCode::Call {
+        results,
+        function,
+        args,
+        unconstrained,
+    } = instr
+    else {
+        unreachable!("apply_call_rewrite on a non-Call");
+    };
+
+    // 1. Read each expanded argument array's cells before the call.
+    for ae in &cr.args {
+        let arr = args[ae.index];
+        for k in 0..ae.n {
+            out.push(OpCode::ArrayGet {
+                result: ae.cells[k],
+                array: arr,
+                index: index_consts[k],
+            });
+        }
+    }
+
+    // 2. Splice the argument list: each expanded array arg becomes its `N` cells.
+    let mut new_args: Vec<ValueId> = Vec::with_capacity(args.len());
+    for (i, a) in args.iter().enumerate() {
+        if let Some(ae) = cr.args.iter().find(|e| e.index == i) {
+            new_args.extend(ae.cells.iter().copied());
+        } else {
+            new_args.push(*a);
+        }
+    }
+
+    // 3. Splice the result list: each expanded array result becomes its `N` cells; remember the
+    //    reconstruction into the original result id.
+    let mut new_results: Vec<ValueId> = Vec::with_capacity(results.len());
+    let mut reconstructs: Vec<OpCode> = Vec::new();
+    for (j, r) in results.iter().enumerate() {
+        if let Some(re) = cr.results.iter().find(|e| e.position == j) {
+            new_results.extend(re.cells.iter().copied());
+            reconstructs.push(OpCode::MkSeq {
+                result: *r,
+                elems: re.cells.clone(),
+                seq_type: SequenceTargetType::Array(re.n),
+                elem_type: re.elem.clone(),
+            });
+        } else {
+            new_results.push(*r);
+        }
+    }
+
+    out.push(OpCode::Call {
+        results: new_results,
+        function,
+        args: new_args,
+        unconstrained,
+    });
+    out.extend(reconstructs);
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compiler::{
+        analysis::{flow_analysis::FlowAnalysis, types::Types},
+        passes::{
+            array_sroa::ArraySroa,
+            dead_code_elimination::{Config, DCE},
+            mem2reg::Mem2Reg,
+        },
+        ssa::hlssa::builder::{HLEmitter, HLSSABuilder},
+    };
+
+    fn fr(n: u64) -> ark_bn254::Fr {
+        ark_bn254::Fr::from(n)
+    }
+
+    /// Build the analyses on the current IR and run only this pass (mirrors the pass-manager).
+    fn run_expansion(ssa: &mut HLSSA) {
+        let flow = FlowAnalysis::run(ssa);
+        let types = Types::new().run(ssa, &flow);
+        let pt = PointsTo::run(ssa, &flow, &types);
+        ArrayBoundaryExpansion::new().do_run(ssa, &types, &pt);
+    }
+
+    fn run_sroa(ssa: &mut HLSSA) {
+        let flow = FlowAnalysis::run(ssa);
+        let types = Types::new().run(ssa, &flow);
+        let pt = PointsTo::run(ssa, &flow, &types);
+        ArraySroa::new().do_run(ssa, &flow, &types, &pt);
+    }
+
+    fn run_mem2reg(ssa: &mut HLSSA) {
+        let flow = FlowAnalysis::run(ssa);
+        let types = Types::new().run(ssa, &flow);
+        let pt = PointsTo::run(ssa, &flow, &types);
+        Mem2Reg::new().do_run(ssa, &flow, &types, &pt);
+    }
+
+    fn run_dce(ssa: &mut HLSSA) {
+        let flow = FlowAnalysis::run(ssa);
+        DCE::new(Config::pre_r1c()).do_run(ssa, &flow);
+    }
+
+    /// `(MkSeq count, ArrayGet count)` in a function body.
+    fn seq_get_counts(ssa: &HLSSA, fid: FunctionId) -> (usize, usize) {
+        let mut t = (0, 0);
+        for (_, block) in ssa.get_function(fid).get_blocks() {
+            for inst in block.get_instructions() {
+                match inst {
+                    OpCode::MkSeq { .. } => t.0 += 1,
+                    OpCode::ArrayGet { .. } => t.1 += 1,
+                    _ => {}
+                }
+            }
+        }
+        t
+    }
+
+    fn param_types(ssa: &HLSSA, fid: FunctionId) -> Vec<Type> {
+        ssa.get_function(fid).get_param_types()
+    }
+
+    fn return_count(ssa: &HLSSA, fid: FunctionId) -> usize {
+        ssa.get_function(fid).get_returns().len()
+    }
+
+    /// `(arg count, result count)` of the first `Call` in a function, if any.
+    fn first_call_arity(ssa: &HLSSA, fid: FunctionId) -> Option<(usize, usize)> {
+        for (_, block) in ssa.get_function(fid).get_blocks() {
+            for inst in block.get_instructions() {
+                if let OpCode::Call { args, results, .. } = inst {
+                    return Some((args.len(), results.len()));
+                }
+            }
+        }
+        None
+    }
+
+    /// A scalar array *parameter* that is only constant-indexed in the callee is expanded into
+    /// per-cell formals, and the follow-up ArraySroa peels the reconstruction on both sides.
+    #[test]
+    fn param_array_expands_and_peels() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let sink;
+        {
+            let mut sb = HLSSABuilder::new(&mut ssa);
+            sink = sb.ssa().add_function("sink".to_string());
+            // sink(a: Array<Field,2>) -> Field: return a[0] + a[1]
+            sb.modify_function(sink, |b| {
+                b.function.add_return_type(Type::field());
+                let entry = b.function.get_entry_id();
+                let mut e = b.block(entry);
+                let a = e.add_parameter(Type::field().array_of(2));
+                let i0 = e.u_const(32, 0);
+                let i1 = e.u_const(32, 1);
+                let x = e.array_get(a, i0);
+                let y = e.array_get(a, i1);
+                let s = e.add(x, y);
+                e.terminate_return(vec![s]);
+            });
+            // main(): arr = [3, 4]; return sink(arr)
+            sb.modify_function(main_id, |b| {
+                b.function.add_return_type(Type::field());
+                let entry = b.function.get_entry_id();
+                let mut e = b.block(entry);
+                let c3 = e.field_const(fr(3));
+                let c4 = e.field_const(fr(4));
+                let arr = e.mk_seq(vec![c3, c4], SequenceTargetType::Array(2), Type::field());
+                let r = e.call(sink, vec![arr], 1)[0];
+                e.terminate_return(vec![r]);
+            });
+        }
+        run_expansion(&mut ssa);
+
+        // sink's array param became two scalar params; the call passes two scalar args.
+        let pts = param_types(&ssa, sink);
+        assert_eq!(pts.len(), 2, "array param expanded into 2 cells");
+        assert!(
+            pts.iter().all(|t| !t.is_array_or_slice()),
+            "cells are scalars"
+        );
+        assert_eq!(
+            first_call_arity(&ssa, main_id),
+            Some((2, 1)),
+            "call passes 2 args"
+        );
+
+        // The follow-up ArraySroa peels both reconstructions away.
+        run_sroa(&mut ssa);
+        assert_eq!(seq_get_counts(&ssa, sink), (0, 0), "sink fully peeled");
+        assert_eq!(
+            seq_get_counts(&ssa, main_id).0,
+            0,
+            "main's array literal peeled"
+        );
+    }
+
+    /// A scalar array *return* that is built from constants in the callee is expanded into per-cell
+    /// returns, and ArraySroa peels both sides.
+    #[test]
+    fn return_array_expands_and_peels() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let make;
+        {
+            let mut sb = HLSSABuilder::new(&mut ssa);
+            make = sb.ssa().add_function("make".to_string());
+            // make() -> Array<Field,2>: return [7, 9]
+            sb.modify_function(make, |b| {
+                b.function.add_return_type(Type::field().array_of(2));
+                let entry = b.function.get_entry_id();
+                let mut e = b.block(entry);
+                let c7 = e.field_const(fr(7));
+                let c9 = e.field_const(fr(9));
+                let arr = e.mk_seq(vec![c7, c9], SequenceTargetType::Array(2), Type::field());
+                e.terminate_return(vec![arr]);
+            });
+            // main(): a = make(); return a[0] + a[1]
+            sb.modify_function(main_id, |b| {
+                b.function.add_return_type(Type::field());
+                let entry = b.function.get_entry_id();
+                let mut e = b.block(entry);
+                let a = e.call(make, vec![], 1)[0];
+                let i0 = e.u_const(32, 0);
+                let i1 = e.u_const(32, 1);
+                let x = e.array_get(a, i0);
+                let y = e.array_get(a, i1);
+                let s = e.add(x, y);
+                e.terminate_return(vec![s]);
+            });
+        }
+        run_expansion(&mut ssa);
+
+        assert_eq!(
+            return_count(&ssa, make),
+            2,
+            "array return expanded into 2 cells"
+        );
+        assert_eq!(
+            first_call_arity(&ssa, main_id),
+            Some((0, 2)),
+            "call yields 2 results"
+        );
+
+        run_sroa(&mut ssa);
+        assert_eq!(seq_get_counts(&ssa, make), (0, 0), "make fully peeled");
+        assert_eq!(seq_get_counts(&ssa, main_id), (0, 0), "main fully peeled");
+    }
+
+    /// A cell the callee never reads becomes a dead formal after the peel; the follow-up DCE drops
+    /// it interprocedurally (the formal *and* the matching argument at the call site). The used
+    /// cell is anchored by a global store so DCE keeps it (this toy's only other consumer, the
+    /// entry-point return, is itself pruned at this stage).
+    #[test]
+    fn unused_cell_is_eliminated() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        ssa.set_global_types(vec![Type::field()]);
+        let main_id = ssa.get_unique_entrypoint_id();
+        let sink;
+        {
+            let mut sb = HLSSABuilder::new(&mut ssa);
+            sink = sb.ssa().add_function("sink".to_string());
+            // sink(a: Array<Field,2>) -> Field: return a[0]   (cell 1 unused)
+            sb.modify_function(sink, |b| {
+                b.function.add_return_type(Type::field());
+                let entry = b.function.get_entry_id();
+                let mut e = b.block(entry);
+                let a = e.add_parameter(Type::field().array_of(2));
+                let i0 = e.u_const(32, 0);
+                let x = e.array_get(a, i0);
+                e.terminate_return(vec![x]);
+            });
+            // main(): arr = [3, 4]; global[0] = sink(arr); return
+            sb.modify_function(main_id, |b| {
+                let entry = b.function.get_entry_id();
+                let mut e = b.block(entry);
+                let c3 = e.field_const(fr(3));
+                let c4 = e.field_const(fr(4));
+                let arr = e.mk_seq(vec![c3, c4], SequenceTargetType::Array(2), Type::field());
+                let r = e.call(sink, vec![arr], 1)[0];
+                e.init_global(0, r);
+                e.terminate_return(vec![]);
+            });
+        }
+        run_expansion(&mut ssa);
+        run_sroa(&mut ssa);
+        run_mem2reg(&mut ssa);
+        run_dce(&mut ssa);
+
+        assert_eq!(
+            param_types(&ssa, sink).len(),
+            1,
+            "dead cell-1 formal removed by DCE"
+        );
+        assert_eq!(
+            first_call_arity(&ssa, main_id),
+            Some((1, 1)),
+            "matching dead argument removed at the call site"
+        );
+    }
+
+    /// Negative — a dynamically-indexed array parameter hits a hard collapse trigger, so it is not
+    /// expanded.
+    #[test]
+    fn dynamic_index_param_is_retained() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let sink;
+        {
+            let mut sb = HLSSABuilder::new(&mut ssa);
+            sink = sb.ssa().add_function("sink".to_string());
+            // sink(a: Array<Field,2>, i: u32) -> Field: return a[i]
+            sb.modify_function(sink, |b| {
+                b.function.add_return_type(Type::field());
+                let entry = b.function.get_entry_id();
+                let mut e = b.block(entry);
+                let a = e.add_parameter(Type::field().array_of(2));
+                let i = e.add_parameter(Type::u(32));
+                let x = e.array_get(a, i);
+                e.terminate_return(vec![x]);
+            });
+            // main(): arr = [3, 4]; return sink(arr, 0)
+            sb.modify_function(main_id, |b| {
+                b.function.add_return_type(Type::field());
+                let entry = b.function.get_entry_id();
+                let mut e = b.block(entry);
+                let c3 = e.field_const(fr(3));
+                let c4 = e.field_const(fr(4));
+                let arr = e.mk_seq(vec![c3, c4], SequenceTargetType::Array(2), Type::field());
+                let i0 = e.u_const(32, 0);
+                let r = e.call(sink, vec![arr, i0], 1)[0];
+                e.terminate_return(vec![r]);
+            });
+        }
+        run_expansion(&mut ssa);
+        assert!(
+            param_types(&ssa, sink)[0].is_array_or_slice(),
+            "dynamically-indexed array param retained"
+        );
+    }
+
+    /// Negative — an array passed onward to another (non-expandable) call is a second boundary on
+    /// the group, so the parameter is not expanded (composition deferred).
+    #[test]
+    fn onward_passed_param_is_retained() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        ssa.set_global_types(vec![Type::field().array_of(2)]);
+        let main_id = ssa.get_unique_entrypoint_id();
+        let (g, sink);
+        {
+            let mut sb = HLSSABuilder::new(&mut ssa);
+            g = sb.ssa().add_function("g".to_string());
+            sink = sb.ssa().add_function("sink".to_string());
+            // sink(a: Array<Field,2>): global[0] = a; return   (leaks ⇒ not itself expandable)
+            sb.modify_function(sink, |b| {
+                let entry = b.function.get_entry_id();
+                let mut e = b.block(entry);
+                let a = e.add_parameter(Type::field().array_of(2));
+                e.init_global(0, a);
+                e.terminate_return(vec![]);
+            });
+            // g(a: Array<Field,2>): sink(a); return   (forwards its array param onward)
+            sb.modify_function(g, |b| {
+                let entry = b.function.get_entry_id();
+                let mut e = b.block(entry);
+                let a = e.add_parameter(Type::field().array_of(2));
+                e.call(sink, vec![a], 0);
+                e.terminate_return(vec![]);
+            });
+            // main(): arr = [3, 4]; g(arr); return
+            sb.modify_function(main_id, |b| {
+                let entry = b.function.get_entry_id();
+                let mut e = b.block(entry);
+                let c3 = e.field_const(fr(3));
+                let c4 = e.field_const(fr(4));
+                let arr = e.mk_seq(vec![c3, c4], SequenceTargetType::Array(2), Type::field());
+                e.call(g, vec![arr], 0);
+                e.terminate_return(vec![]);
+            });
+        }
+        run_expansion(&mut ssa);
+        assert!(
+            param_types(&ssa, g)[0].is_array_or_slice(),
+            "onward-passed array param retained (second boundary)"
+        );
+    }
+
+    /// The shape gate: only bare fixed-size arrays of bare scalars within the size bounds expand.
+    #[test]
+    fn expandable_array_shape_gate() {
+        assert!(expandable_array(&Type::field().array_of(2)).is_some());
+        assert!(expandable_array(&Type::u(32).array_of(4)).is_some());
+        assert!(
+            expandable_array(&Type::field().array_of(1)).is_none(),
+            "below MIN_CELLS"
+        );
+        assert!(
+            expandable_array(&Type::field().array_of(SIZE_CAP + 1)).is_none(),
+            "above SIZE_CAP"
+        );
+        assert!(expandable_array(&Type::field()).is_none(), "not an array");
+        assert!(
+            expandable_array(&Type::field().array_of(2).array_of(2)).is_none(),
+            "nested array cell"
+        );
+        assert!(
+            expandable_array(&Type::field().ref_of().array_of(2)).is_none(),
+            "ref cell deferred"
+        );
+    }
+}

--- a/compiler/src/compiler/passes/mod.rs
+++ b/compiler/src/compiler/passes/mod.rs
@@ -1,4 +1,5 @@
 pub mod arg_promotion;
+pub mod array_boundary_expansion;
 pub mod array_sroa;
 pub mod common_subexpression_elimination;
 pub mod dead_code_elimination;

--- a/compiler/src/compiler/ssa/mod.rs
+++ b/compiler/src/compiler/ssa/mod.rs
@@ -472,8 +472,20 @@ impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> SSA<Op, Ty, C> 
     ///
     /// Takes `&self` so passes that hold a shared `&HLSSA` (e.g. the specializer, while the
     /// symbolic executor borrows the SSA) can still mint ids. The counter is atomic.
+    ///
+    /// For minting a known number of values, see [`Self::fresh_values`].
     pub fn fresh_value(&self) -> ValueId {
         ValueId(self.next_value_id.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Allocate `n` fresh `ValueId`s from the SSA-wide counter.
+    ///
+    /// Takes `&self` so passes that hold a shared `&HLSSA` (e.g. the specializer, while the
+    /// symbolic executor borrows the SSA) can still mint ids. The counter is atomic.
+    ///
+    /// For minting single values, see [`Self::fresh_value`].
+    pub fn fresh_values(&self, n: usize) -> Vec<ValueId> {
+        (0..n).map(|_| self.fresh_value()).collect()
     }
 
     /// Upper bound on `ValueId`s issued so far. Useful for sizing dense per-value tables.

--- a/compiler/src/driver.rs
+++ b/compiler/src/driver.rs
@@ -30,6 +30,7 @@ use crate::{
         pass_manager::PassManager,
         passes::{
             arg_promotion::ArgPromotion,
+            array_boundary_expansion::ArrayBoundaryExpansion,
             array_sroa::ArraySroa,
             common_subexpression_elimination::CSE,
             dead_code_elimination::{self, DCE},
@@ -241,6 +242,24 @@ impl Driver {
                 // A third Mem2Reg promotes the materialized callee allocs and the now-local caller
                 // allocs that arg promotion exposed.
                 Box::new(Mem2Reg::new()),
+                // Sever array *call boundaries*: expand an array parameter/return whose only
+                // obstacle to being `Split` is crossing the boundary into per-cell scalars,
+                // reconstructing the array locally on each side.
+                Box::new(ArrayBoundaryExpansion::new()),
+                // A fresh ArraySroa peels the now-local reconstructed arrays (they only become
+                // `Split` on this re-analysis), and a Mem2Reg promotes any per-cell ref allocs the
+                // peel exposes.
+                Box::new(ArraySroa::new()),
+                Box::new(Mem2Reg::new()),
+                // Reclaim cells a side never used: dead by-value formals, their matching arguments
+                // at every static call site, dead return slots, and the now-dead caller-side
+                // `ArrayGet`s — interprocedurally. (`pre_wti` otherwise runs no DCE, and
+                // TrivialPhiElimination does not touch entry-block formals).
+                //
+                // Uses `preserve_blocks()` so it does not collapse empty intermediate blocks into
+                // multiple-predecessor merges that the later untaint_control_flow cannot yet
+                // handle.
+                Box::new(DCE::new(dead_code_elimination::Config::preserve_blocks())),
                 // Mem2Reg promotes each scalarized leaf cell into its own block-parameter phi. For
                 // an aggregate threaded through control flow that is mostly trivial phis (the same
                 // value from every predecessor); collapse them before they reach WTI and codegen.


### PR DESCRIPTION
This pass takes arrays that are provably constant indexed program-wide and spills them to minimal sets of scalars. It is a companion to the Array SROA pass which does this inside functions.