### PR TITLE
Run the unit tests on CI

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -103,8 +103,40 @@ jobs:
       - name: Check Determinism
         run: make determinism-check
 
-  test:
-    name: Run Tests
+  unit-test:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Download Nix Dependencies
+        run: nix develop
+
+      - name: Cache Cargo Dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Run Unit Tests
+        run: make unit-test
+
+  regression-test:
+    name: Run Regression Tests
     runs-on: ubuntu-latest
     steps:
       - name: Generate MavrosBot Token

--- a/wasm-runtime/src/lib.rs
+++ b/wasm-runtime/src/lib.rs
@@ -24,16 +24,21 @@ use ark_ff::BigInt;
 //
 // ═══════════════════════════════════════════════════════════════════════════════
 
+#[cfg(target_arch = "wasm32")]
 const HEADER: usize = 8;
+#[cfg(target_arch = "wasm32")]
 const ALIGN: usize = 8;
 
+#[cfg(target_arch = "wasm32")]
 static mut LIVE_BYTES: usize = 0;
 
+#[cfg(target_arch = "wasm32")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __live_bytes() -> usize {
     unsafe { LIVE_BYTES }
 }
 
+#[cfg(target_arch = "wasm32")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn malloc(size: u32) -> *mut u8 {
     unsafe {
@@ -49,6 +54,7 @@ pub unsafe extern "C" fn malloc(size: u32) -> *mut u8 {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn free(ptr: *mut u8) {
     #[allow(static_mut_refs)]


### PR DESCRIPTION
Fixes a SEGV in the WASM runtime library as it was seeing symbol clashes on non-WASM targets.