### PR TITLE
Introduce a Click-Cooper-style analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ workflows in mind.
 
 ## Building
 
-This project uses [Nix](https://lix.system) [flakes](https://nixos.wiki/wiki/Flakes) to provide a
+This project uses [Nix](https://lix.systems) [flakes](https://nixos.wiki/wiki/Flakes) to provide a
 pinned build environment with all the tools you need to build the project. Assuming you have nix
 installed, simply `make shell` to drop into your user shell inside the build environment, or run
 `nix develop --command <your-command-here>` to run a specific command in the build environment.

--- a/compiler/src/compiler/analysis/call_string.rs
+++ b/compiler/src/compiler/analysis/call_string.rs
@@ -1,0 +1,50 @@
+//! The bounded call-string [`Context`]: the context-sensitivity coordinate shared by
+//! interprocedural analyses.
+//!
+//! A context is a `k`-limited string of call sites so the context space stays finite with recursion
+//! folding onto its recursion head. The empty context is the polymorphic context, under which
+//! `main` is specialized.
+
+use crate::compiler::ssa::{FunctionId, ValueId};
+
+// TYPES
+// ================================================================================================
+
+/// A call site, identified by the caller function and a stable per-call id within its body: the
+/// `Call`'s first result value, or its first argument when the call has no results.
+pub type CallSite = (FunctionId, ValueId);
+
+// CONTEXT
+// ================================================================================================
+
+/// A bounded call-string identifying the context a function (or abstract object) was specialized
+/// in.
+#[derive(Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord, Default)]
+pub struct Context(Vec<CallSite>);
+
+impl Context {
+    /// The empty (polymorphic / summary) context.
+    pub fn empty() -> Self {
+        Context(Vec::new())
+    }
+
+    /// Whether this is the empty context.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// This context extended by `site`, truncated to the most-recent `k` sites (k-CFA).
+    ///
+    /// Passing `k == 0` collapses every context to the empty one ([`Self::empty`]).
+    pub fn push(&self, site: CallSite, k: usize) -> Self {
+        if k == 0 {
+            return Context::empty();
+        }
+        let mut sites = self.0.clone();
+        sites.push(site);
+        if sites.len() > k {
+            sites.drain(0..sites.len() - k);
+        }
+        Context(sites)
+    }
+}

--- a/compiler/src/compiler/analysis/click_cooper/conditional.rs
+++ b/compiler/src/compiler/analysis/click_cooper/conditional.rs
@@ -1,0 +1,338 @@
+//! Facts that are downstream of conditional expressions (asserts, equalities, disequalities, and
+//! unpinned witness forwarding).
+//!
+//! These facts only hold on _accepting_ runs because a constraint establishes them. Per the
+//! module-level soundness contract they are sound only under _constraint-preserving_ use (local
+//! rewrites that maintain the establishing constraint). The computation here is performed
+//! post-convergence using a single pass over the already solved function facts structure, plus the
+//! dominance.
+//!
+//! # Dominance and Post-Dominance, not Dataflow
+//!
+//! An assert is a *global* constraint, not a runtime check: on an accepting run it holds at every
+//! program point, whether the assert lies in that point's past or future. So an assert in reachable
+//! block `B` contributes its fact to the entry of every reachable block `C` for which the assert is
+//! guaranteed to be on the accepting run that flows through `C` — and there are two static ways to
+//! prove that:
+//!
+//! - **`B` strictly dominates `C`** — the assert has *already run* before `C`. Static dominance is
+//!   sound because every statically-dominating block also dominates on the executable subgraph
+//!   (pruning paths only adds dominators), a conservative under-approximation of executable-path
+//!   dominance, and thus subsumes the intersect-at-join dataflow used by branch facts.
+//! - **`B` strictly post-dominates `C`** — the assert is *bound to run* on every continuation out of
+//!   `C`, so on an accepting (terminating) run the constraint is satisfied and the fact holds at `C`
+//!   too. (A non-terminating run never reaches the assert, but never reaches `exit` either, so it is
+//!   non-accepting and excluded; `post_dominates` is `false` for a block that cannot reach `exit`,
+//!   which is the safe answer.)
+//!
+//! The post-dominance direction needs one guard the dominance direction supplies for free: under
+//! dominance `def(v) dom B dom C`, so the asserted value `v` is transitively live at `C`; under
+//! post-dominance that chain breaks, so `v` (both sides, for an equality) must be independently
+//! checked to be in scope at `C` (defined in a block that dominates `C`). This also keeps a
+//! loop-carried value — defined inside a loop and asserted below it — from being mis-attributed to a
+//! pre-loop block.
+//!
+//! Only asserts get the post-dominance direction. A disequality is an *edge* fact (the false edge of
+//! an equality branch): it is path-conditional — true only on the taken edge — so it holds at the
+//! entry of its target block `else_b` only when that edge is the block's sole executable in-edge, and
+//! from there propagates to every block `else_b` *dominates* (reflexively). A post-dominated block
+//! need not have taken that edge, so disequalities stay dominance-only.
+
+use std::sync::Arc;
+
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        analysis::{
+            click_cooper::{
+                lattice::{Constness, bool_constant},
+                solver::FunctionFacts,
+            },
+            flow_analysis::CFG,
+            types::FunctionTypeInfo,
+            value_definitions::{FunctionValueDefinitions, ValueDefinition},
+        },
+        ssa::{
+            BlockId, Terminator, ValueId,
+            hlssa::{CastTarget, CmpKind, Constant, HLFunction, HLSSAConstantsSnapshot, OpCode},
+        },
+    },
+};
+
+// CONDITIONAL FACTS
+// ================================================================================================
+
+/// The conditional facts of one function.
+///
+/// All maps are keyed by the block at whose **entry** the fact holds.
+#[derive(Debug, Default)]
+pub(crate) struct ConditionalFacts {
+    /// Values forced to a constant by a dominating or post-dominating assert: `Assert{v}` ⇒
+    /// `v = true`, `AssertCmp{Eq, x, c}` (with one side unconditional-constant `c`) ⇒ the other
+    /// side `= c`.
+    assert_const: HashMap<BlockId, HashMap<ValueId, Arc<Constant>>>,
+
+    /// Equalities established by a dominating or post-dominating `AssertCmp{Eq, a, b}` where neither
+    /// side is a (unconditional) constant — a *conditional* analog of congruence's `known_equal`.
+    assert_eq: HashMap<BlockId, Vec<(ValueId, ValueId)>>,
+
+    /// Disequalities `(a, b)` from the false edge of an equality `JmpIf` dominating the block.
+    diseq: HashMap<BlockId, HashSet<(ValueId, ValueId)>>,
+
+    /// The honest values a free witness handle `r` is equal to.
+    ///
+    /// It is derived from the two readings of one correspondence: `r = witness_of(v)` — an unpinned
+    /// `WriteWitness { result: Some(r), value: v, pinned: false }` (`r → v`) — and
+    /// `v = value_of(r)` — a `Cast { value: r, target: ValueOf }` honest projection (`r → result`).
+    /// Both key on the witness `r`; each `Vec` is sorted + deduplicated for determinism.
+    witness_fwd: HashMap<ValueId, Vec<ValueId>>,
+}
+
+impl ConditionalFacts {
+    /// The constant `v` is forced to on entry to `bid` by a dominating assert, or `None`.
+    pub(crate) fn asserted_const(&self, bid: BlockId, v: ValueId) -> Option<Arc<Constant>> {
+        self.assert_const.get(&bid)?.get(&v).cloned()
+    }
+
+    /// `true` if a dominating assert proves `a == b` on entry to `bid` (reflexive + symmetric).
+    pub(crate) fn asserted_equal(&self, bid: BlockId, a: ValueId, b: ValueId) -> bool {
+        a == b
+            || self.assert_eq.get(&bid).is_some_and(|eqs| {
+                eqs.iter()
+                    .any(|(x, y)| (*x == a && *y == b) || (*x == b && *y == a))
+            })
+    }
+
+    /// `true` if `a` and `b` are proven unequal on entry to `bid` (symmetric).
+    pub(crate) fn known_disequal(&self, bid: BlockId, a: ValueId, b: ValueId) -> bool {
+        self.diseq
+            .get(&bid)
+            .is_some_and(|set| set.contains(&(a, b)) || set.contains(&(b, a)))
+    }
+
+    /// The honest values equal to the free witness handle `r` (the `WriteWitness` hint and every
+    /// `value_of(r)` read), sorted + deduped; an empty slice if `r` forwards nothing.
+    pub(crate) fn witness_forward(&self, r: ValueId) -> &[ValueId] {
+        self.witness_fwd
+            .get(&r)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+}
+
+// BUILD
+// ================================================================================================
+
+/// Compute the conditional side facts of `function`.
+pub(crate) fn build(
+    function: &HLFunction,
+    facts: &FunctionFacts,
+    cfg: &CFG,
+    consts: &HLSSAConstantsSnapshot,
+    type_info: &FunctionTypeInfo,
+) -> ConditionalFacts {
+    let mut out = ConditionalFacts::default();
+
+    // The *unconditional* constant of `v` (interned or proven by the lattice), if any.
+    //
+    // Asserts that pin a value to such a constant produce a *conditional* fact; the unconditional
+    // view is never touched.
+    let const_of = |v: ValueId| -> Option<Arc<Constant>> {
+        if let Some(c) = consts.get(&v) {
+            return Some(c.clone());
+        }
+        match facts.lattice.get(&v) {
+            Some(Constness::Const(c)) => Some(c.clone()),
+            _ => None,
+        }
+    };
+
+    // A value→defining-block lookup, used to gate the post-dominance fan-out (Step 3) on the
+    // asserted value being live at the target block. `v` is in scope on entry to `c` iff it is
+    // defined in a block that dominates `c`. A value with no structural definition (an interned
+    // constant / global) is in scope everywhere. Dominance fan-out needs no such check: `def(v)`
+    // dominates the asserting block, which dominates the target, so `v` is transitively live there.
+    let defs = FunctionValueDefinitions::from_function(function);
+    let in_scope = |v: ValueId, c: BlockId| match defs.get_definition(v) {
+        Some(ValueDefinition::Param(b, ..) | ValueDefinition::Instruction(b, ..)) => {
+            cfg.dominates(*b, c)
+        }
+        None => true,
+    };
+
+    // Step 1: Gather facts at their establishing block, plus the (global) witness forwards and the
+    // `Cmp{Eq}` results needed to interpret equality branches.
+    let mut raw_const: HashMap<BlockId, Vec<(ValueId, Arc<Constant>)>> = HashMap::default();
+    let mut raw_eq: HashMap<BlockId, Vec<(ValueId, ValueId)>> = HashMap::default();
+    let mut eq_cmp_of: HashMap<ValueId, (ValueId, ValueId)> = HashMap::default();
+
+    for (bid, block) in function.get_blocks() {
+        if !facts.reachable.contains(bid) {
+            continue;
+        }
+        for instr in block.get_instructions() {
+            match instr {
+                OpCode::Assert { value } => {
+                    raw_const
+                        .entry(*bid)
+                        .or_default()
+                        .push((*value, bool_constant(true)));
+                }
+                OpCode::AssertCmp {
+                    kind: CmpKind::Eq,
+                    lhs,
+                    rhs,
+                } => {
+                    if let Some(c) = const_of(*lhs) {
+                        raw_const.entry(*bid).or_default().push((*rhs, c));
+                    } else if let Some(c) = const_of(*rhs) {
+                        raw_const.entry(*bid).or_default().push((*lhs, c));
+                    } else {
+                        raw_eq.entry(*bid).or_default().push((*lhs, *rhs));
+                    }
+                }
+                OpCode::Cmp {
+                    kind: CmpKind::Eq,
+                    result,
+                    lhs,
+                    rhs,
+                } => {
+                    eq_cmp_of.insert(*result, (*lhs, *rhs));
+                }
+
+                // A redirect `r → v` pins a free witness to its honest value (honest witgen sets
+                // `r = v`): it *adds* a functional constraint, so it narrows the accept set
+                // (`A_M ⊆ A_N`) and never rejects the honest run.
+                OpCode::WriteWitness {
+                    result: Some(r),
+                    value,
+                    pinned: false,
+                } if type_info.get_value_type(*r).is_witness_of() => {
+                    out.witness_fwd.entry(*r).or_default().push(*value);
+                }
+
+                // The same correspondence read the other way: `result = value_of(r)` strips `r`'s
+                // witness wrapper to its honest value, so `result == r` honestly — another member of
+                // `r`'s honest-value set. The operand `value` is the witness (always `WitnessOf` for
+                // a well-typed `ValueOf`; the guard mirrors the `WriteWitness` arm).
+                OpCode::Cast {
+                    result,
+                    value,
+                    target: CastTarget::ValueOf,
+                } if type_info.get_value_type(*value).is_witness_of() => {
+                    out.witness_fwd.entry(*value).or_default().push(*result);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Canonicalize each witness's honest-value set: sort + dedup so the result is independent of
+    // block/instruction scan order (the analysis must be byte-deterministic).
+    for members in out.witness_fwd.values_mut() {
+        members.sort_unstable();
+        members.dedup();
+    }
+
+    // Step 2: Disequalities from the false edge of an equality branch, keyed by the false target at
+    // whose entry they hold. The fact holds there only when that edge is the target's *sole*
+    // executable in-edge (otherwise a join could merge in a path that never established it).
+    let mut raw_diseq: HashMap<BlockId, HashSet<(ValueId, ValueId)>> = HashMap::default();
+    for (bid, block) in function.get_blocks() {
+        if !facts.reachable.contains(bid) {
+            continue;
+        }
+        let Some(Terminator::JmpIf(cond, then_b, else_b)) = block.get_terminator() else {
+            continue;
+        };
+
+        // A degenerate branch to the same block both ways establishes nothing on either edge.
+        if then_b == else_b {
+            continue;
+        }
+        let Some((lhs, rhs)) = eq_cmp_of.get(cond) else {
+            continue;
+        };
+        if !facts.reachable.contains(else_b) {
+            continue;
+        }
+
+        let preds: Vec<BlockId> = facts
+            .exec_edges
+            .iter()
+            .filter(|(_, t)| t == else_b)
+            .map(|(p, _)| *p)
+            .collect();
+        if preds.len() == 1 && preds[0] == *bid {
+            raw_diseq.entry(*else_b).or_default().insert((*lhs, *rhs));
+        }
+    }
+
+    // Step 3: Fan out to dominated (and, for asserts, post-dominated) blocks. The inner loop only
+    // needs the blocks that actually established a fact (the keys of the raw maps), not every
+    // reachable block. Iterating sorted targets `C` (outer) and sorted fact-source blocks `B`
+    // (inner) keeps the result deterministic and first-writer-wins on any contradictory pair of
+    // asserts (which can only co-dominate/co-post-dominate a block that no honest run reaches).
+    let mut reachable_blocks: Vec<BlockId> = facts.reachable.iter().copied().collect();
+    reachable_blocks.sort_by_key(|b| b.0);
+    let mut fact_sources: Vec<BlockId> = raw_const
+        .keys()
+        .chain(raw_eq.keys())
+        .chain(raw_diseq.keys())
+        .copied()
+        .collect();
+    fact_sources.sort_unstable();
+    fact_sources.dedup();
+
+    for &c in &reachable_blocks {
+        for &b in &fact_sources {
+            // Assert facts hold at `C` when the assert is guaranteed on every run flowing through
+            // `C`: either it has already run (`B` strictly dominates `C`) or it is bound to run on
+            // every continuation (`B` strictly post-dominates `C`). `B != C` excludes the asserting
+            // block's own entry.
+            let dominates = b != c && cfg.dominates(b, c);
+            let post_dominates = b != c && cfg.post_dominates(b, c);
+
+            if dominates || post_dominates {
+                if let Some(consts_at_b) = raw_const.get(&b) {
+                    let entry = out.assert_const.entry(c).or_default();
+                    for (v, k) in consts_at_b {
+                        // Dominance makes `v` transitively live at `C`; under post-dominance only,
+                        // `v` must be independently in scope (see the module soundness note).
+                        if dominates || in_scope(*v, c) {
+                            entry.entry(*v).or_insert_with(|| k.clone());
+                        }
+                    }
+                }
+                if let Some(eqs_at_b) = raw_eq.get(&b) {
+                    let entry = out.assert_eq.entry(c).or_default();
+                    for pair in eqs_at_b {
+                        let (x, y) = pair;
+
+                        // Post-dominance requires *both* sides of the equality to be in scope at
+                        // `C`.
+                        if (dominates || (in_scope(*x, c) && in_scope(*y, c)))
+                            && !entry.contains(pair)
+                        {
+                            entry.push(*pair);
+                        }
+                    }
+                }
+            }
+
+            // Disequalities are path-conditional edge facts already attached to their target's
+            // entry, so they propagate reflexively (`B == C` keeps the fact at the target itself)
+            // and stay dominance-only — a post-dominated block need not have taken that edge.
+            if cfg.dominates(b, c) {
+                if let Some(diseqs_at_b) = raw_diseq.get(&b) {
+                    let entry = out.diseq.entry(c).or_default();
+                    for pair in diseqs_at_b {
+                        entry.insert(*pair);
+                    }
+                }
+            }
+        }
+    }
+
+    out
+}

--- a/compiler/src/compiler/analysis/click_cooper/congruence.rs
+++ b/compiler/src/compiler/analysis/click_cooper/congruence.rs
@@ -1,0 +1,456 @@
+//! The congruence factor: optimistic global value numbering by partition refinement.
+//!
+//! This is the value-numbering half of Click–Cooper (Alpern–Wegman–Zadeck, POPL '88). Every
+//! like-shaped value starts assumed congruent (one class per operator kind) and classes are only
+//! ever **split**, never merged. Because the partition starts maximal, loop-carried congruences —
+//! two parallel induction variables that are equal across the back-edge — survive refinement.
+//!
+//! # Coupling and Staging
+//!
+//! Two values are congruent when they are computed by the same operator from operandwise-congruent
+//! inputs. The factor reads two products of the constants + reachability fixpoint.
+//!
+//! - **Constants** are used to seed the partition — a value the lattice proved `Const(c)` is
+//!   labelled by `c`, so two values equal to the same constant are congruent (the const →
+//!   congruence coupling).
+//! - **Reachability** scopes φ-operands — a block parameter's operands are the incoming jump-args
+//!   on each *executable* predecessor edge only, so a dead in-edge never forces two φ's apart.
+
+use std::sync::Arc;
+
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::ssa::{
+        BlockId, Instruction, Terminator, ValueId,
+        hlssa::{BinaryArithOpKind, CastTarget, CmpKind, Constant, HLFunction, OpCode},
+    },
+};
+
+// TYPES
+// ================================================================================================
+
+/// The type of the identifier for a given congruence class.
+type ClassId = usize;
+
+// CONGRUENCE
+// ================================================================================================
+
+/// The converged congruence partition for one function.
+#[derive(Debug, Default)]
+pub(crate) struct Congruence {
+    /// A mapping from values to congruence class IDs.
+    class_of: HashMap<ValueId, ClassId>,
+
+    /// Class → members (each inner list sorted by value id). The inverse of `class_of`.
+    ///
+    /// The outer `Vec` is keyed by `ClassId`, which is a dense, contiguous, self-assigned `usize`
+    /// (allocated as `members.len()` and never deleted — classes only ever split, never merge), and
+    /// the refinement loop sweeps it by index.
+    members: Vec<Vec<ValueId>>,
+}
+
+impl Congruence {
+    /// `true` if `a` and `b` are proven congruent (structurally equal in every run).
+    pub(crate) fn known_equal(&self, a: ValueId, b: ValueId) -> bool {
+        match (self.class_of.get(&a), self.class_of.get(&b)) {
+            (Some(x), Some(y)) => x == y,
+            (Some(_), None) | (None, Some(_)) | (None, None) => false,
+        }
+    }
+
+    /// Every value congruent to `v` (including `v`), sorted by value id. Empty if `v` is unknown.
+    pub(crate) fn class_members(&self, v: ValueId) -> Vec<ValueId> {
+        match self.class_of.get(&v) {
+            Some(&cid) => self.members[cid].clone(),
+            None => Vec::new(),
+        }
+    }
+
+    /// A deterministic representative of `v`'s class (the smallest member by value id).
+    ///
+    /// Note: this is *not* yet guaranteed to dominate the other members, so it is not a legal
+    /// redirect target on its own. The dominance-aware leader requires threading the `FlowAnalysis`
+    /// dominance into the congruence partition.
+    pub(crate) fn leader(&self, v: ValueId) -> Option<ValueId> {
+        let &cid = self.class_of.get(&v)?;
+        self.members[cid].first().copied()
+    }
+
+    /// Solve the partition for `function` over the converged reachability state.
+    ///
+    /// `const_of` reports the unconditional constant of a value (the constants+reachability lattice),
+    /// used for the const→congruence seeding.
+    pub(crate) fn build(
+        function: &HLFunction,
+        reachable: &HashSet<BlockId>,
+        exec_edges: &HashSet<(BlockId, BlockId)>,
+        const_of: impl Fn(ValueId) -> Option<Arc<Constant>>,
+    ) -> Congruence {
+        let entry = function.get_entry_id();
+
+        // 1. Classify every value defined in a reachable block, and gather the full value universe
+        //    (definitions plus every referenced operand).
+        let mut nodes: HashMap<ValueId, Node> = HashMap::default();
+        let mut universe: HashSet<ValueId> = HashSet::default();
+
+        for (bid, block) in function.get_blocks() {
+            if !reachable.contains(bid) {
+                continue;
+            }
+
+            for (index, p) in block.get_parameter_values().copied().enumerate() {
+                universe.insert(p);
+
+                // Entry parameters are the function's formals: opaque at the intraprocedural level.
+                let node = if *bid == entry {
+                    Node::Opaque
+                } else {
+                    Node::Phi { block: *bid, index }
+                };
+                nodes.insert(p, node);
+            }
+
+            for instr in block.get_instructions() {
+                for input in instr.get_inputs() {
+                    universe.insert(*input);
+                }
+                match op_signature(instr) {
+                    Some((key, operands, commutative)) => {
+                        let mut results = instr.get_results();
+                        if let Some(r) = results.next() {
+                            universe.insert(*r);
+                            nodes.insert(
+                                *r,
+                                Node::Op {
+                                    key,
+                                    operands,
+                                    commutative,
+                                },
+                            );
+                        }
+                        // Pure folds are single-result; any extra results are opaque (defensive).
+                        for r in results {
+                            universe.insert(*r);
+                            nodes.insert(*r, Node::Opaque);
+                        }
+                    }
+                    None => {
+                        for r in instr.get_results() {
+                            universe.insert(*r);
+                            nodes.insert(*r, Node::Opaque);
+                        }
+                    }
+                }
+            }
+
+            match block.get_terminator() {
+                Some(Terminator::Jmp(_, args)) => universe.extend(args.iter().copied()),
+                Some(Terminator::JmpIf(cond, _, _)) => {
+                    universe.insert(*cond);
+                }
+                Some(Terminator::Return(vals)) => universe.extend(vals.iter().copied()),
+                None => {}
+            }
+        }
+
+        let mut universe: Vec<ValueId> = universe.into_iter().collect();
+        universe.sort_unstable();
+
+        // 2. Seed the optimistic partition: one class per operand-free label. Constants group by
+        //    value, like-shaped ops/φs group by operator, opaque values are singletons.
+        let mut class_of: HashMap<ValueId, ClassId> = HashMap::default();
+        let mut members: Vec<Vec<ValueId>> = Vec::new();
+        let mut splittable: Vec<bool> = Vec::new();
+        let mut label_to_class: HashMap<Label, ClassId> = HashMap::default();
+
+        for &v in &universe {
+            let label = if let Some(c) = const_of(v) {
+                Label::Const(c)
+            } else {
+                match nodes.get(&v) {
+                    Some(Node::Phi { block, .. }) => Label::Phi(*block),
+                    Some(Node::Op { key, .. }) => Label::Op(key.clone()),
+                    Some(Node::Opaque) | None => Label::Opaque(v),
+                }
+            };
+
+            // Only operator/φ classes can split; constant and opaque classes are already exact.
+            let can_split = matches!(label, Label::Phi(_) | Label::Op(_));
+            let cid = *label_to_class.entry(label).or_insert_with(|| {
+                members.push(Vec::new());
+                splittable.push(can_split);
+                members.len() - 1
+            });
+            members[cid].push(v);
+            class_of.insert(v, cid);
+        }
+
+        // Executable predecessors per block, sorted ascending, computed once. The φ refinement
+        // signature below would otherwise rescan the whole edge set on every evaluation (once per
+        // φ member, per splittable class, per round). `exec_edges` is a set, so no predecessor is
+        // duplicated; sorting matches the old `BTreeSet` order so φ-operand classes stay
+        // positionally aligned and deterministic.
+        let mut exec_preds: HashMap<BlockId, Vec<BlockId>> = HashMap::default();
+        for (p, t) in exec_edges {
+            exec_preds.entry(*t).or_default().push(*p);
+        }
+        for preds in exec_preds.values_mut() {
+            preds.sort_unstable();
+        }
+
+        // 3. Refine to a stable partition: split any class whose members disagree on the classes of
+        //    their operands. Splitting is monotone.
+        //
+        // The signature map is hoisted out of the loop and cleared per class so refinement does not
+        // re-allocate it every round.
+        let mut groups: HashMap<Sig, Vec<ValueId>> = HashMap::default();
+        loop {
+            let mut changed = false;
+            let class_count = members.len();
+            for cid in 0..class_count {
+                if !splittable[cid] || members[cid].len() < 2 {
+                    continue;
+                }
+
+                groups.clear();
+                for &v in &members[cid] {
+                    let sig = signature(function, &exec_preds, &nodes, &class_of, v);
+                    groups.entry(sig).or_default().push(v);
+                }
+
+                if groups.len() <= 1 {
+                    continue;
+                }
+
+                // Split into one class per signature, draining `groups` in its deterministic
+                // iteration order. The partition and leaders are order-independent, so numbering is
+                // invisible to every consumer.
+                let mut drained = groups.drain();
+                let (_, first) = drained.next().expect("groups has > 1 entry, checked above");
+                members[cid] = first;
+                for (_, g) in drained {
+                    let new_cid = members.len();
+                    for &v in &g {
+                        class_of.insert(v, new_cid);
+                    }
+                    members.push(g);
+                    splittable.push(true);
+                    changed = true;
+                }
+            }
+
+            if !changed {
+                break;
+            }
+        }
+
+        Congruence { class_of, members }
+    }
+}
+
+// CLASSIFICATION
+// ================================================================================================
+
+/// What a value *is*, for congruence purposes.
+enum Node {
+    /// A block parameter (φ) of a non-entry block.
+    ///
+    /// Its operands are the incoming jump-args, one per executable predecessor edge.
+    Phi { block: BlockId, index: usize },
+
+    /// A pure, deterministic operator whose result is a function of its operand *values*.
+    Op { key: OpKey, operands: Vec<ValueId>, commutative: bool },
+
+    /// Anything else (memory, witnesses, calls, witness/runtime casts, …): not value-numbered, so it
+    /// gets its own singleton class and is never congruent to another value.
+    Opaque,
+}
+
+/// The operand-free operator key seeding the optimistic partition: two values can be congruent only
+/// if they share this key (same operator and the same immediate, non-value attributes).
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum OpKey {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    And,
+    Or,
+    Xor,
+    Shl,
+    Shr,
+    CmpEq,
+    CmpLt,
+    MulConst,
+    Cast(CastTarget),
+    SExt(usize, usize),
+    BitRange(usize, usize),
+    Not,
+    Select,
+}
+
+/// The operand-free label that seeds the initial classes.
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum Label {
+    /// Grouped by constant value — the const→congruence coupling.
+    Const(Arc<Constant>),
+
+    /// φ-functions of the same join block (refined by their per-edge operands).
+    Phi(BlockId),
+
+    /// Like-shaped pure ops (refined by their operand classes).
+    Op(OpKey),
+
+    /// A value of its own — always a singleton.
+    Opaque(ValueId),
+}
+
+/// A value's refinement signature.
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum Sig {
+    /// Operands mapped to their _current_ classes.
+    Operands(Vec<ClassId>),
+
+    /// A φ unresolvable on some executable edge (a non-`Jmp` predecessor) is never merged.
+    Opaque(ValueId),
+}
+
+/// The pure, deterministic ops eligible for value numbering, paired with their operands and
+/// commutativity.
+fn op_signature(instr: &OpCode) -> Option<(OpKey, Vec<ValueId>, bool)> {
+    use BinaryArithOpKind::*;
+    Some(match instr {
+        OpCode::BinaryArithOp { kind, lhs, rhs, .. } => {
+            let (key, commutative) = match kind {
+                Add => (OpKey::Add, true),
+                Sub => (OpKey::Sub, false),
+                Mul => (OpKey::Mul, true),
+                Div => (OpKey::Div, false),
+                Mod => (OpKey::Mod, false),
+                And => (OpKey::And, true),
+                Or => (OpKey::Or, true),
+                Xor => (OpKey::Xor, true),
+                Shl => (OpKey::Shl, false),
+                Shr => (OpKey::Shr, false),
+            };
+            (key, vec![*lhs, *rhs], commutative)
+        }
+        OpCode::Cmp { kind, lhs, rhs, .. } => match kind {
+            CmpKind::Eq => (OpKey::CmpEq, vec![*lhs, *rhs], true),
+            CmpKind::Lt => (OpKey::CmpLt, vec![*lhs, *rhs], false),
+        },
+        OpCode::MulConst { const_val, var, .. } => (OpKey::MulConst, vec![*const_val, *var], true),
+        OpCode::Cast { value, target, .. } => match target {
+            CastTarget::Nop | CastTarget::Field | CastTarget::U(_) | CastTarget::I(_) => {
+                (OpKey::Cast(target.clone()), vec![*value], false)
+            }
+            CastTarget::WitnessOf
+            | CastTarget::ValueOf
+            | CastTarget::ArrayToSlice
+            | CastTarget::Map(_) => return None,
+        },
+        OpCode::SExt {
+            value,
+            from_bits,
+            to_bits,
+            ..
+        } => (OpKey::SExt(*from_bits, *to_bits), vec![*value], false),
+        OpCode::BitRange {
+            value,
+            offset,
+            width,
+            ..
+        } => (OpKey::BitRange(*offset, *width), vec![*value], false),
+        OpCode::Not { value, .. } => (OpKey::Not, vec![*value], false),
+        OpCode::Select {
+            cond, if_t, if_f, ..
+        } => (OpKey::Select, vec![*cond, *if_t, *if_f], false),
+
+        // Not pure/deterministic value-numbering candidates.
+        OpCode::MkSeq { .. }
+        | OpCode::MkSeqOfBlob { .. }
+        | OpCode::MkRepeated { .. }
+        | OpCode::Alloc { .. }
+        | OpCode::Store { .. }
+        | OpCode::Load { .. }
+        | OpCode::Assert { .. }
+        | OpCode::AssertCmp { .. }
+        | OpCode::AssertR1C { .. }
+        | OpCode::Call { .. }
+        | OpCode::ArrayGet { .. }
+        | OpCode::ArraySet { .. }
+        | OpCode::SlicePush { .. }
+        | OpCode::SliceLen { .. }
+        | OpCode::ToBits { .. }
+        | OpCode::ToRadix { .. }
+        | OpCode::MemOp { .. }
+        | OpCode::WriteWitness { .. }
+        | OpCode::FreshWitness { .. }
+        | OpCode::NextDCoeff { .. }
+        | OpCode::BumpD { .. }
+        | OpCode::Constrain { .. }
+        | OpCode::Lookup { .. }
+        | OpCode::DLookup { .. }
+        | OpCode::Rangecheck { .. }
+        | OpCode::ReadGlobal { .. }
+        | OpCode::TupleProj { .. }
+        | OpCode::TupleRefProj { .. }
+        | OpCode::MkTuple { .. }
+        | OpCode::Todo { .. }
+        | OpCode::InitGlobal { .. }
+        | OpCode::DropGlobal { .. }
+        | OpCode::Spread { .. }
+        | OpCode::Unspread { .. }
+        | OpCode::Guard { .. } => return None,
+    })
+}
+
+/// `v`'s current refinement signature.
+///
+/// `exec_preds` maps each block to its executable predecessors (sorted ascending).
+fn signature(
+    function: &HLFunction,
+    exec_preds: &HashMap<BlockId, Vec<BlockId>>,
+    nodes: &HashMap<ValueId, Node>,
+    class_of: &HashMap<ValueId, ClassId>,
+    v: ValueId,
+) -> Sig {
+    let class = |operand: &ValueId| class_of.get(operand).copied().unwrap_or(usize::MAX);
+    match nodes.get(&v) {
+        Some(Node::Op {
+            operands,
+            commutative,
+            ..
+        }) => {
+            let mut classes: Vec<ClassId> = operands.iter().map(class).collect();
+            if *commutative {
+                classes.sort_unstable();
+            }
+            Sig::Operands(classes)
+        }
+        Some(Node::Phi { block, index }) => {
+            // Predecessors are pre-sorted (deterministic) so positionally-aligned operand classes
+            // are comparable.
+            let preds: &[BlockId] = exec_preds.get(block).map(Vec::as_slice).unwrap_or(&[]);
+            let mut classes = Vec::with_capacity(preds.len());
+            for &p in preds {
+                match function.get_block(p).get_terminator() {
+                    Some(Terminator::Jmp(t, args)) if t == block && *index < args.len() => {
+                        classes.push(class(&args[*index]));
+                    }
+
+                    // A parameterized block reached by a non-`Jmp` edge (or a `Jmp` that does not
+                    // target this φ's block / lacks the operand) cannot be resolved here; refuse to
+                    // merge it with any other φ.
+                    Some(Terminator::Jmp(..))
+                    | Some(Terminator::JmpIf(..))
+                    | Some(Terminator::Return(..))
+                    | None => return Sig::Opaque(v),
+                }
+            }
+            Sig::Operands(classes)
+        }
+        Some(Node::Opaque) | None => Sig::Opaque(v),
+    }
+}

--- a/compiler/src/compiler/analysis/click_cooper/lattice.rs
+++ b/compiler/src/compiler/analysis/click_cooper/lattice.rs
@@ -1,0 +1,337 @@
+//! The constant-propagation lattice element and its constant-evaluation transfer functions.
+
+use std::sync::{Arc, OnceLock};
+
+use ark_ff::{PrimeField, Zero};
+
+use crate::compiler::{
+    Field,
+    ssa::hlssa::{BinaryArithOpKind, CastTarget, CmpKind, Constant, MAX_SUPPORTED_SIGNED_BITS},
+    util::{bit_mask, decode_signed, encode_signed, fits_signed},
+};
+
+// CONSTNESS
+// ================================================================================================
+
+/// A value's *constness*: where it sits in the constant-propagation lattice.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum Constness {
+    /// Not (yet) known to be reachable with any value.
+    Top,
+
+    /// Proven to always hold this constant.
+    Const(Arc<Constant>),
+
+    /// Overdefined: holds a runtime-dependent (or non-foldable) value.
+    Bottom,
+}
+
+// CONSTANT EVALUATION
+// ================================================================================================
+
+pub(crate) fn const_join(a: Constness, b: Constness) -> Constness {
+    match (a, b) {
+        (Constness::Top, x) | (x, Constness::Top) => x,
+        (Constness::Bottom, _) | (_, Constness::Bottom) => Constness::Bottom,
+        (Constness::Const(c1), Constness::Const(c2)) => {
+            if c1 == c2 {
+                Constness::Const(c1)
+            } else {
+                Constness::Bottom
+            }
+        }
+    }
+}
+
+pub(crate) fn const_bool(c: &Constant) -> Option<bool> {
+    match c {
+        Constant::U(1, 0) => Some(false),
+        Constant::U(1, 1) => Some(true),
+        Constant::U(..)
+        | Constant::I(..)
+        | Constant::Field(_)
+        | Constant::FnPtr(_)
+        | Constant::Blob(_) => None,
+    }
+}
+
+pub(crate) fn bool_constness(value: bool) -> Constness {
+    Constness::Const(bool_constant(value))
+}
+
+pub(crate) fn bool_constant(value: bool) -> Arc<Constant> {
+    static FALSE: OnceLock<Arc<Constant>> = OnceLock::new();
+    static TRUE: OnceLock<Arc<Constant>> = OnceLock::new();
+    let slot = if value { &TRUE } else { &FALSE };
+    slot.get_or_init(|| Arc::new(Constant::U(1, value as u128)))
+        .clone()
+}
+
+/// Fold a binary arithmetic op.
+///
+/// Integer results must fit the operand width: an overflowing pure op is an erroneous evaluation
+/// with a backend-specific residue, so an overflowing fold is refused rather than guessed at.
+pub(crate) fn eval_binary(kind: BinaryArithOpKind, a: &Constant, b: &Constant) -> Option<Constant> {
+    use BinaryArithOpKind::*;
+    match (a, b) {
+        (Constant::U(s1, x), Constant::U(s2, y)) => {
+            match kind {
+                // Shifts are the only ops with legitimately mixed operand widths (the amount is
+                // typically a narrow integer), but the type analysis types the result as
+                // `U(max(s1, s2))`. A fold to a `U(s1)` constant is therefore only width-preserving
+                // when the amount is no wider than the value; refuse the degenerate wider-amount
+                // case rather than silently changing the result's width.
+                Shl | Shr => {
+                    if s2 > s1 {
+                        return None;
+                    }
+                }
+                Add | Sub | Mul | Div | Mod | And | Or | Xor => {
+                    if s1 != s2 {
+                        return None;
+                    }
+                }
+            }
+
+            let s = *s1;
+            let v = match kind {
+                Add => x.checked_add(*y)?,
+                Sub => x.checked_sub(*y)?,
+                Mul => x.checked_mul(*y)?,
+                Div => {
+                    if *y == 0 {
+                        return None;
+                    }
+                    x / y
+                }
+                Mod => {
+                    if *y == 0 {
+                        return None;
+                    }
+                    x % y
+                }
+                And => x & y,
+                Or => x | y,
+                Xor => x ^ y,
+                Shl | Shr => {
+                    if *y >= s as u128 {
+                        return None;
+                    }
+                    match kind {
+                        Shl => x.checked_shl(*y as u32)?,
+                        Shr => x >> (*y as u32),
+                        Add | Sub | Mul | Div | Mod | And | Or | Xor => unreachable!(),
+                    }
+                }
+            };
+
+            if v > bit_mask(s) {
+                return None;
+            }
+            Some(Constant::U(s, v))
+        }
+        (Constant::I(s1, x), Constant::I(s2, y)) => {
+            if s1 != s2 {
+                return None;
+            }
+            let s = *s1;
+            if s == 0 || s > MAX_SUPPORTED_SIGNED_BITS {
+                return None;
+            }
+            match kind {
+                And => Some(Constant::I(s, x & y)),
+                Or => Some(Constant::I(s, x | y)),
+                Xor => Some(Constant::I(s, x ^ y)),
+                Add | Sub | Mul | Div | Mod => {
+                    let xa = decode_signed(s, *x);
+                    let ya = decode_signed(s, *y);
+                    let v = match kind {
+                        Add => xa.checked_add(ya)?,
+                        Sub => xa.checked_sub(ya)?,
+                        Mul => xa.checked_mul(ya)?,
+                        Div => {
+                            if ya == 0 {
+                                return None;
+                            }
+                            xa.checked_div(ya)?
+                        }
+                        Mod => {
+                            if ya == 0 {
+                                return None;
+                            }
+                            xa.checked_rem(ya)?
+                        }
+                        And | Or | Xor | Shl | Shr => unreachable!(),
+                    };
+                    if !fits_signed(s, v) {
+                        return None;
+                    }
+                    Some(Constant::I(s, encode_signed(s, v)))
+                }
+                Shl | Shr => None,
+            }
+        }
+        (Constant::Field(x), Constant::Field(y)) => match kind {
+            Add => Some(Constant::Field(*x + *y)),
+            Sub => Some(Constant::Field(*x - *y)),
+            Mul => Some(Constant::Field(*x * *y)),
+            Div => {
+                if y.is_zero() {
+                    None
+                } else {
+                    Some(Constant::Field(*x / *y))
+                }
+            }
+            Mod | And | Or | Xor | Shl | Shr => None,
+        },
+
+        // Mixed-kind pairs and non-scalar constants do not fold.
+        (
+            Constant::U(..)
+            | Constant::I(..)
+            | Constant::Field(_)
+            | Constant::FnPtr(_)
+            | Constant::Blob(_),
+            Constant::U(..)
+            | Constant::I(..)
+            | Constant::Field(_)
+            | Constant::FnPtr(_)
+            | Constant::Blob(_),
+        ) => None,
+    }
+}
+
+/// Folds a constant comparison operation.
+pub(crate) fn eval_cmp(kind: CmpKind, a: &Constant, b: &Constant) -> Option<Constant> {
+    let res = |v: bool| Some(Constant::U(1, v as u128));
+    match (kind, a, b) {
+        (CmpKind::Eq, Constant::U(s1, x), Constant::U(s2, y)) if s1 == s2 => res(x == y),
+        (CmpKind::Eq, Constant::I(s1, x), Constant::I(s2, y)) if s1 == s2 => res(x == y),
+        (CmpKind::Eq, Constant::Field(x), Constant::Field(y)) => res(x == y),
+        (CmpKind::Lt, Constant::U(s1, x), Constant::U(s2, y)) if s1 == s2 => res(x < y),
+        (CmpKind::Lt, Constant::I(s1, x), Constant::I(s2, y))
+            if s1 == s2 && *s1 >= 1 && *s1 <= MAX_SUPPORTED_SIGNED_BITS =>
+        {
+            res(decode_signed(*s1, *x) < decode_signed(*s1, *y))
+        }
+
+        // Width-mismatched, mixed-kind, and non-scalar comparisons do not fold
+        (
+            CmpKind::Eq | CmpKind::Lt,
+            Constant::U(..)
+            | Constant::I(..)
+            | Constant::Field(_)
+            | Constant::FnPtr(_)
+            | Constant::Blob(_),
+            Constant::U(..)
+            | Constant::I(..)
+            | Constant::Field(_)
+            | Constant::FnPtr(_)
+            | Constant::Blob(_),
+        ) => None,
+    }
+}
+
+/// Folds a field multiplication operation.
+pub(crate) fn eval_field_mul(a: &Constant, b: &Constant) -> Option<Constant> {
+    match (a, b) {
+        (Constant::Field(x), Constant::Field(y)) => Some(Constant::Field(*x * *y)),
+        (
+            Constant::U(..)
+            | Constant::I(..)
+            | Constant::Field(_)
+            | Constant::FnPtr(_)
+            | Constant::Blob(_),
+            Constant::U(..)
+            | Constant::I(..)
+            | Constant::Field(_)
+            | Constant::FnPtr(_)
+            | Constant::Blob(_),
+        ) => None,
+    }
+}
+
+/// Folds a constant cast operation.
+///
+/// HLSSA casts are raw-bits conversions (sign extension is the separate `SExt` op). Integers
+/// zero-extend into fields, fields truncate to their low bits, and integer-to-integer casts
+/// zero-extend or truncate.
+pub(crate) fn eval_cast(target: &CastTarget, v: &Constant) -> Option<Constant> {
+    match target {
+        CastTarget::Nop => Some(v.clone()),
+        CastTarget::WitnessOf
+        | CastTarget::ArrayToSlice
+        | CastTarget::ValueOf
+        | CastTarget::Map(_) => None,
+        CastTarget::Field => match v {
+            Constant::U(_, x) | Constant::I(_, x) => Some(Constant::Field(Field::from(*x))),
+            Constant::Field(_) => Some(v.clone()),
+            Constant::FnPtr(_) | Constant::Blob(_) => None,
+        },
+        CastTarget::U(n) => int_cast_bits(v, *n).map(|bits| Constant::U(*n, bits)),
+        CastTarget::I(n) => {
+            if *n > MAX_SUPPORTED_SIGNED_BITS {
+                return None;
+            }
+            int_cast_bits(v, *n).map(|bits| Constant::I(*n, bits))
+        }
+    }
+}
+
+/// Extracts the low `n` bits of a constant's value and returns them as a raw u128 magnitude, or
+/// `None` if the constant is not numeric.
+fn int_cast_bits(v: &Constant, n: usize) -> Option<u128> {
+    let mask = bit_mask(n);
+    match v {
+        Constant::U(_, x) | Constant::I(_, x) => Some(x & mask),
+        Constant::Field(f) => {
+            let limbs = f.into_bigint().0;
+            let low = (limbs[0] as u128) | ((limbs[1] as u128) << 64);
+            Some(low & mask)
+        }
+        Constant::FnPtr(_) | Constant::Blob(_) => None,
+    }
+}
+
+/// Folds a constant sign extension operation.
+pub(crate) fn eval_sext(v: &Constant, from_bits: usize, to_bits: usize) -> Option<Constant> {
+    if from_bits == 0 || from_bits > to_bits || to_bits > 128 {
+        return None;
+    }
+    let ext = |x: u128| {
+        if (x >> (from_bits - 1)) & 1 == 1 {
+            x | (bit_mask(to_bits) & !bit_mask(from_bits))
+        } else {
+            x
+        }
+    };
+    match v {
+        Constant::U(_, x) => Some(Constant::U(to_bits, ext(*x))),
+        Constant::I(_, x) => Some(Constant::I(to_bits, ext(*x))),
+        Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => None,
+    }
+}
+
+/// Folds a constant `BitRange` operation.
+///
+/// `BitRange` keeps the source type (it is the IR's truncation primitive), so only the payload
+/// bits change.
+pub(crate) fn eval_bit_range(v: &Constant, offset: usize, width: usize) -> Option<Constant> {
+    if offset >= 128 {
+        return None;
+    }
+    match v {
+        Constant::U(s, x) => Some(Constant::U(*s, (x >> offset) & bit_mask(width))),
+        Constant::I(s, x) => Some(Constant::I(*s, (x >> offset) & bit_mask(width))),
+        Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => None,
+    }
+}
+
+/// Folds a constant binary negation.
+pub(crate) fn eval_not(v: &Constant) -> Option<Constant> {
+    match v {
+        Constant::U(s, x) => Some(Constant::U(*s, !x & bit_mask(*s))),
+        Constant::I(s, x) => Some(Constant::I(*s, !x & bit_mask(*s))),
+        Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => None,
+    }
+}

--- a/compiler/src/compiler/analysis/click_cooper/mod.rs
+++ b/compiler/src/compiler/analysis/click_cooper/mod.rs
@@ -1,0 +1,1003 @@
+//! A Click–Cooper-style combined optimistic analysis.
+//!
+//! An analysis that handles **constants**, **reachability** and **congruence** (using optimistic
+//! AWZ value numbering). It is designed to drive constant/condition propagation and PRE; a
+//! context-sensitive interprocedural layer is planned (see
+//! [Deferred Improvements](#deferred-improvements)). The combination is _at least_ as precise as
+//! running the factors separately and alternating to a fixpoint (Click & Cooper, _Combining
+//! Analyses, Combining Optimizations_, TOPLAS 1995).
+//!
+//! It operates over two kinds of facts:
+//!
+//! - **Intraprocedural facts** are those within a given function and are derived from a
+//!   Wegman-Zadeck constants and reachability fixpoint with a structural-congruence partition over
+//!   the reachability state.
+//! - **Conditional facts** are ones derived from asserts, equalities, disequalities, and unpinned
+//!   witness forwarding. They are computed post-convergence over the same reachability state plus
+//!   GFG dominance, and are intentionally disjoint from the unconditional view.
+//!
+//! **Unconditional facts** are those which hold on any path so that any use (replacing a use,
+//! deleting a pure definition, or pruning an unreachable block) maintains soundness. **Conditional
+//! facts** are those established through control flow (branches, assertions, witness operations)
+//! that are only correct to use in contexts where the establishing constraints are preserved.
+//!
+//! # Correctness
+//!
+//! This analysis is **sound** because each fact class is sound, with the reasoning given as
+//! follows:
+//!
+//! - **Constants:** The transfer functions fold a value only when the result is exact for the
+//!   operand widths so `value == c` holds under any advice.
+//! - **Reachability:** An edge is executable only when a predecessor's terminator can take it. A
+//!   block proven unreachable is thus taken in no run.
+//! - **Congruence:** Two values are congruent iff computed by the same operator from operand-wise
+//!   congruent inputs, hence equal in all runs. Congruence never asserts an equality an adversarial
+//!   witness could validate.
+//! - **Conditional Facts:** Assert-derived constants, equalities, and disequalities hold only on
+//!   accepting runs that preserve their establishing constraint, so they are exposed only through
+//!   dedicated queries. An assert, being a global constraint that holds at every point of an
+//!   accepting run, is *also* attributed to in-scope blocks it post-dominates (the assert is then
+//!   guaranteed on every continuation). Control-flow derived equality and disequality facts, being
+//!   path-conditional, stay dominance-only.
+//! - **Witness Forwarding:** Both readings of the one witness↔value correspondence — the
+//!   `WriteWitness` hint (`r = witness_of(v)`) and the `ValueOf` projection (`v = value_of(r)`) —
+//!   only _add_ constraints and hence never reject an honest run, while two free witnesses are
+//!   never unified (the relation is keyed by the witness, and its members are honest values).
+//!
+//! This analysis **terminates** because every factor has finite height and every loop is monotone,
+//! as follows:
+//!
+//! - **Constants:** The lattice has height 2 (`Top ⊐ Const ⊐ Bottom`) and `set_lattice` only
+//!   lowers, so each value changes at most twice.
+//! - **Reachability:** `exec_edges` and `reachable` grow monotonically within the finite CFG;
+//!   per-block branch facts only ever shrink at joins. The two-worklist loop drains a finite number
+//!   of edge/value events.
+//! - **Congruence:** Partition refinement only ever *splits* classes, and the class count is
+//!   bounded by the value count, so it stabilises in at most `|values|` rounds.
+//!
+//! # Deferred Improvements
+//!
+//! The following are improvements planned for the future of this analysis.
+//!
+//! - **Combined-Fixpoint Writebacks:** Congruence runs as a single pass over the converged
+//!   reachability rather than interleaved with the constant worklist, because the reverse couplings
+//!   are not wired: a congruence class with a `Const` member does not promote its peers into the
+//!   (SCCP-visible) constant lattice, and a branch condition congruent to a constant does not fold
+//!   an edge. These pay off only in a consumer that exploits the full combined fixpoint; until such
+//!   a consumer exists, omitting them keeps SCCP's output unchanged. A future consumer can recover
+//!   the promotion by composing [`ClickCooper::known_equal`] with [`ClickCooper::const_of`].
+//! - **Assert Facts at Index Granularity:** Assert-derived facts are attributed at block-entry
+//!   granularity via *strict* dominance/post-dominance, so a use in the asserting block itself
+//!   (after the assert) is not yet claimed. Index-precise program points would recover it; soundness
+//!   is unaffected.
+//! - **Dominance-Aware Congruence Leader:** [`ClickCooper::leader`] returns the smallest-id class
+//!   member, which is not necessarily a dominating definition; a redirecting consumer (CSE/PRE)
+//!   needs the dominating member, which requires threading `FlowAnalysis` dominance into the
+//!   congruence partition.
+//! - **Interprocedural (1-CFA) Layer:** A context-sensitive interprocedural layer — polymorphic
+//!   jump-function summaries (a `return_const` jump function holding for any arguments, a
+//!   `return Param(i)` pass-through equal to argument `i`) plus 1-CFA per-`(function, k-limited
+//!   call-string)` specialization, mirroring the two-phase structure of `analysis/points_to` — was
+//!   prototyped and then removed pending a consumer that exploits it. SCCP, the only current
+//!   consumer, reads intraprocedural facts only, so the layer was deferred to keep the analysis
+//!   lean; it can be reinstated (along with its `*_in` context-keyed queries) with its first
+//!   interprocedural consumer. The deferred layer also did not propagate cross-call structural
+//!   congruence (e.g. `f(x); f(y)` with `x ≡ y` yielding congruent results).
+
+mod conditional;
+mod congruence;
+mod lattice;
+mod solver;
+
+use std::sync::Arc;
+
+use crate::{
+    collections::HashMap,
+    compiler::{
+        analysis::{
+            click_cooper::{
+                conditional::ConditionalFacts,
+                lattice::{Constness, bool_constant},
+                solver::{FunctionFacts, FunctionSolver},
+            },
+            flow_analysis::FlowAnalysis,
+            types::TypeInfo,
+        },
+        pass_manager::{Analysis, AnalysisId, AnalysisStore},
+        ssa::{
+            BlockId, FunctionId, ValueId,
+            hlssa::{Constant, HLSSA, HLSSAConstantsSnapshot},
+        },
+    },
+};
+
+// CLICK COOPER ANALYSIS
+// ================================================================================================
+
+/// The Click-Cooper analysis pass.
+///
+/// See the module documentation for more details.
+#[derive(Debug)]
+pub struct ClickCooper {
+    /// Program-wide interned-constant snapshot.
+    consts: HLSSAConstantsSnapshot,
+
+    /// Per-function **intraprocedural** converged facts (parameters and call results `Bottom`).
+    functions: HashMap<FunctionId, FunctionFacts>,
+
+    /// Per-function **conditional** side facts (assert-derived constants/equalities, branch
+    /// disequalities, unpinned-witness forwarding).
+    ///
+    /// Held in their own fields read by their own queries, entirely disjoint from the unconditional
+    /// view above.
+    conditional: HashMap<FunctionId, ConditionalFacts>,
+}
+
+impl Analysis for ClickCooper {
+    fn dependencies() -> Vec<AnalysisId> {
+        vec![FlowAnalysis::id(), TypeInfo::id()]
+    }
+
+    fn compute(ssa: &HLSSA, store: &AnalysisStore) -> Self {
+        ClickCooper::run(ssa, store.get::<FlowAnalysis>(), store.get::<TypeInfo>())
+    }
+}
+
+impl ClickCooper {
+    fn run(ssa: &HLSSA, flow: &FlowAnalysis, types: &TypeInfo) -> Self {
+        // One snapshot serves all functions: a constant referenced from a function is always
+        // interned program-wide.
+        let consts = ssa.const_snapshot();
+
+        // Per-function intraprocedural facts: parameters and call results `Bottom`. The conditional
+        // side facts are computed from the same converged state plus CFG dominance, kept in a
+        // disjoint map so the unconditional view is untouched.
+        let mut functions = HashMap::default();
+        let mut conditional = HashMap::default();
+        for fid in ssa.get_function_ids() {
+            let function = ssa.get_function(fid);
+            let mut solver = FunctionSolver::new(function, &consts);
+            solver.run();
+            let facts = solver.into_facts();
+            let cond = conditional::build(
+                function,
+                &facts,
+                flow.get_function_cfg(fid),
+                &consts,
+                types.get_function(fid),
+            );
+            conditional.insert(fid, cond);
+            functions.insert(fid, facts);
+        }
+
+        ClickCooper {
+            consts,
+            functions,
+            conditional,
+        }
+    }
+}
+
+/// Unconditional queries — facts that hold in **every** run.
+///
+/// Using them to replace uses, delete pure defs, or prune unreachable blocks is accept-set
+/// preserving. This impl block contains both the intraprocedural and interprocedural queries.
+impl ClickCooper {
+    /// The constant `v` provably holds in `f` in *every* run, or `None`.
+    ///
+    /// Interned constants and the global constant lattice only; path-sensitive branch facts are
+    /// excluded.
+    pub fn const_of(&self, f: FunctionId, v: ValueId) -> Option<Arc<Constant>> {
+        Self::const_in_facts(&self.consts, self.functions.get(&f), v)
+    }
+
+    /// `true` if `bid` reachable in `f`.
+    pub fn is_reachable(&self, f: FunctionId, bid: BlockId) -> bool {
+        self.functions
+            .get(&f)
+            .is_some_and(|facts| facts.reachable.contains(&bid))
+    }
+
+    /// `true` if the CFG edge `from -> to` proven executable in `f`.
+    pub fn is_executable_edge(&self, f: FunctionId, from: BlockId, to: BlockId) -> bool {
+        self.functions
+            .get(&f)
+            .is_some_and(|facts| facts.exec_edges.contains(&(from, to)))
+    }
+
+    /// Every value proven (unconditionally) constant in `f`, as `(value, constant)` pairs.
+    ///
+    /// Excludes already-interned constant values and conditional branch facts.
+    pub fn new_const_values(&self, f: FunctionId) -> Vec<(ValueId, Arc<Constant>)> {
+        let Some(facts) = self.functions.get(&f) else {
+            return Vec::new();
+        };
+        facts
+            .lattice
+            .iter()
+            .filter_map(|(v, e)| match e {
+                Constness::Const(c) => Some((*v, c.clone())),
+                Constness::Top | Constness::Bottom => None,
+            })
+            .collect()
+    }
+
+    /// `true` if `a` and `b` are proven *structurally* congruent in `f`.
+    pub fn known_equal(&self, f: FunctionId, a: ValueId, b: ValueId) -> bool {
+        self.functions
+            .get(&f)
+            .is_some_and(|facts| facts.congruence.known_equal(a, b))
+    }
+
+    /// Every value structurally congruent to `v` in `f` (including `v`), sorted by value id.
+    pub fn congruence_class(&self, f: FunctionId, v: ValueId) -> Vec<ValueId> {
+        self.functions
+            .get(&f)
+            .map(|facts| facts.congruence.class_members(v))
+            .unwrap_or_default()
+    }
+
+    /// A deterministic representative of `v`'s congruence class in `f` (smallest member by value
+    /// id).
+    ///
+    /// Not yet guaranteed to dominate the class, so it is not a legal redirect target on its own;
+    /// the dominance-aware leader requires threading the (already-available) `FlowAnalysis`
+    /// dominance into the congruence partition.
+    pub fn leader(&self, f: FunctionId, v: ValueId) -> Option<ValueId> {
+        self.functions
+            .get(&f)
+            .and_then(|facts| facts.congruence.leader(v))
+    }
+}
+
+/// Conditional queries — facts established by a branch or assert that hold only downstream of the
+/// establishing control flow.
+///
+/// These let Mavros be stricter on adversarial inputs, so they are sound *only* under
+/// constraint-preserving use: a local, structure-preserving rewrite that keeps the establishing
+/// branch/assert (never folding away the constraint that proves the fact).
+impl ClickCooper {
+    /// The constant `v` holds on entry to `bid` in `f`, honoring path-sensitive branch facts.
+    pub fn const_in_block(&self, f: FunctionId, bid: BlockId, v: ValueId) -> Option<Arc<Constant>> {
+        if let Some(c) = self.consts.get(&v) {
+            return Some(c.clone());
+        }
+        let facts = self.functions.get(&f)?;
+        if let Some(known) = facts.block_facts.get(&bid).and_then(|m| m.get(&v)) {
+            return Some(bool_constant(*known));
+        }
+        Self::const_in_facts(&self.consts, Some(facts), v)
+    }
+
+    /// `Some(...)` if `v` known true/false on entry to `bid` in `f` (a branch predicate fact).
+    pub fn bool_fact(&self, f: FunctionId, bid: BlockId, v: ValueId) -> Option<bool> {
+        self.functions
+            .get(&f)?
+            .block_facts
+            .get(&bid)?
+            .get(&v)
+            .copied()
+    }
+
+    /// If `v` is an (in-block) constant boolean, get its value, honoring branch facts, or `None`
+    /// otherwise.
+    pub fn const_bool_in_block(&self, f: FunctionId, bid: BlockId, v: ValueId) -> Option<bool> {
+        self.const_in_block(f, bid, v)
+            .and_then(|c| lattice::const_bool(&c))
+    }
+
+    /// The branch predicate facts at entry to `bid` in `f`, as `(value, bool-constant)` pairs
+    /// sorted by value id.
+    pub fn block_bool_facts(&self, f: FunctionId, bid: BlockId) -> Vec<(ValueId, Arc<Constant>)> {
+        let Some(facts) = self.functions.get(&f) else {
+            return Vec::new();
+        };
+        let Some(m) = facts.block_facts.get(&bid) else {
+            return Vec::new();
+        };
+        let mut out: Vec<(ValueId, Arc<Constant>)> =
+            m.iter().map(|(v, b)| (*v, bool_constant(*b))).collect();
+        out.sort_by_key(|(v, _)| v.0);
+        out
+    }
+
+    /// The constant `v` is pinned to on entry to `bid` in `f` by a *dominating assert*
+    /// (`Assert{v}`⇒`true`, or `AssertCmp{Eq, v, c}`).
+    ///
+    /// A conditional fact, deliberately disjoint from [`Self::const_of`] as a
+    /// consumer must keep the establishing assert.
+    pub fn asserted_const(&self, f: FunctionId, bid: BlockId, v: ValueId) -> Option<Arc<Constant>> {
+        self.conditional.get(&f)?.asserted_const(bid, v)
+    }
+
+    /// `true` if a dominating `AssertCmp{Eq}` proves `a == b` on entry to `bid` in `f`.
+    ///
+    /// The conditional analog of [`Self::known_equal`] (structural congruence): sound only for
+    /// constraint-preserving use, so kept out of the unconditional partition.
+    pub fn asserted_equal(&self, f: FunctionId, bid: BlockId, a: ValueId, b: ValueId) -> bool {
+        self.conditional
+            .get(&f)
+            .is_some_and(|c| c.asserted_equal(bid, a, b))
+    }
+
+    /// `true` if `a` and `b` are proven unequal on entry to `bid` in `f` (the false edge of an
+    /// equality branch).
+    ///
+    /// Note that this only accounts for _disequality_ `a != b`, and not expanded linear
+    /// inequalities.
+    pub fn known_unequal(&self, f: FunctionId, bid: BlockId, a: ValueId, b: ValueId) -> bool {
+        self.conditional
+            .get(&f)
+            .is_some_and(|c| c.known_disequal(bid, a, b))
+    }
+
+    /// The honest values the free witness handle `r` is equal to in `f`, containing no duplicates.
+    ///
+    ///
+    /// It is drawn from both readings of one correspondence: the unpinned
+    /// `WriteWitness{result: Some(r), value, pinned: false}` hint (`r = witness_of(value)`) and
+    /// every `Cast{value: r, target: ValueOf}` read (`result = value_of(r)`).
+    ///
+    /// A sound *redirect* fact (each member adds a functional constraint ⇒ `A_M ⊆ A_N`, never
+    /// rejecting the honest run), not a structural congruence — so it lives here, never in
+    /// [`Self::known_equal`], and two free witnesses are never unified.
+    pub fn witness_forward(&self, f: FunctionId, r: ValueId) -> &[ValueId] {
+        self.conditional
+            .get(&f)
+            .map(|c| c.witness_forward(r))
+            .unwrap_or_default()
+    }
+}
+
+/// Private query helper shared by [`Self::const_of`] and [`Self::const_in_block`].
+impl ClickCooper {
+    /// The constant `v` holds in `facts`, or `None`: interned constants first, then the constant
+    /// lattice.
+    fn const_in_facts(
+        consts: &HLSSAConstantsSnapshot,
+        facts: Option<&FunctionFacts>,
+        v: ValueId,
+    ) -> Option<Arc<Constant>> {
+        if let Some(c) = consts.get(&v) {
+            return Some(c.clone());
+        }
+        match facts?.lattice.get(&v) {
+            Some(Constness::Const(c)) => Some(c.clone()),
+            Some(Constness::Top) | Some(Constness::Bottom) | None => None,
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::{ClickCooper, FlowAnalysis};
+    use crate::compiler::{
+        analysis::types::Types,
+        ssa::{
+            Terminator,
+            hlssa::{BinaryArithOpKind, CastTarget, CmpKind, Constant, HLSSA, OpCode, Type},
+        },
+    };
+
+    /// Build the analysis for `ssa` with freshly-computed dependencies, for test use only.
+    pub(crate) fn run_in_test(ssa: &HLSSA) -> ClickCooper {
+        let flow = FlowAnalysis::run(ssa);
+        let types = Types::new().run(ssa, &flow);
+        ClickCooper::run(ssa, &flow, &types)
+    }
+
+    /// Two values that fold to the *same* constant are congruent, even when computed differently —
+    /// the const → congruence coupling.
+    #[test]
+    fn equal_constants_are_congruent() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c1 = ssa.add_const(Constant::U(32, 1));
+        let c2 = ssa.add_const(Constant::U(32, 2));
+        let c3 = ssa.add_const(Constant::U(32, 3));
+        let c4 = ssa.add_const(Constant::U(32, 4));
+        let (a, b) = (ssa.fresh_value(), ssa.fresh_value());
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let entry = f.get_entry_mut();
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: c2,
+            rhs: c3,
+        });
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: c1,
+            rhs: c4,
+        });
+        entry.set_terminator(Terminator::Return(vec![a, b]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        // 2+3 and 1+4 both equal 5.
+        assert!(cc.known_equal(fid, a, b));
+        // But not congruent to a different constant.
+        assert!(!cc.known_equal(fid, a, c2));
+    }
+
+    /// The same expression over the same operands is congruent, commutatively; different operators
+    /// or operands are not.
+    #[test]
+    fn structural_congruence_is_commutative() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let (x, y) = (ssa.fresh_value(), ssa.fresh_value());
+        let (a, b, c, d) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let f = ssa.get_unique_entrypoint_mut();
+        f.get_entry_mut().push_parameter(x, Type::u(32));
+        f.get_entry_mut().push_parameter(y, Type::u(32));
+        let entry = f.get_entry_mut();
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: y,
+        });
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: y,
+        });
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: c,
+            lhs: y,
+            rhs: x,
+        });
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Sub,
+            result: d,
+            lhs: x,
+            rhs: y,
+        });
+        entry.set_terminator(Terminator::Return(vec![a, b, c, d]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        assert!(cc.known_equal(fid, a, b));
+        assert!(cc.known_equal(fid, a, c)); // x+y ≡ y+x
+        assert!(!cc.known_equal(fid, a, d)); // x+y ≢ x-y
+        assert!(!cc.known_equal(fid, x, y)); // distinct opaque values
+
+        let mut expected = vec![a, b, c];
+        expected.sort();
+        assert_eq!(cc.congruence_class(fid, a), expected);
+    }
+
+    /// φ-operands come from *executable* edges only: a parameter whose value differs solely on a
+    /// dead in-edge is still congruent to one that agrees on the live edge.
+    #[test]
+    fn phi_congruence_excludes_dead_edges() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c_true = ssa.add_const(Constant::U(1, 1));
+        let (x, y, p, q) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let live = f.add_block();
+        let dead = f.add_block();
+        let merge = f.add_block();
+        f.get_entry_mut().push_parameter(x, Type::field());
+        f.get_entry_mut().push_parameter(y, Type::field());
+        f.get_entry_mut()
+            .set_terminator(Terminator::JmpIf(c_true, live, dead));
+        // Live edge agrees on both params; the dead edge would have forced them apart.
+        f.get_block_mut(live)
+            .set_terminator(Terminator::Jmp(merge, vec![x, x]));
+        f.get_block_mut(dead)
+            .set_terminator(Terminator::Jmp(merge, vec![x, y]));
+        let merge_block = f.get_block_mut(merge);
+        merge_block.push_parameter(p, Type::field());
+        merge_block.push_parameter(q, Type::field());
+        merge_block.set_terminator(Terminator::Return(vec![p, q]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        assert!(cc.known_equal(fid, p, q));
+    }
+
+    /// The same merge with *both* edges live keeps the parameters apart — congruence is genuinely
+    /// reachability-sensitive.
+    #[test]
+    fn phi_distinguished_when_both_edges_live() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let (cond, x, y, p, q) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let e1 = f.add_block();
+        let e2 = f.add_block();
+        let merge = f.add_block();
+        f.get_entry_mut().push_parameter(cond, Type::u(1));
+        f.get_entry_mut().push_parameter(x, Type::field());
+        f.get_entry_mut().push_parameter(y, Type::field());
+        f.get_entry_mut()
+            .set_terminator(Terminator::JmpIf(cond, e1, e2));
+        f.get_block_mut(e1)
+            .set_terminator(Terminator::Jmp(merge, vec![x, x]));
+        f.get_block_mut(e2)
+            .set_terminator(Terminator::Jmp(merge, vec![x, y]));
+        let merge_block = f.get_block_mut(merge);
+        merge_block.push_parameter(p, Type::field());
+        merge_block.push_parameter(q, Type::field());
+        merge_block.set_terminator(Terminator::Return(vec![p, q]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        assert!(!cc.known_equal(fid, p, q));
+    }
+
+    /// The optimistic win pessimistic value numbering cannot reach: two parallel induction variables
+    /// that start equal and step identically are congruent across the loop back-edge.
+    #[test]
+    fn loop_carried_parallel_induction_is_congruent() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c0 = ssa.add_const(Constant::U(32, 0));
+        let c1 = ssa.add_const(Constant::U(32, 1));
+        let c10 = ssa.add_const(Constant::U(32, 10));
+        let (i, j, lt, i2, j2) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let header = f.add_block();
+        let body = f.add_block();
+        let exit = f.add_block();
+
+        f.get_entry_mut()
+            .set_terminator(Terminator::Jmp(header, vec![c0, c0]));
+        let header_block = f.get_block_mut(header);
+        header_block.push_parameter(i, Type::u(32));
+        header_block.push_parameter(j, Type::u(32));
+        header_block.push_instruction(OpCode::Cmp {
+            kind: CmpKind::Lt,
+            result: lt,
+            lhs: i,
+            rhs: c10,
+        });
+        header_block.set_terminator(Terminator::JmpIf(lt, body, exit));
+        let body_block = f.get_block_mut(body);
+        body_block.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: i2,
+            lhs: i,
+            rhs: c1,
+        });
+        body_block.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: j2,
+            lhs: j,
+            rhs: c1,
+        });
+        body_block.set_terminator(Terminator::Jmp(header, vec![i2, j2]));
+        f.get_block_mut(exit)
+            .set_terminator(Terminator::Return(vec![i, j]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        assert!(cc.known_equal(fid, i, j)); // loop-carried congruence
+        assert!(cc.known_equal(fid, i2, j2)); // and their parallel updates
+    }
+
+    /// Assert-vacuum soundness: `assert(x == 5)` pins `x` to 5 *conditionally* in dominated blocks,
+    /// but never unconditionally — so a global fold (SCCP) can't fold `x` and vacuum the assert.
+    #[test]
+    fn assert_eq_const_is_conditional_not_unconditional() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c5 = ssa.add_const(Constant::U(32, 5));
+        let x = ssa.fresh_value();
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let entry_id = f.get_entry_id();
+        let after = f.add_block();
+        f.get_entry_mut().push_parameter(x, Type::u(32));
+        f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c5,
+        });
+        f.get_entry_mut()
+            .set_terminator(Terminator::Jmp(after, vec![]));
+        f.get_block_mut(after)
+            .set_terminator(Terminator::Return(vec![]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        // Unconditionally `x` is unknown — the assert never enters the global lattice.
+        assert_eq!(cc.const_of(fid, x), None);
+        assert!(cc.new_const_values(fid).iter().all(|(v, _)| *v != x));
+        // Conditionally `x == 5` at every block the assert *strictly* dominates ...
+        assert_eq!(
+            cc.asserted_const(fid, after, x).as_deref(),
+            Some(&Constant::U(32, 5))
+        );
+        // ... but not in the asserting block itself (block-entry granularity).
+        assert_eq!(cc.asserted_const(fid, entry_id, x), None);
+    }
+
+    /// `assert(b)` proves `b == true` conditionally in dominated blocks, never unconditionally.
+    #[test]
+    fn assert_bool_is_conditional() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let b = ssa.fresh_value();
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let after = f.add_block();
+        f.get_entry_mut().push_parameter(b, Type::u(1));
+        f.get_entry_mut()
+            .push_instruction(OpCode::Assert { value: b });
+        f.get_entry_mut()
+            .set_terminator(Terminator::Jmp(after, vec![]));
+        f.get_block_mut(after)
+            .set_terminator(Terminator::Return(vec![]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        assert_eq!(cc.const_of(fid, b), None);
+        assert_eq!(
+            cc.asserted_const(fid, after, b).as_deref(),
+            Some(&Constant::U(1, 1))
+        );
+    }
+
+    /// `assert(x == y)` with neither side constant records a *conditional* equality — distinct from
+    /// structural congruence, which (unconditionally) keeps the two parameters apart.
+    #[test]
+    fn assert_eq_pure_equality_is_conditional() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let (x, y) = (ssa.fresh_value(), ssa.fresh_value());
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let entry_id = f.get_entry_id();
+        let after = f.add_block();
+        f.get_entry_mut().push_parameter(x, Type::u(32));
+        f.get_entry_mut().push_parameter(y, Type::u(32));
+        f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: y,
+        });
+        f.get_entry_mut()
+            .set_terminator(Terminator::Jmp(after, vec![]));
+        f.get_block_mut(after)
+            .set_terminator(Terminator::Return(vec![]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        assert!(cc.asserted_equal(fid, after, x, y));
+        assert!(cc.asserted_equal(fid, after, y, x)); // symmetric
+        assert!(!cc.asserted_equal(fid, entry_id, x, y)); // not in the asserting block
+        // Structural congruence (unconditional) does not see the assert.
+        assert!(!cc.known_equal(fid, x, y));
+    }
+
+    /// The false edge of `if x == y` proves `x != y` at its target and the blocks that target
+    /// dominates — and nowhere else.
+    #[test]
+    fn disequality_from_false_edge() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let (x, y, eq) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let entry_id = f.get_entry_id();
+        let then_b = f.add_block();
+        let else_b = f.add_block();
+        let after = f.add_block();
+        f.get_entry_mut().push_parameter(x, Type::u(32));
+        f.get_entry_mut().push_parameter(y, Type::u(32));
+        f.get_entry_mut().push_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: x,
+            rhs: y,
+        });
+        f.get_entry_mut()
+            .set_terminator(Terminator::JmpIf(eq, then_b, else_b));
+        f.get_block_mut(then_b)
+            .set_terminator(Terminator::Return(vec![]));
+        f.get_block_mut(else_b)
+            .set_terminator(Terminator::Jmp(after, vec![]));
+        f.get_block_mut(after)
+            .set_terminator(Terminator::Return(vec![]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        // x != y on the false-edge target and blocks it dominates.
+        assert!(cc.known_unequal(fid, else_b, x, y));
+        assert!(cc.known_unequal(fid, else_b, y, x)); // symmetric
+        assert!(cc.known_unequal(fid, after, x, y));
+        // Not on the true edge, nor before the branch.
+        assert!(!cc.known_unequal(fid, then_b, x, y));
+        assert!(!cc.known_unequal(fid, entry_id, x, y));
+    }
+
+    /// An unpinned witness write forwards `r → v`; distinct witnesses get distinct forwards and are
+    /// never congruent; a *pinned* write (a real constraint) forwards nothing.
+    #[test]
+    fn unpinned_witness_forwards_distinct_not_merged() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let (v1, v2) = (ssa.fresh_value(), ssa.fresh_value());
+        let (r1, r2, rp) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+
+        let f = ssa.get_unique_entrypoint_mut();
+        f.get_entry_mut().push_parameter(v1, Type::u(32));
+        f.get_entry_mut().push_parameter(v2, Type::u(32));
+        let entry = f.get_entry_mut();
+        entry.push_instruction(OpCode::WriteWitness {
+            result: Some(r1),
+            value: v1,
+            pinned: false,
+        });
+        entry.push_instruction(OpCode::WriteWitness {
+            result: Some(r2),
+            value: v2,
+            pinned: false,
+        });
+        entry.push_instruction(OpCode::WriteWitness {
+            result: Some(rp),
+            value: v1,
+            pinned: true,
+        });
+        entry.set_terminator(Terminator::Return(vec![]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        assert_eq!(cc.witness_forward(fid, r1), [v1].as_slice());
+        assert_eq!(cc.witness_forward(fid, r2), [v2].as_slice());
+        // A pinned write carries a real `r == v` constraint — it is not a free witness, no forward.
+        assert!(cc.witness_forward(fid, rp).is_empty());
+        // Two distinct free witnesses are never unified (the hard non-merge prohibition).
+        assert!(!cc.known_equal(fid, r1, r2));
+    }
+
+    /// `witness_forward` is the sorted union of *both* readings of the one witness↔value
+    /// correspondence: the `WriteWitness` hint (`r → v`) and every `value_of(r)` read (`r → w`).
+    /// Distinct witnesses keep disjoint sets — no cross-witness union.
+    #[test]
+    fn witness_forward_unions_hint_and_value_of_reads() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let (v, v2) = (ssa.fresh_value(), ssa.fresh_value()); // honest hint payloads
+        let (r, r2) = (ssa.fresh_value(), ssa.fresh_value()); // witness handles
+        let (w1, w2) = (ssa.fresh_value(), ssa.fresh_value()); // two distinct `value_of(r)` reads
+
+        let f = ssa.get_unique_entrypoint_mut();
+        f.get_entry_mut().push_parameter(v, Type::u(32));
+        f.get_entry_mut().push_parameter(v2, Type::u(32));
+        let entry = f.get_entry_mut();
+        entry.push_instruction(OpCode::WriteWitness {
+            result: Some(r),
+            value: v,
+            pinned: false,
+        });
+        // `value_of(r)` strips r's witness wrapper: w1, w2 are honestly equal to r. Two separate
+        // reads stay distinct (ValueOf is excluded from value-numbering), so both join r's set.
+        entry.push_instruction(OpCode::Cast {
+            result: w1,
+            value: r,
+            target: CastTarget::ValueOf,
+        });
+        entry.push_instruction(OpCode::Cast {
+            result: w2,
+            value: r,
+            target: CastTarget::ValueOf,
+        });
+        entry.push_instruction(OpCode::WriteWitness {
+            result: Some(r2),
+            value: v2,
+            pinned: false,
+        });
+        entry.set_terminator(Terminator::Return(vec![]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        // r's honest-value set is the sorted union of the hint and both `value_of` reads.
+        let mut expected = vec![v, w1, w2];
+        expected.sort_unstable();
+        assert_eq!(cc.witness_forward(fid, r), expected.as_slice());
+
+        // The unrelated witness keeps a disjoint, single-element set — no cross-witness union.
+        assert_eq!(cc.witness_forward(fid, r2), [v2].as_slice());
+        assert!(!cc.known_equal(fid, r, r2));
+    }
+
+    /// An assert placed in the *last* block proves nothing by dominance (nothing follows it), but it
+    /// post-dominates everything upstream — so on accepting runs its fact holds at those earlier
+    /// blocks. The asserted value (`x`, a parameter) is in scope throughout.
+    #[test]
+    fn assert_below_use_holds_via_post_dominance() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c5 = ssa.add_const(Constant::U(32, 5));
+        let x = ssa.fresh_value();
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let entry_id = f.get_entry_id();
+        let mid = f.add_block();
+        let tail = f.add_block();
+        f.get_entry_mut().push_parameter(x, Type::u(32));
+        f.get_entry_mut()
+            .set_terminator(Terminator::Jmp(mid, vec![]));
+        f.get_block_mut(mid)
+            .set_terminator(Terminator::Jmp(tail, vec![]));
+        f.get_block_mut(tail).push_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c5,
+        });
+        f.get_block_mut(tail)
+            .set_terminator(Terminator::Return(vec![]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        // `tail` post-dominates `mid` and `entry`, so `x == 5` holds at both — a fact pure dominance
+        // (the assert is last) would miss entirely.
+        assert_eq!(
+            cc.asserted_const(fid, mid, x).as_deref(),
+            Some(&Constant::U(32, 5))
+        );
+        assert_eq!(
+            cc.asserted_const(fid, entry_id, x).as_deref(),
+            Some(&Constant::U(32, 5))
+        );
+        // Still never recorded at the asserting block's own entry (block-entry granularity).
+        assert_eq!(cc.asserted_const(fid, tail, x), None);
+    }
+
+    /// Post-dominance fan-out is gated on the asserted value being in scope: a value defined *below*
+    /// the target block must not have the fact attributed to that target (the guard dominance
+    /// otherwise supplies for free).
+    #[test]
+    fn post_dominance_respects_value_scope() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c10 = ssa.add_const(Constant::U(32, 10));
+        let p = ssa.fresh_value();
+        let x = ssa.fresh_value();
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let entry_id = f.get_entry_id();
+        let mid = f.add_block();
+        let tail = f.add_block();
+        f.get_entry_mut().push_parameter(p, Type::u(32));
+        f.get_entry_mut()
+            .set_terminator(Terminator::Jmp(mid, vec![]));
+        // `x` is defined in `mid`, *below* `entry`.
+        f.get_block_mut(mid)
+            .push_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: x,
+                lhs: p,
+                rhs: p,
+            });
+        f.get_block_mut(mid)
+            .set_terminator(Terminator::Jmp(tail, vec![]));
+        f.get_block_mut(tail).push_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c10,
+        });
+        f.get_block_mut(tail)
+            .set_terminator(Terminator::Return(vec![]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        // At `mid`, `x` is in scope and `tail` post-dominates it ⇒ the fact holds.
+        assert_eq!(
+            cc.asserted_const(fid, mid, x).as_deref(),
+            Some(&Constant::U(32, 10))
+        );
+        // At `entry`, `x` is not yet defined — the in-scope guard withholds the fact even though
+        // `tail` post-dominates `entry`.
+        assert_eq!(cc.asserted_const(fid, entry_id, x), None);
+    }
+
+    /// An assert on only one arm of a branch neither dominates nor post-dominates the blocks around
+    /// the branch, so its fact must not leak there — the other arm reaches `exit` without it.
+    #[test]
+    fn assert_on_one_branch_does_not_post_dominate() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c5 = ssa.add_const(Constant::U(32, 5));
+        let cond = ssa.fresh_value();
+        let x = ssa.fresh_value();
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let entry_id = f.get_entry_id();
+        let then_b = f.add_block();
+        let else_b = f.add_block();
+        let merge = f.add_block();
+        f.get_entry_mut().push_parameter(cond, Type::u(1));
+        f.get_entry_mut().push_parameter(x, Type::u(32));
+        f.get_entry_mut()
+            .set_terminator(Terminator::JmpIf(cond, then_b, else_b));
+        // The assert lives only on the `then` branch.
+        f.get_block_mut(then_b).push_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c5,
+        });
+        f.get_block_mut(then_b)
+            .set_terminator(Terminator::Jmp(merge, vec![]));
+        f.get_block_mut(else_b)
+            .set_terminator(Terminator::Jmp(merge, vec![]));
+        f.get_block_mut(merge)
+            .set_terminator(Terminator::Return(vec![]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        // `x` is in scope everywhere, so only the missing dominance/post-dominance keeps the fact
+        // out of `entry` and `merge` (the `else` path skips the assert).
+        assert_eq!(cc.asserted_const(fid, entry_id, x), None);
+        assert_eq!(cc.asserted_const(fid, merge, x), None);
+        // And never at the asserting block's own entry.
+        assert_eq!(cc.asserted_const(fid, then_b, x), None);
+    }
+
+    /// A post-dominating *pure* equality (`assert(x == y)`, neither side constant) requires *both*
+    /// sides in scope at the target.
+    #[test]
+    fn post_dominating_assert_eq_needs_both_sides_in_scope() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let x = ssa.fresh_value();
+        let y = ssa.fresh_value();
+        let p = ssa.fresh_value();
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let entry_id = f.get_entry_id();
+        let mid = f.add_block();
+        let tail = f.add_block();
+        f.get_entry_mut().push_parameter(x, Type::u(32));
+        f.get_entry_mut().push_parameter(p, Type::u(32));
+        f.get_entry_mut()
+            .set_terminator(Terminator::Jmp(mid, vec![]));
+        // `y` is defined in `mid`, below `entry`.
+        f.get_block_mut(mid)
+            .push_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: y,
+                lhs: p,
+                rhs: p,
+            });
+        f.get_block_mut(mid)
+            .set_terminator(Terminator::Jmp(tail, vec![]));
+        f.get_block_mut(tail).push_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: y,
+        });
+        f.get_block_mut(tail)
+            .set_terminator(Terminator::Return(vec![]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        // Both sides live at `mid` ⇒ the post-dominating equality holds, symmetrically.
+        assert!(cc.asserted_equal(fid, mid, x, y));
+        assert!(cc.asserted_equal(fid, mid, y, x));
+        // `y` is undefined at `entry`, so the equality is withheld there.
+        assert!(!cc.asserted_equal(fid, entry_id, x, y));
+    }
+}

--- a/compiler/src/compiler/analysis/click_cooper/solver.rs
+++ b/compiler/src/compiler/analysis/click_cooper/solver.rs
@@ -1,0 +1,610 @@
+//! The per-function combined optimistic fixpoint.
+//!
+//! This is the classic Wegman-Zadeck two-worklist algorithm. Every value starts at ⊤, is lowered to
+//! a concrete constant when a transfer function folds it, and bottoms out at ⊥ otherwise; block
+//! reachability and value lattices are computed together so constants propagate through
+//! constant-decided branches.
+
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        analysis::click_cooper::{
+            congruence::Congruence,
+            lattice::{
+                Constness, bool_constness, const_bool, const_join, eval_binary, eval_bit_range,
+                eval_cast, eval_cmp, eval_field_mul, eval_not, eval_sext,
+            },
+        },
+        ssa::{
+            BlockId, Instruction, Terminator, ValueId,
+            hlssa::{Constant, HLFunction, HLSSAConstantsSnapshot, OpCode},
+        },
+    },
+};
+
+// TYPES
+// ================================================================================================
+
+/// Per-block branch predicate facts: a value known true/false on entry to the block, recorded only
+/// when every executable incoming edge proves the same boolean.
+pub(crate) type BoolFacts = HashMap<ValueId, bool>;
+
+// FUNCTION FACTS
+// ================================================================================================
+
+/// The converged per-function analysis state.
+#[derive(Debug, Default)]
+pub(crate) struct FunctionFacts {
+    /// Each value's converged constness (`⊤` / `Const` / `⊥`).
+    ///
+    /// A value absent from the map is implicitly `⊤` (never lowered); already-interned constants
+    /// are resolved from the snapshot, so they are not stored here.
+    pub lattice: HashMap<ValueId, Constness>,
+
+    /// Blocks proven reachable by the combined reachability+constant fixpoint — those whose
+    /// instructions were visited at least once.
+    pub reachable: HashSet<BlockId>,
+
+    /// CFG edges `(from, to)` proven executable. A constant-decided `JmpIf` marks only the taken
+    /// edge, so its untaken successor can stay unreachable.
+    pub exec_edges: HashSet<(BlockId, BlockId)>,
+
+    /// Per-block branch predicate facts: values known true/false on entry to a block, recorded only
+    /// where every executable in-edge agrees on the same boolean (path-sensitive).
+    pub block_facts: HashMap<BlockId, BoolFacts>,
+
+    /// The converged global value-numbering partition (structural congruence classes), built once
+    /// over the final reachability/lattice state.
+    pub congruence: Congruence,
+}
+
+// FUNCTION SOLVER
+// ================================================================================================
+
+/// The fact solver for a single function.
+pub(crate) struct FunctionSolver<'f, 'c> {
+    /// The function being solved.
+    function: &'f HLFunction,
+
+    /// A snapshot of the constants that are currently available.
+    consts: &'c HLSSAConstantsSnapshot,
+
+    /// Each value's constness in the in-progress fixpoint; a value absent from the map is
+    /// implicitly `⊤` (not yet lowered).
+    lattice: HashMap<ValueId, Constness>,
+
+    /// CFG edges `(from, to)` proven executable so far.
+    exec_edges: HashSet<(BlockId, BlockId)>,
+
+    /// Executable predecessors per block — the inverse of `exec_edges`, kept in step with it (and
+    /// so deduplicated by that edge set) so a block's live in-edges can be iterated directly.
+    exec_preds: HashMap<BlockId, Vec<BlockId>>,
+
+    /// Blocks whose instructions have been visited at least once.
+    reachable: HashSet<BlockId>,
+
+    /// Predicate facts known at block entry (intersected over executable in-edges).
+    block_facts: HashMap<BlockId, BoolFacts>,
+
+    /// Newly-executable CFG edges awaiting processing — the flow (reachability) worklist.
+    edge_worklist: Vec<(BlockId, BlockId)>,
+
+    /// Values whose lattice cell just changed, awaiting re-evaluation of their uses — the SSA
+    /// worklist.
+    value_worklist: Vec<ValueId>,
+
+    /// For each value: the sites that read it. `None` marks the block's terminator.
+    uses: HashMap<ValueId, Vec<(BlockId, Option<usize>)>>,
+}
+
+impl<'f, 'c> FunctionSolver<'f, 'c> {
+    pub(crate) fn new(function: &'f HLFunction, consts: &'c HLSSAConstantsSnapshot) -> Self {
+        let mut uses: HashMap<ValueId, Vec<(BlockId, Option<usize>)>> = HashMap::default();
+        for (bid, block) in function.get_blocks() {
+            for (idx, instr) in block.get_instructions().enumerate() {
+                for input in instr.get_inputs() {
+                    uses.entry(*input).or_default().push((*bid, Some(idx)));
+                }
+            }
+            if let Some(term) = block.get_terminator() {
+                let inputs: Vec<ValueId> = match term {
+                    Terminator::Jmp(_, args) => args.clone(),
+                    Terminator::JmpIf(cond, _, _) => vec![*cond],
+                    Terminator::Return(vals) => vals.clone(),
+                };
+                for v in inputs {
+                    uses.entry(v).or_default().push((*bid, None));
+                }
+            }
+        }
+
+        Self {
+            function,
+            consts,
+            lattice: HashMap::default(),
+            exec_edges: HashSet::default(),
+            exec_preds: HashMap::default(),
+            reachable: HashSet::default(),
+            block_facts: HashMap::default(),
+            edge_worklist: Vec::new(),
+            value_worklist: Vec::new(),
+            uses,
+        }
+    }
+
+    pub(crate) fn run(&mut self) {
+        let entry = self.function.get_entry_id();
+
+        // Entry parameters are the function's arguments — unknown (`Bottom`) intraprocedurally.
+        for (p, _) in self.function.get_entry().get_parameters() {
+            self.lattice.insert(*p, Constness::Bottom);
+        }
+        self.reachable.insert(entry);
+        self.block_facts.insert(entry, BoolFacts::default());
+        self.visit_block(entry);
+
+        loop {
+            if let Some((p, b)) = self.edge_worklist.pop() {
+                self.process_edge(p, b);
+                continue;
+            }
+            if let Some(v) = self.value_worklist.pop() {
+                self.process_value(v);
+                continue;
+            }
+            break;
+        }
+        self.assert_no_stuck_conditions();
+    }
+
+    /// Convert the solver into facts.
+    pub(crate) fn into_facts(self) -> FunctionFacts {
+        let congruence =
+            Congruence::build(
+                self.function,
+                &self.reachable,
+                &self.exec_edges,
+                |v| match self.lattice_of(v) {
+                    Constness::Const(c) => Some(c),
+                    Constness::Top | Constness::Bottom => None,
+                },
+            );
+
+        FunctionFacts {
+            lattice: self.lattice,
+            reachable: self.reachable,
+            exec_edges: self.exec_edges,
+            block_facts: self.block_facts,
+            congruence,
+        }
+    }
+
+    /// A `JmpIf` condition can converge at ⊤ only if it (transitively) bottoms out at a block
+    /// parameter fed solely by itself along executable edges, so we sanity check.
+    fn assert_no_stuck_conditions(&self) {
+        for bid in &self.reachable {
+            if let Some(Terminator::JmpIf(cond, _, _)) =
+                self.function.get_block(*bid).get_terminator()
+            {
+                assert!(
+                    self.lattice_of(*cond) != Constness::Top,
+                    "ICE: ClickCooper converged with JmpIf condition v{} in `{}` stuck at ⊤; \
+                     the condition is only defined through a self-referential block-parameter \
+                     cycle, so a use is not dominated by its definition (malformed SSA)",
+                    cond.0,
+                    self.function.get_name(),
+                );
+            }
+        }
+    }
+
+    fn lattice_of(&self, v: ValueId) -> Constness {
+        if let Some(c) = self.consts.get(&v) {
+            return Constness::Const(c.clone());
+        }
+        self.lattice.get(&v).cloned().unwrap_or(Constness::Top)
+    }
+
+    fn lattice_in_block(&self, bid: BlockId, v: ValueId) -> Constness {
+        if let Some(c) = self.consts.get(&v) {
+            return Constness::Const(c.clone());
+        }
+        if let Some(value) = self.block_facts.get(&bid).and_then(|facts| facts.get(&v)) {
+            return bool_constness(*value);
+        }
+        self.lattice.get(&v).cloned().unwrap_or(Constness::Top)
+    }
+
+    /// Lower `v` to `join(current, new)`, scheduling its users if the value changed.
+    fn set_lattice(&mut self, v: ValueId, new: Constness) {
+        let old = self.lattice_of(v);
+        let joined = const_join(old.clone(), new);
+        if joined != old {
+            self.lattice.insert(v, joined);
+            self.value_worklist.push(v);
+        }
+    }
+
+    fn process_edge(&mut self, p: BlockId, b: BlockId) {
+        if !self.exec_edges.insert((p, b)) {
+            return;
+        }
+        self.exec_preds.entry(b).or_default().push(p);
+
+        // Snapshot the executable predecessors once and share it across both recomputations: both
+        // helpers take `&mut self`, so they need an owned copy detached from `self.exec_preds`.
+        let preds = self.exec_preds.get(&b).cloned().unwrap_or_default();
+        self.recompute_params_at(b, &preds, None);
+
+        let facts_changed = self.recompute_facts(b, &preds);
+        let first_visit = self.reachable.insert(b);
+        if first_visit || facts_changed {
+            self.visit_block(b);
+        }
+    }
+
+    fn process_value(&mut self, v: ValueId) {
+        let sites = self.uses.get(&v).cloned().unwrap_or_default();
+        for (bid, site) in sites {
+            if !self.reachable.contains(&bid) {
+                continue;
+            }
+            match site {
+                Some(idx) => self.visit_instruction(bid, idx),
+                None => self.revisit_terminator_for(bid, v),
+            }
+        }
+    }
+
+    /// Re-examine `bid`'s terminator because its operand `v` changed.
+    ///
+    /// A `Jmp` along an already-executable edge re-joins only the target parameters that actually
+    /// consume `v`.
+    fn revisit_terminator_for(&mut self, bid: BlockId, v: ValueId) {
+        match self.function.get_block(bid).get_terminator() {
+            Some(Terminator::Jmp(t, args)) => {
+                let t = *t;
+                if self.exec_edges.contains(&(bid, t)) {
+                    let indices: Vec<usize> = args
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(i, a)| (*a == v).then_some(i))
+                        .collect();
+                    let preds = self.exec_preds.get(&t).cloned().unwrap_or_default();
+                    self.recompute_params_at(t, &preds, Some(&indices));
+                }
+            }
+            Some(Terminator::JmpIf(..)) | Some(Terminator::Return(..)) | None => {
+                self.visit_terminator(bid)
+            }
+        }
+    }
+
+    fn visit_block(&mut self, bid: BlockId) {
+        let n = self.function.get_block(bid).get_instructions().count();
+        for idx in 0..n {
+            self.visit_instruction(bid, idx);
+        }
+        self.visit_terminator(bid);
+    }
+
+    fn visit_instruction(&mut self, bid: BlockId, idx: usize) {
+        let updates = self.transfer(bid, self.function.get_block(bid).get_instruction(idx));
+        for (v, lat) in updates {
+            self.set_lattice(v, lat);
+        }
+    }
+
+    fn visit_terminator(&mut self, bid: BlockId) {
+        let Some(term) = self.function.get_block(bid).get_terminator().cloned() else {
+            return;
+        };
+        match term {
+            Terminator::Jmp(t, _) => self.notify_edge(bid, t),
+            Terminator::JmpIf(cond, t, f) => match self.lattice_in_block(bid, cond) {
+                Constness::Top => {}
+                Constness::Const(c) => match const_bool(&c) {
+                    Some(true) => self.notify_edge(bid, t),
+                    Some(false) => self.notify_edge(bid, f),
+                    None => {
+                        self.notify_edge(bid, t);
+                        self.notify_edge(bid, f);
+                    }
+                },
+                Constness::Bottom => {
+                    self.notify_edge(bid, t);
+                    self.notify_edge(bid, f);
+                }
+            },
+            Terminator::Return(_) => {}
+        }
+    }
+
+    /// Mark edge `(p, t)` executable; if it already is, the jump arguments may have changed, so
+    /// re-join the target's parameters.
+    fn notify_edge(&mut self, p: BlockId, t: BlockId) {
+        if self.exec_edges.contains(&(p, t)) {
+            let preds = self.exec_preds.get(&t).cloned().unwrap_or_default();
+            self.recompute_params_at(t, &preds, None);
+            if self.recompute_facts(t, &preds) {
+                self.visit_block(t);
+            }
+        } else {
+            self.edge_worklist.push((p, t));
+        }
+    }
+
+    /// Re-join target parameters from `preds`.
+    ///
+    /// `indices` selects which parameters to recompute; `None` recomputes them all (the common
+    /// full-recompute path) without materialising a `0..n` index vector. `preds` is the caller's
+    /// executable-predecessor snapshot for `b`.
+    fn recompute_params_at(&mut self, b: BlockId, preds: &[BlockId], indices: Option<&[usize]>) {
+        if b == self.function.get_entry_id() {
+            return;
+        }
+
+        let block = self.function.get_block(b);
+        if !block.has_parameters() {
+            return;
+        }
+
+        let params: Vec<ValueId> = block.get_parameter_values().copied().collect();
+        let mut updates = Vec::with_capacity(indices.map_or(params.len(), <[usize]>::len));
+
+        match indices {
+            Some(indices) => {
+                for &i in indices {
+                    updates.push((params[i], self.join_param(b, preds, i)));
+                }
+            }
+            None => {
+                for i in 0..params.len() {
+                    updates.push((params[i], self.join_param(b, preds, i)));
+                }
+            }
+        }
+        for (p, lat) in updates {
+            self.set_lattice(p, lat);
+        }
+    }
+
+    /// The constness contributed to block `b`'s `i`-th parameter, joined over the `i`-th jump
+    /// argument of every executable predecessor in `preds`.
+    fn join_param(&self, b: BlockId, preds: &[BlockId], i: usize) -> Constness {
+        let mut acc = Constness::Top;
+        for pred in preds {
+            match self.function.get_block(*pred).get_terminator() {
+                Some(Terminator::Jmp(t, args)) if *t == b => {
+                    acc = const_join(acc, self.lattice_in_block(*pred, args[i]));
+                }
+                // A parameterized block is only ever entered via `Jmp`; treat anything else
+                // (including a `Jmp` to a different target) as unknown rather than trusting the
+                // invariant.
+                Some(Terminator::Jmp(..))
+                | Some(Terminator::JmpIf(..))
+                | Some(Terminator::Return(..))
+                | None => acc = Constness::Bottom,
+            }
+        }
+        acc
+    }
+
+    fn recompute_facts(&mut self, b: BlockId, preds: &[BlockId]) -> bool {
+        if b == self.function.get_entry_id() {
+            return false;
+        }
+        let mut iter = preds.iter().copied();
+        let Some(first_pred) = iter.next() else {
+            return false;
+        };
+
+        let mut facts = self.edge_facts(first_pred, b);
+        for pred in iter {
+            let next = self.edge_facts(pred, b);
+            facts.retain(|value, known| next.get(value) == Some(known));
+            if facts.is_empty() {
+                break;
+            }
+        }
+
+        let old = self.block_facts.get(&b).cloned().unwrap_or_default();
+        if old == facts {
+            return false;
+        }
+
+        if facts.is_empty() {
+            self.block_facts.remove(&b);
+        } else {
+            self.block_facts.insert(b, facts);
+        }
+        true
+    }
+
+    fn edge_facts(&self, pred: BlockId, target: BlockId) -> BoolFacts {
+        let mut facts = self.block_facts.get(&pred).cloned().unwrap_or_default();
+        if let Some((cond, value)) = self.branch_fact_for_edge(pred, target) {
+            facts.insert(cond, value);
+        }
+        facts
+    }
+
+    fn branch_fact_for_edge(&self, pred: BlockId, target: BlockId) -> Option<(ValueId, bool)> {
+        let Some(Terminator::JmpIf(cond, then_b, else_b)) =
+            self.function.get_block(pred).get_terminator()
+        else {
+            return None;
+        };
+        if then_b == else_b {
+            return None;
+        }
+        if *then_b == target {
+            Some((*cond, true))
+        } else if *else_b == target {
+            Some((*cond, false))
+        } else {
+            None
+        }
+    }
+
+    /// The transfer function: new lattice values for the instruction's results.
+    fn transfer(&self, bid: BlockId, instr: &OpCode) -> Vec<(ValueId, Constness)> {
+        match instr {
+            OpCode::BinaryArithOp {
+                kind,
+                result,
+                lhs,
+                rhs,
+            } => vec![(
+                *result,
+                self.eval2(bid, *lhs, *rhs, |a, b| eval_binary(*kind, a, b)),
+            )],
+            OpCode::Cmp {
+                kind,
+                result,
+                lhs,
+                rhs,
+            } => vec![(
+                *result,
+                self.eval2(bid, *lhs, *rhs, |a, b| eval_cmp(*kind, a, b)),
+            )],
+            OpCode::MulConst {
+                result,
+                const_val,
+                var,
+            } => vec![(*result, self.eval2(bid, *const_val, *var, eval_field_mul))],
+            OpCode::Cast {
+                result,
+                value,
+                target,
+            } => vec![(*result, self.eval1(bid, *value, |v| eval_cast(target, v)))],
+            OpCode::SExt {
+                result,
+                value,
+                from_bits,
+                to_bits,
+            } => vec![(
+                *result,
+                self.eval1(bid, *value, |v| eval_sext(v, *from_bits, *to_bits)),
+            )],
+            OpCode::BitRange {
+                result,
+                value,
+                offset,
+                width,
+            } => vec![(
+                *result,
+                self.eval1(bid, *value, |v| eval_bit_range(v, *offset, *width)),
+            )],
+            OpCode::Not { result, value } => vec![(*result, self.eval1(bid, *value, eval_not))],
+            OpCode::Select {
+                result,
+                cond,
+                if_t,
+                if_f,
+            } => vec![(*result, self.eval_select(bid, *cond, *if_t, *if_f))],
+
+            // Everything else — including `Call`, whose result is unknown intraprocedurally, is
+            // overdefined. The rewrite relies on this: a constant-valued instruction result is
+            // always the output of one of the pure scalar ops above. Spelled out variant by variant
+            // (no catch-all) so that adding an opcode forces a decision here.
+            OpCode::Call { .. }
+            | OpCode::MkSeq { .. }
+            | OpCode::MkSeqOfBlob { .. }
+            | OpCode::MkRepeated { .. }
+            | OpCode::Alloc { .. }
+            | OpCode::Store { .. }
+            | OpCode::Load { .. }
+            | OpCode::Assert { .. }
+            | OpCode::AssertCmp { .. }
+            | OpCode::AssertR1C { .. }
+            | OpCode::ArrayGet { .. }
+            | OpCode::ArraySet { .. }
+            | OpCode::SlicePush { .. }
+            | OpCode::SliceLen { .. }
+            | OpCode::ToBits { .. }
+            | OpCode::ToRadix { .. }
+            | OpCode::MemOp { .. }
+            | OpCode::WriteWitness { .. }
+            | OpCode::FreshWitness { .. }
+            | OpCode::NextDCoeff { .. }
+            | OpCode::BumpD { .. }
+            | OpCode::Constrain { .. }
+            | OpCode::Lookup { .. }
+            | OpCode::DLookup { .. }
+            | OpCode::Rangecheck { .. }
+            | OpCode::ReadGlobal { .. }
+            | OpCode::TupleProj { .. }
+            | OpCode::TupleRefProj { .. }
+            | OpCode::MkTuple { .. }
+            | OpCode::Todo { .. }
+            | OpCode::InitGlobal { .. }
+            | OpCode::DropGlobal { .. }
+            | OpCode::Spread { .. }
+            | OpCode::Unspread { .. }
+            | OpCode::Guard { .. } => {
+                // Single source of truth: anything overdefined here must not be classified as a
+                // deletable pure scalar fold, or SCCP would drop a side-effecting / constrained
+                // instruction whose result it aliased to a constant. The reverse direction (a fold
+                // wrongly marked non-foldable) is caught by the byte-identical corpus gate.
+                debug_assert!(
+                    !instr.is_pure_scalar_fold(),
+                    "transfer treats {instr:?} as overdefined but OpCode::is_pure_scalar_fold \
+                     classifies it as a deletable fold; the two must agree"
+                );
+                instr
+                    .get_results()
+                    .map(|r| (*r, Constness::Bottom))
+                    .collect()
+            }
+        }
+    }
+
+    /// Evaluate a 1-argument function `f` on `v` in the context of `bid`.
+    fn eval1(
+        &self,
+        bid: BlockId,
+        v: ValueId,
+        f: impl FnOnce(&Constant) -> Option<Constant>,
+    ) -> Constness {
+        match self.lattice_in_block(bid, v) {
+            Constness::Top => Constness::Top,
+            Constness::Const(c) => f(&c)
+                .map(|c| Constness::Const(std::sync::Arc::new(c)))
+                .unwrap_or(Constness::Bottom),
+            Constness::Bottom => Constness::Bottom,
+        }
+    }
+
+    /// Evaluate a 2-argument function `f` on `l, r` in the context of `bid`.
+    fn eval2(
+        &self,
+        bid: BlockId,
+        l: ValueId,
+        r: ValueId,
+        f: impl FnOnce(&Constant, &Constant) -> Option<Constant>,
+    ) -> Constness {
+        match (self.lattice_in_block(bid, l), self.lattice_in_block(bid, r)) {
+            (Constness::Top, _) | (_, Constness::Top) => Constness::Top,
+            (Constness::Const(a), Constness::Const(b)) => f(&a, &b)
+                .map(|c| Constness::Const(std::sync::Arc::new(c)))
+                .unwrap_or(Constness::Bottom),
+            (Constness::Bottom, _) | (_, Constness::Bottom) => Constness::Bottom,
+        }
+    }
+
+    fn eval_select(&self, bid: BlockId, cond: ValueId, if_t: ValueId, if_f: ValueId) -> Constness {
+        match self.lattice_in_block(bid, cond) {
+            Constness::Top => Constness::Top,
+            Constness::Const(c) => match const_bool(&c) {
+                Some(true) => self.lattice_in_block(bid, if_t),
+                Some(false) => self.lattice_in_block(bid, if_f),
+                None => Constness::Bottom,
+            },
+            Constness::Bottom => const_join(
+                self.lattice_in_block(bid, if_t),
+                self.lattice_in_block(bid, if_f),
+            ),
+        }
+    }
+}

--- a/compiler/src/compiler/analysis/mod.rs
+++ b/compiler/src/compiler/analysis/mod.rs
@@ -1,3 +1,5 @@
+pub mod call_string;
+pub mod click_cooper;
 pub mod flow_analysis;
 pub mod instrumenter;
 pub mod liveness;
@@ -9,3 +11,5 @@ pub mod value_definitions;
 pub mod value_range_analysis;
 pub mod witness_info;
 pub mod witness_taint_inference;
+
+pub use call_string::{CallSite, Context};

--- a/compiler/src/compiler/analysis/points_to/object.rs
+++ b/compiler/src/compiler/analysis/points_to/object.rs
@@ -47,44 +47,9 @@ pub type Path = Vec<Descent>;
 // CALL CONTEXT
 // ================================================================================================
 
-/// A bounded call-string identifying the context an abstract object was created in.
-///
-/// Context sensitivity keeps two call sites of the same helper from conflating their local
-/// allocations. The string is k-limited (see [`Context::push`]) so the object universe stays
-/// finite; recursion folds onto the recursion head. The empty context is the polymorphic (phase-1,
-/// summary) context.
-#[derive(Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord, Default)]
-pub struct Context(Vec<CallSite>);
-
-/// A call site, identified by the caller function and the first result value of the `Call`
-/// instruction (a stable per-call id within a polymorphic body).
-pub type CallSite = (FunctionId, ValueId);
-
-impl Context {
-    /// The empty (polymorphic / summary) context.
-    pub fn empty() -> Self {
-        Context(Vec::new())
-    }
-
-    /// Whether this is the empty context.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// This context extended by `site`, truncated to the most-recent `k` sites (k-CFA).
-    pub fn push(&self, site: CallSite, k: usize) -> Self {
-        if k == 0 {
-            return Context::empty();
-        }
-        let mut sites = self.0.clone();
-        sites.push(site);
-        if sites.len() > k {
-            let drop = sites.len() - k;
-            sites.drain(0..drop);
-        }
-        Context(sites)
-    }
-}
+/// The bounded call-string identifying the context an abstract object was created in: context
+/// sensitivity keeps two call sites of the same helper from conflating their local allocations.
+pub use crate::compiler::analysis::call_string::{CallSite, Context};
 
 // ABSTRACT OBJECTS
 // ================================================================================================

--- a/compiler/src/compiler/passes/sparse_conditional_constant_propagation.rs
+++ b/compiler/src/compiler/passes/sparse_conditional_constant_propagation.rs
@@ -1,63 +1,32 @@
 //! Sparse conditional constant propagation (Wegman–Zadeck) over the HLSSA.
 //!
-//! Runs the classic optimistic worklist algorithm per function: every value starts at ⊤
-//! (unvisited), is lowered to a concrete constant when a transfer function can fold it, and bottoms
-//! out at ⊥ (overdefined) otherwise. Block reachability and value lattices are computed together,
-//! so constants are propagated through branches that are themselves decided by constants — strictly
-//! stronger than folding and branch pruning as separate passes.
-//!
-//! In addition to the global SCCP value lattice, the analysis tracks branch-edge predicate facts:
-//! on the true edge of `JmpIf(c, t, f)`, `c` is true; on the false edge, `c` is false. Facts are
-//! intersected at joins, so they only survive while every executable incoming edge agrees. This
-//! captures path-sensitive condition propagation without pretending a branch condition is globally
-//! constant.
-//!
-//! After the lattice converges, the rewrite:
-//!
-//! - replaces every use of a constant-valued instruction result or block parameter with the
-//!   interned constant, dropping the (pure, by construction) defining instruction,
-//! - aliases `Select`s with a constant condition to the chosen arm even when the arms are not
-//!   constants,
-//! - rewrites `JmpIf`s with a constant condition into `Jmp`s to the live successor,
-//! - deletes blocks the analysis proved unreachable.
-//!
-//! Constant-valued block parameters are aliased but left in place; DCE will prune the now-unused
-//! parameters and their jump arguments.
+//! This pass relies on the combined [`ClickCooper`] analysis for the decisions that it makes. The
+//! analysis currently exposes some additional functionality to ensure that SCCP can remain
+//! byte-for-byte identical to the previous implementation. This pass **will be removed** in
+//! subsequent work, and those additional pieces of functionality will be removed with them.
 //!
 //! # Folding Semantics
 //!
 //! Only *pure scalar* values are folded, and only when every operand is a pure interned constant —
-//! a `WitnessOf`-typed value is never an interned constant, so witness arithmetic is never touched
-//! and result types never change. Integer folds are deliberately conservative: an op is folded
-//! only when the mathematical result fits the operand bit width. An overflowing pure integer op is
-//! an erroneous evaluation, not a value: where overflow is observable the lowering guards it with
-//! explicit checks (see `pure_guards`), and the residue an op leaves behind past those checks is
-//! backend-specific (machine integers wrap at a register width, R1CS computes in the field) and
-//! deliberately not part of the IR semantics. Folding an overflowed result would bake one
-//! backend's residue into all of them, so the op is instead left in place to fail (or wrap)
-//! exactly as it would have at runtime. Division by a constant zero is likewise left alone.
-
-use std::sync::{Arc, OnceLock};
-
-use ark_ff::{PrimeField, Zero};
+//! a `WitnessOf`-typed value is never an interned constant, so witness arithmetic is never touched.
 
 use crate::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     compiler::{
-        Field,
-        pass_manager::{AnalysisStore, Pass},
+        analysis::click_cooper::ClickCooper,
+        pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
         passes::fix_double_jumps::{ReplaceScope, ValueReplacements},
         ssa::{
-            BlockId, Instruction, Terminator, ValueId,
-            hlssa::{
-                BinaryArithOpKind, CastTarget, CmpKind, Constant, HLFunction, HLSSA,
-                HLSSAConstantsSnapshot, MAX_SUPPORTED_SIGNED_BITS, OpCode,
-            },
+            BlockId, FunctionId, Instruction, Terminator, ValueId,
+            hlssa::{HLFunction, HLSSA, OpCode},
         },
-        util::{bit_mask, decode_signed, encode_signed, fits_signed},
     },
 };
 
+// SCCP
+// ================================================================================================
+
+/// A standard implementation of (Wegman-Zadeck) sparse conditional constant propagation.
 pub struct SCCP {}
 
 impl Pass for SCCP {
@@ -65,8 +34,12 @@ impl Pass for SCCP {
         "sccp"
     }
 
-    fn run(&self, ssa: &mut HLSSA, _store: &AnalysisStore) {
-        self.do_run(ssa);
+    fn needs(&self) -> Vec<AnalysisId> {
+        vec![ClickCooper::id()]
+    }
+
+    fn run(&self, ssa: &mut HLSSA, store: &AnalysisStore) {
+        self.do_run(ssa, store.get::<ClickCooper>());
     }
 }
 
@@ -75,906 +48,59 @@ impl SCCP {
         Self {}
     }
 
-    pub fn do_run(&self, ssa: &mut HLSSA) {
-        // One snapshot serves all functions: a constant interned by the rewrite of an earlier
-        // function is only ever referenced from that (already rewritten) function, so a later
-        // function's analysis never needs to see it.
-        let consts = ssa.const_snapshot();
+    pub fn do_run(&self, ssa: &mut HLSSA, cc: &ClickCooper) {
         let fids: Vec<_> = ssa.get_function_ids().collect();
         for fid in fids {
             let mut function = ssa.take_function(fid);
-            let result = {
-                let mut analysis = FunctionLattice::new(&function, &consts);
-                analysis.run();
-                analysis.into_result()
-            };
-            rewrite(&mut function, ssa, &result);
+            rewrite(&mut function, ssa, cc, fid);
             ssa.put_function(fid, function);
         }
     }
 }
 
-// LATTICE
+// REWRITING FUNCTIONALITY
 // ================================================================================================
 
-/// The abstract value of a single SSA value: one element of the constant-propagation lattice.
-/// Constants are `Arc`-shared with the SSA's interning table, so cloning an element is cheap.
-#[derive(Clone, Debug, PartialEq)]
-enum LatticeElement {
-    /// Not (yet) known to be reachable with any value.
-    Top,
-    /// Proven to always hold this constant.
-    Const(Arc<Constant>),
-    /// Overdefined: holds a runtime-dependent (or non-foldable) value.
-    Bottom,
-}
-
-fn join(a: LatticeElement, b: LatticeElement) -> LatticeElement {
-    match (a, b) {
-        (LatticeElement::Top, x) | (x, LatticeElement::Top) => x,
-        (LatticeElement::Bottom, _) | (_, LatticeElement::Bottom) => LatticeElement::Bottom,
-        (LatticeElement::Const(c1), LatticeElement::Const(c2)) => {
-            if c1 == c2 {
-                LatticeElement::Const(c1)
-            } else {
-                LatticeElement::Bottom
-            }
-        }
-    }
-}
-
-/// The converged per-function analysis state handed to the rewrite.
-struct LatticeResult<'c> {
-    consts: &'c HLSSAConstantsSnapshot,
-    lattice: HashMap<ValueId, LatticeElement>,
-    reachable: HashSet<BlockId>,
-    block_facts: HashMap<BlockId, BoolFacts>,
-}
-
-impl LatticeResult<'_> {
-    fn lookup_in_block(&self, bid: BlockId, v: ValueId) -> LatticeElement {
-        if let Some(c) = self.consts.get(&v) {
-            return LatticeElement::Const(c.clone());
-        }
-        if let Some(value) = self.block_facts.get(&bid).and_then(|facts| facts.get(&v)) {
-            return bool_lattice(*value);
-        }
-        self.lattice.get(&v).cloned().unwrap_or(LatticeElement::Top)
-    }
-}
-
-type BoolFacts = HashMap<ValueId, bool>;
-
-// ANALYSIS
-// ================================================================================================
-
-struct FunctionLattice<'f, 'c> {
-    function: &'f HLFunction,
-    consts: &'c HLSSAConstantsSnapshot,
-    lattice: HashMap<ValueId, LatticeElement>,
-
-    /// CFG edges proven executable, and the executable predecessors per block (deduplicated by the
-    /// edge set).
-    exec_edges: HashSet<(BlockId, BlockId)>,
-    exec_preds: HashMap<BlockId, Vec<BlockId>>,
-
-    /// Blocks whose instructions have been visited at least once.
-    reachable: HashSet<BlockId>,
-
-    /// Predicate facts known at block entry. A fact appears here only when every executable
-    /// incoming edge proves the same boolean value.
-    block_facts: HashMap<BlockId, BoolFacts>,
-
-    edge_worklist: Vec<(BlockId, BlockId)>,
-    value_worklist: Vec<ValueId>,
-
-    /// For each value: the sites that read it. `None` marks the block's terminator.
-    uses: HashMap<ValueId, Vec<(BlockId, Option<usize>)>>,
-}
-
-impl<'f, 'c> FunctionLattice<'f, 'c> {
-    fn new(function: &'f HLFunction, consts: &'c HLSSAConstantsSnapshot) -> Self {
-        let mut uses: HashMap<ValueId, Vec<(BlockId, Option<usize>)>> = HashMap::default();
-        for (bid, block) in function.get_blocks() {
-            for (idx, instr) in block.get_instructions().enumerate() {
-                for input in instr.get_inputs() {
-                    uses.entry(*input).or_default().push((*bid, Some(idx)));
-                }
-            }
-            if let Some(term) = block.get_terminator() {
-                let inputs: Vec<ValueId> = match term {
-                    Terminator::Jmp(_, args) => args.clone(),
-                    Terminator::JmpIf(cond, _, _) => vec![*cond],
-                    Terminator::Return(vals) => vals.clone(),
-                };
-                for v in inputs {
-                    uses.entry(v).or_default().push((*bid, None));
-                }
-            }
-        }
-        Self {
-            function,
-            consts,
-            lattice: HashMap::default(),
-            exec_edges: HashSet::default(),
-            exec_preds: HashMap::default(),
-            reachable: HashSet::default(),
-            block_facts: HashMap::default(),
-            edge_worklist: Vec::new(),
-            value_worklist: Vec::new(),
-            uses,
-        }
-    }
-
-    fn into_result(self) -> LatticeResult<'c> {
-        LatticeResult {
-            consts: self.consts,
-            lattice: self.lattice,
-            reachable: self.reachable,
-            block_facts: self.block_facts,
-        }
-    }
-
-    fn run(&mut self) {
-        let entry = self.function.get_entry_id();
-        // Entry parameters are the function's arguments: unknown at this (intraprocedural) level.
-        for (p, _) in self.function.get_entry().get_parameters() {
-            self.lattice.insert(*p, LatticeElement::Bottom);
-        }
-        self.reachable.insert(entry);
-        self.block_facts.insert(entry, BoolFacts::default());
-        self.visit_block(entry);
-
-        loop {
-            if let Some((p, b)) = self.edge_worklist.pop() {
-                self.process_edge(p, b);
-                continue;
-            }
-            if let Some(v) = self.value_worklist.pop() {
-                self.process_value(v);
-                continue;
-            }
-            break;
-        }
-        self.assert_no_stuck_conditions();
-    }
-
-    /// A `JmpIf` condition can converge at ⊤ only if it (transitively) bottoms out at a block
-    /// parameter fed solely by itself along executable edges — a use its definition does not
-    /// dominate, i.e. malformed SSA. The rewrite would silently delete blocks the kept `JmpIf`
-    /// still targets, so ICE here instead.
-    fn assert_no_stuck_conditions(&self) {
-        for bid in &self.reachable {
-            if let Some(Terminator::JmpIf(cond, _, _)) =
-                self.function.get_block(*bid).get_terminator()
-            {
-                assert!(
-                    self.lattice_of(*cond) != LatticeElement::Top,
-                    "ICE: SCCP converged with JmpIf condition v{} in `{}` stuck at ⊤; \
-                     the condition is only defined through a self-referential block-parameter \
-                     cycle, so a use is not dominated by its definition (malformed SSA)",
-                    cond.0,
-                    self.function.get_name(),
-                );
-            }
-        }
-    }
-
-    fn lattice_of(&self, v: ValueId) -> LatticeElement {
-        if let Some(c) = self.consts.get(&v) {
-            return LatticeElement::Const(c.clone());
-        }
-        self.lattice.get(&v).cloned().unwrap_or(LatticeElement::Top)
-    }
-
-    fn lattice_in_block(&self, bid: BlockId, v: ValueId) -> LatticeElement {
-        if let Some(c) = self.consts.get(&v) {
-            return LatticeElement::Const(c.clone());
-        }
-        if let Some(value) = self.block_facts.get(&bid).and_then(|facts| facts.get(&v)) {
-            return bool_lattice(*value);
-        }
-        self.lattice.get(&v).cloned().unwrap_or(LatticeElement::Top)
-    }
-
-    /// Lower `v` to `join(current, new)`, scheduling its users if the value changed.
-    fn set_lattice(&mut self, v: ValueId, new: LatticeElement) {
-        let old = self.lattice_of(v);
-        let joined = join(old.clone(), new);
-        if joined != old {
-            self.lattice.insert(v, joined);
-            self.value_worklist.push(v);
-        }
-    }
-
-    fn process_edge(&mut self, p: BlockId, b: BlockId) {
-        if !self.exec_edges.insert((p, b)) {
-            return;
-        }
-        self.exec_preds.entry(b).or_default().push(p);
-        self.recompute_params(b);
-        let facts_changed = self.recompute_facts(b);
-        let first_visit = self.reachable.insert(b);
-        if first_visit || facts_changed {
-            self.visit_block(b);
-        }
-    }
-
-    fn process_value(&mut self, v: ValueId) {
-        let sites = self.uses.get(&v).cloned().unwrap_or_default();
-        for (bid, site) in sites {
-            if !self.reachable.contains(&bid) {
-                continue;
-            }
-            match site {
-                Some(idx) => self.visit_instruction(bid, idx),
-                None => self.revisit_terminator_for(bid, v),
-            }
-        }
-    }
-
-    /// Re-examine `bid`'s terminator because its operand `v` changed. A `Jmp` along an
-    /// already-executable edge re-joins only the target parameters that actually consume `v`
-    /// (per-phi), not every parameter of the target; other terminators take the generic path.
-    fn revisit_terminator_for(&mut self, bid: BlockId, v: ValueId) {
-        match self.function.get_block(bid).get_terminator() {
-            Some(Terminator::Jmp(t, args)) => {
-                let t = *t;
-                if self.exec_edges.contains(&(bid, t)) {
-                    let indices: Vec<usize> = args
-                        .iter()
-                        .enumerate()
-                        .filter_map(|(i, a)| (*a == v).then_some(i))
-                        .collect();
-                    self.recompute_params_at(t, &indices);
-                }
-                // Otherwise the edge is still queued and `process_edge` will join all parameters
-                // when it runs.
-            }
-            _ => self.visit_terminator(bid),
-        }
-    }
-
-    fn visit_block(&mut self, bid: BlockId) {
-        let n = self.function.get_block(bid).get_instructions().count();
-        for idx in 0..n {
-            self.visit_instruction(bid, idx);
-        }
-        self.visit_terminator(bid);
-    }
-
-    fn visit_instruction(&mut self, bid: BlockId, idx: usize) {
-        let updates = self.transfer(bid, self.function.get_block(bid).get_instruction(idx));
-        for (v, lat) in updates {
-            self.set_lattice(v, lat);
-        }
-    }
-
-    fn visit_terminator(&mut self, bid: BlockId) {
-        let Some(term) = self.function.get_block(bid).get_terminator().cloned() else {
-            return;
-        };
-        match term {
-            Terminator::Jmp(t, _) => self.notify_edge(bid, t),
-            Terminator::JmpIf(cond, t, f) => match self.lattice_in_block(bid, cond) {
-                LatticeElement::Top => {}
-                LatticeElement::Const(c) => match const_bool(&c) {
-                    Some(true) => self.notify_edge(bid, t),
-                    Some(false) => self.notify_edge(bid, f),
-                    None => {
-                        self.notify_edge(bid, t);
-                        self.notify_edge(bid, f);
-                    }
-                },
-                LatticeElement::Bottom => {
-                    self.notify_edge(bid, t);
-                    self.notify_edge(bid, f);
-                }
-            },
-            Terminator::Return(_) => {}
-        }
-    }
-
-    /// Mark edge `(p, t)` executable; if it already is, the jump arguments may have changed, so
-    /// re-join the target's parameters.
-    fn notify_edge(&mut self, p: BlockId, t: BlockId) {
-        if self.exec_edges.contains(&(p, t)) {
-            self.recompute_params(t);
-            if self.recompute_facts(t) {
-                self.visit_block(t);
-            }
-        } else {
-            self.edge_worklist.push((p, t));
-        }
-    }
-
-    /// Join each parameter of `b` over the arguments along all executable in-edges.
-    fn recompute_params(&mut self, b: BlockId) {
-        let n = self.function.get_block(b).get_parameter_values().count();
-        let all: Vec<usize> = (0..n).collect();
-        self.recompute_params_at(b, &all);
-    }
-
-    /// Join the parameters of `b` at `indices` over the arguments along all executable in-edges.
-    /// Restricting the join to the touched indices keeps a single jump-argument change from
-    /// re-joining every parameter of the target (the classic per-phi formulation).
-    fn recompute_params_at(&mut self, b: BlockId, indices: &[usize]) {
-        if indices.is_empty() || b == self.function.get_entry_id() {
-            return;
-        }
-        let block = self.function.get_block(b);
-        if !block.has_parameters() {
-            return;
-        }
-        let params: Vec<ValueId> = block.get_parameter_values().copied().collect();
-        let preds = self.exec_preds.get(&b).cloned().unwrap_or_default();
-        let mut updates = Vec::with_capacity(indices.len());
-        for &i in indices {
-            let mut acc = LatticeElement::Top;
-            for pred in &preds {
-                match self.function.get_block(*pred).get_terminator() {
-                    Some(Terminator::Jmp(t, args)) if *t == b => {
-                        acc = join(acc, self.lattice_in_block(*pred, args[i]));
-                    }
-                    // A parameterized block is only ever entered via `Jmp`; treat anything else
-                    // as unknown rather than trusting the invariant.
-                    _ => acc = LatticeElement::Bottom,
-                }
-            }
-            updates.push((params[i], acc));
-        }
-        for (p, lat) in updates {
-            self.set_lattice(p, lat);
-        }
-    }
-
-    fn recompute_facts(&mut self, b: BlockId) -> bool {
-        if b == self.function.get_entry_id() {
-            return false;
-        }
-        let preds = self.exec_preds.get(&b).cloned().unwrap_or_default();
-        let mut iter = preds.into_iter();
-        let Some(first_pred) = iter.next() else {
-            return false;
-        };
-
-        let mut facts = self.edge_facts(first_pred, b);
-        for pred in iter {
-            let next = self.edge_facts(pred, b);
-            facts.retain(|value, known| next.get(value) == Some(known));
-            if facts.is_empty() {
-                break;
-            }
-        }
-
-        let old = self.block_facts.get(&b).cloned().unwrap_or_default();
-        if old == facts {
-            return false;
-        }
-
-        if facts.is_empty() {
-            self.block_facts.remove(&b);
-        } else {
-            self.block_facts.insert(b, facts);
-        }
-        true
-    }
-
-    fn edge_facts(&self, pred: BlockId, target: BlockId) -> BoolFacts {
-        let mut facts = self.block_facts.get(&pred).cloned().unwrap_or_default();
-        if let Some((cond, value)) = self.branch_fact_for_edge(pred, target) {
-            facts.insert(cond, value);
-        }
-        facts
-    }
-
-    fn branch_fact_for_edge(&self, pred: BlockId, target: BlockId) -> Option<(ValueId, bool)> {
-        let Some(Terminator::JmpIf(cond, then_b, else_b)) =
-            self.function.get_block(pred).get_terminator()
-        else {
-            return None;
-        };
-        if then_b == else_b {
-            return None;
-        }
-        if *then_b == target {
-            Some((*cond, true))
-        } else if *else_b == target {
-            Some((*cond, false))
-        } else {
-            None
-        }
-    }
-
-    /// The transfer function: new lattice values for the instruction's results.
-    fn transfer(&self, bid: BlockId, instr: &OpCode) -> Vec<(ValueId, LatticeElement)> {
-        match instr {
-            OpCode::BinaryArithOp {
-                kind,
-                result,
-                lhs,
-                rhs,
-            } => vec![(
-                *result,
-                self.eval2(bid, *lhs, *rhs, |a, b| eval_binary(*kind, a, b)),
-            )],
-            OpCode::Cmp {
-                kind,
-                result,
-                lhs,
-                rhs,
-            } => vec![(
-                *result,
-                self.eval2(bid, *lhs, *rhs, |a, b| eval_cmp(*kind, a, b)),
-            )],
-            OpCode::MulConst {
-                result,
-                const_val,
-                var,
-            } => vec![(*result, self.eval2(bid, *const_val, *var, eval_field_mul))],
-            OpCode::Cast {
-                result,
-                value,
-                target,
-            } => vec![(*result, self.eval1(bid, *value, |v| eval_cast(target, v)))],
-            OpCode::SExt {
-                result,
-                value,
-                from_bits,
-                to_bits,
-            } => vec![(
-                *result,
-                self.eval1(bid, *value, |v| eval_sext(v, *from_bits, *to_bits)),
-            )],
-            OpCode::BitRange {
-                result,
-                value,
-                offset,
-                width,
-            } => vec![(
-                *result,
-                self.eval1(bid, *value, |v| eval_bit_range(v, *offset, *width)),
-            )],
-            OpCode::Not { result, value } => vec![(*result, self.eval1(bid, *value, eval_not))],
-            OpCode::Select {
-                result,
-                cond,
-                if_t,
-                if_f,
-            } => vec![(*result, self.eval_select(bid, *cond, *if_t, *if_f))],
-            // Everything else (memory, witness ops, calls, asserts, sequences, ...) is
-            // overdefined. The rewrite relies on this: a constant-valued instruction result is
-            // always the output of one of the pure scalar ops above. Spelled out variant by
-            // variant (no catch-all) so that adding an opcode forces a decision here.
-            OpCode::MkSeq { .. }
-            | OpCode::MkSeqOfBlob { .. }
-            | OpCode::MkRepeated { .. }
-            | OpCode::Alloc { .. }
-            | OpCode::Store { .. }
-            | OpCode::Load { .. }
-            | OpCode::Assert { .. }
-            | OpCode::AssertCmp { .. }
-            | OpCode::AssertR1C { .. }
-            | OpCode::Call { .. }
-            | OpCode::ArrayGet { .. }
-            | OpCode::ArraySet { .. }
-            | OpCode::SlicePush { .. }
-            | OpCode::SliceLen { .. }
-            | OpCode::ToBits { .. }
-            | OpCode::ToRadix { .. }
-            | OpCode::MemOp { .. }
-            | OpCode::WriteWitness { .. }
-            | OpCode::FreshWitness { .. }
-            | OpCode::NextDCoeff { .. }
-            | OpCode::BumpD { .. }
-            | OpCode::Constrain { .. }
-            | OpCode::Lookup { .. }
-            | OpCode::DLookup { .. }
-            | OpCode::Rangecheck { .. }
-            | OpCode::ReadGlobal { .. }
-            | OpCode::TupleProj { .. }
-            | OpCode::TupleRefProj { .. }
-            | OpCode::MkTuple { .. }
-            | OpCode::Todo { .. }
-            | OpCode::InitGlobal { .. }
-            | OpCode::DropGlobal { .. }
-            | OpCode::Spread { .. }
-            | OpCode::Unspread { .. }
-            | OpCode::Guard { .. } => instr
-                .get_results()
-                .map(|r| (*r, LatticeElement::Bottom))
-                .collect(),
-        }
-    }
-
-    fn eval1(
-        &self,
-        bid: BlockId,
-        v: ValueId,
-        f: impl FnOnce(&Constant) -> Option<Constant>,
-    ) -> LatticeElement {
-        match self.lattice_in_block(bid, v) {
-            LatticeElement::Top => LatticeElement::Top,
-            LatticeElement::Const(c) => f(&c)
-                .map(|c| LatticeElement::Const(Arc::new(c)))
-                .unwrap_or(LatticeElement::Bottom),
-            LatticeElement::Bottom => LatticeElement::Bottom,
-        }
-    }
-
-    fn eval2(
-        &self,
-        bid: BlockId,
-        l: ValueId,
-        r: ValueId,
-        f: impl FnOnce(&Constant, &Constant) -> Option<Constant>,
-    ) -> LatticeElement {
-        match (self.lattice_in_block(bid, l), self.lattice_in_block(bid, r)) {
-            (LatticeElement::Top, _) | (_, LatticeElement::Top) => LatticeElement::Top,
-            (LatticeElement::Const(a), LatticeElement::Const(b)) => f(&a, &b)
-                .map(|c| LatticeElement::Const(Arc::new(c)))
-                .unwrap_or(LatticeElement::Bottom),
-            _ => LatticeElement::Bottom,
-        }
-    }
-
-    fn eval_select(
-        &self,
-        bid: BlockId,
-        cond: ValueId,
-        if_t: ValueId,
-        if_f: ValueId,
-    ) -> LatticeElement {
-        match self.lattice_in_block(bid, cond) {
-            LatticeElement::Top => LatticeElement::Top,
-            LatticeElement::Const(c) => match const_bool(&c) {
-                Some(true) => self.lattice_in_block(bid, if_t),
-                Some(false) => self.lattice_in_block(bid, if_f),
-                None => LatticeElement::Bottom,
-            },
-            // Unknown condition: the select still folds if both arms agree.
-            LatticeElement::Bottom => join(
-                self.lattice_in_block(bid, if_t),
-                self.lattice_in_block(bid, if_f),
-            ),
-        }
-    }
-}
-
-// CONSTANT EVALUATION
-// ================================================================================================
-
-fn const_bool(c: &Constant) -> Option<bool> {
-    match c {
-        Constant::U(1, 0) => Some(false),
-        Constant::U(1, 1) => Some(true),
-        _ => None,
-    }
-}
-
-fn bool_lattice(value: bool) -> LatticeElement {
-    LatticeElement::Const(bool_constant(value))
-}
-
-fn bool_constant(value: bool) -> Arc<Constant> {
-    static FALSE: OnceLock<Arc<Constant>> = OnceLock::new();
-    static TRUE: OnceLock<Arc<Constant>> = OnceLock::new();
-    let slot = if value { &TRUE } else { &FALSE };
-    slot.get_or_init(|| Arc::new(Constant::U(1, value as u128)))
-        .clone()
-}
-
-/// Fold a binary arithmetic op. Integer results must fit the operand width: an overflowing pure op
-/// is an erroneous evaluation with a backend-specific residue (see the module docs), so an
-/// overflowing fold is refused rather than guessed at.
-fn eval_binary(kind: BinaryArithOpKind, a: &Constant, b: &Constant) -> Option<Constant> {
-    use BinaryArithOpKind::*;
-    match (a, b) {
-        (Constant::U(s1, x), Constant::U(s2, y)) => {
-            match kind {
-                // Shifts are the only ops with legitimately mixed operand widths (the amount is
-                // typically a narrow integer), but the type analysis types the result as
-                // `U(max(s1, s2))`. A fold to a `U(s1)` constant is therefore only
-                // width-preserving when the amount is no wider than the value; refuse the
-                // degenerate wider-amount case rather than silently changing the result's width.
-                Shl | Shr => {
-                    if s2 > s1 {
-                        return None;
-                    }
-                }
-                Add | Sub | Mul | Div | Mod | And | Or | Xor => {
-                    if s1 != s2 {
-                        return None;
-                    }
-                }
-            }
-            let s = *s1;
-            let v = match kind {
-                Add => x.checked_add(*y)?,
-                Sub => x.checked_sub(*y)?,
-                Mul => x.checked_mul(*y)?,
-                Div => {
-                    if *y == 0 {
-                        return None;
-                    }
-                    x / y
-                }
-                Mod => {
-                    if *y == 0 {
-                        return None;
-                    }
-                    x % y
-                }
-                And => x & y,
-                Or => x | y,
-                Xor => x ^ y,
-                // A shift by >= the operand width is not defined consistently across backends.
-                Shl | Shr => {
-                    if *y >= s as u128 {
-                        return None;
-                    }
-                    match kind {
-                        Shl => x.checked_shl(*y as u32)?,
-                        _ => x >> (*y as u32),
-                    }
-                }
-            };
-            if v > bit_mask(s) {
-                return None;
-            }
-            Some(Constant::U(s, v))
-        }
-        (Constant::I(s1, x), Constant::I(s2, y)) => {
-            if s1 != s2 {
-                return None;
-            }
-            let s = *s1;
-            if s == 0 || s > MAX_SUPPORTED_SIGNED_BITS {
-                return None;
-            }
-            match kind {
-                And => Some(Constant::I(s, x & y)),
-                Or => Some(Constant::I(s, x | y)),
-                Xor => Some(Constant::I(s, x ^ y)),
-                Add | Sub | Mul | Div | Mod => {
-                    let xa = decode_signed(s, *x);
-                    let ya = decode_signed(s, *y);
-                    let v = match kind {
-                        Add => xa.checked_add(ya)?,
-                        Sub => xa.checked_sub(ya)?,
-                        Mul => xa.checked_mul(ya)?,
-                        Div => {
-                            if ya == 0 {
-                                return None;
-                            }
-                            xa.checked_div(ya)?
-                        }
-                        Mod => {
-                            if ya == 0 {
-                                return None;
-                            }
-                            xa.checked_rem(ya)?
-                        }
-                        _ => unreachable!(),
-                    };
-                    if !fits_signed(s, v) {
-                        return None;
-                    }
-                    Some(Constant::I(s, encode_signed(s, v)))
-                }
-                Shl | Shr => None,
-            }
-        }
-        (Constant::Field(x), Constant::Field(y)) => match kind {
-            Add => Some(Constant::Field(*x + *y)),
-            Sub => Some(Constant::Field(*x - *y)),
-            Mul => Some(Constant::Field(*x * *y)),
-            Div => {
-                if y.is_zero() {
-                    None
-                } else {
-                    Some(Constant::Field(*x / *y))
-                }
-            }
-            Mod | And | Or | Xor | Shl | Shr => None,
-        },
-        // Mixed-kind pairs and non-scalar constants do not fold. Spelled out (no catch-all) so
-        // that adding a `Constant` variant forces a decision here.
-        (
-            Constant::U(..)
-            | Constant::I(..)
-            | Constant::Field(_)
-            | Constant::FnPtr(_)
-            | Constant::Blob(_),
-            Constant::U(..)
-            | Constant::I(..)
-            | Constant::Field(_)
-            | Constant::FnPtr(_)
-            | Constant::Blob(_),
-        ) => None,
-    }
-}
-
-fn eval_cmp(kind: CmpKind, a: &Constant, b: &Constant) -> Option<Constant> {
-    let res = |v: bool| Some(Constant::U(1, v as u128));
-    match (kind, a, b) {
-        (CmpKind::Eq, Constant::U(s1, x), Constant::U(s2, y)) if s1 == s2 => res(x == y),
-        (CmpKind::Eq, Constant::I(s1, x), Constant::I(s2, y)) if s1 == s2 => res(x == y),
-        (CmpKind::Eq, Constant::Field(x), Constant::Field(y)) => res(x == y),
-        (CmpKind::Lt, Constant::U(s1, x), Constant::U(s2, y)) if s1 == s2 => res(x < y),
-        (CmpKind::Lt, Constant::I(s1, x), Constant::I(s2, y))
-            if s1 == s2 && *s1 >= 1 && *s1 <= MAX_SUPPORTED_SIGNED_BITS =>
-        {
-            res(decode_signed(*s1, *x) < decode_signed(*s1, *y))
-        }
-        // Width-mismatched, mixed-kind, and non-scalar comparisons do not fold. Spelled out (no
-        // catch-all) so that adding a `Constant` variant forces a decision here.
-        (
-            CmpKind::Eq | CmpKind::Lt,
-            Constant::U(..)
-            | Constant::I(..)
-            | Constant::Field(_)
-            | Constant::FnPtr(_)
-            | Constant::Blob(_),
-            Constant::U(..)
-            | Constant::I(..)
-            | Constant::Field(_)
-            | Constant::FnPtr(_)
-            | Constant::Blob(_),
-        ) => None,
-    }
-}
-
-fn eval_field_mul(a: &Constant, b: &Constant) -> Option<Constant> {
-    match (a, b) {
-        (Constant::Field(x), Constant::Field(y)) => Some(Constant::Field(*x * *y)),
-        (
-            Constant::U(..)
-            | Constant::I(..)
-            | Constant::Field(_)
-            | Constant::FnPtr(_)
-            | Constant::Blob(_),
-            Constant::U(..)
-            | Constant::I(..)
-            | Constant::Field(_)
-            | Constant::FnPtr(_)
-            | Constant::Blob(_),
-        ) => None,
-    }
-}
-
-/// HLSSA casts are raw-bits conversions (sign extension is the separate `SExt` op): integers
-/// zero-extend into fields, fields truncate to their low bits, and integer-to-integer casts
-/// zero-extend or truncate.
-fn eval_cast(target: &CastTarget, v: &Constant) -> Option<Constant> {
-    match target {
-        CastTarget::Nop => Some(v.clone()),
-        // WitnessOf wraps the value into a witness type: not a pure constant.
-        // ArrayToSlice transfers ownership of a runtime object: nothing to fold.
-        // ValueOf/Map operate on witness wrappers and runtime sequences.
-        CastTarget::WitnessOf
-        | CastTarget::ArrayToSlice
-        | CastTarget::ValueOf
-        | CastTarget::Map(_) => None,
-        CastTarget::Field => match v {
-            Constant::U(_, x) | Constant::I(_, x) => Some(Constant::Field(Field::from(*x))),
-            Constant::Field(_) => Some(v.clone()),
-            Constant::FnPtr(_) | Constant::Blob(_) => None,
-        },
-        CastTarget::U(n) => int_cast_bits(v, *n).map(|bits| Constant::U(*n, bits)),
-        CastTarget::I(n) => {
-            if *n > MAX_SUPPORTED_SIGNED_BITS {
-                return None;
-            }
-            int_cast_bits(v, *n).map(|bits| Constant::I(*n, bits))
-        }
-    }
-}
-
-fn int_cast_bits(v: &Constant, n: usize) -> Option<u128> {
-    let mask = bit_mask(n);
-    match v {
-        Constant::U(_, x) | Constant::I(_, x) => Some(x & mask),
-        Constant::Field(f) => {
-            // Matches the lowering: combine the low limbs of the canonical representation and
-            // truncate to the target width.
-            let limbs = f.into_bigint().0;
-            let low = (limbs[0] as u128) | ((limbs[1] as u128) << 64);
-            Some(low & mask)
-        }
-        Constant::FnPtr(_) | Constant::Blob(_) => None,
-    }
-}
-
-fn eval_sext(v: &Constant, from_bits: usize, to_bits: usize) -> Option<Constant> {
-    if from_bits == 0 || from_bits > to_bits || to_bits > 128 {
-        return None;
-    }
-    let ext = |x: u128| {
-        if (x >> (from_bits - 1)) & 1 == 1 {
-            x | (bit_mask(to_bits) & !bit_mask(from_bits))
-        } else {
-            x
-        }
-    };
-    match v {
-        Constant::U(_, x) => Some(Constant::U(to_bits, ext(*x))),
-        Constant::I(_, x) => Some(Constant::I(to_bits, ext(*x))),
-        Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => None,
-    }
-}
-
-/// `BitRange` keeps the source type (it is the IR's truncation primitive), so only the payload
-/// bits change.
-fn eval_bit_range(v: &Constant, offset: usize, width: usize) -> Option<Constant> {
-    if offset >= 128 {
-        return None;
-    }
-    match v {
-        Constant::U(s, x) => Some(Constant::U(*s, (x >> offset) & bit_mask(width))),
-        Constant::I(s, x) => Some(Constant::I(*s, (x >> offset) & bit_mask(width))),
-        Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => None,
-    }
-}
-
-fn eval_not(v: &Constant) -> Option<Constant> {
-    match v {
-        Constant::U(s, x) => Some(Constant::U(*s, !x & bit_mask(*s))),
-        Constant::I(s, x) => Some(Constant::I(*s, !x & bit_mask(*s))),
-        Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => None,
-    }
-}
-
-// REWRITE
-// ================================================================================================
-
-fn rewrite(function: &mut HLFunction, ssa: &HLSSA, res: &LatticeResult) {
-    // Drop blocks the analysis never reached. Every kept terminator only targets reachable
-    // blocks: a JmpIf with a constant condition is rewritten to a Jmp to its (reachable) live
-    // successor below, and all other terminators had all successor edges marked executable.
+fn rewrite(function: &mut HLFunction, ssa: &HLSSA, cc: &ClickCooper, fid: FunctionId) {
+    // Drop blocks the analysis never reached. Every kept terminator only targets reachable blocks:
+    // a JmpIf with a constant condition is rewritten to a Jmp to its (reachable) live successor
+    // below, and all other terminators had all successor edges marked executable.
     let all_blocks: Vec<BlockId> = function.get_blocks().map(|(id, _)| *id).collect();
     for bid in &all_blocks {
-        if !res.reachable.contains(bid) {
+        if !cc.is_reachable(fid, *bid) {
             let _ = function.take_block(*bid);
         }
     }
 
-    // Alias every constant-valued value (instruction results and block parameters) to the
-    // interned constant. Interning a missing constant allocates a fresh value id, so the entries
-    // are sorted first: iterating the hash map directly would make the output value ids differ
-    // between runs.
+    // Alias every constant-valued value (instruction results and block parameters) to the interned
+    // constant. `const_values` is sorted by value id, so interning a missing constant (which
+    // allocates a fresh value id) is deterministic across runs.
     let mut replacements = ValueReplacements::new();
-    let mut folded: Vec<(ValueId, &Arc<Constant>)> = res
-        .lattice
-        .iter()
-        .filter_map(|(v, lat)| match lat {
-            LatticeElement::Const(c) => Some((*v, c)),
-            LatticeElement::Top | LatticeElement::Bottom => None,
-        })
-        .collect();
-    folded.sort_by_key(|(v, _)| v.0);
-    for (v, c) in folded {
-        replacements.insert(v, ssa.add_const((**c).clone()));
+    let const_values = cc.new_const_values(fid);
+    let const_set: HashSet<ValueId> = const_values.iter().map(|(v, _)| *v).collect();
+    for (v, c) in &const_values {
+        replacements.insert(*v, ssa.add_const((**c).clone()));
     }
 
     let kept_blocks: Vec<BlockId> = function.get_blocks().map(|(id, _)| *id).collect();
     for bid in kept_blocks {
+        let local_replacements = bool_fact_replacements(ssa, cc, fid, bid);
         let block = function.get_block_mut(bid);
-        let local_replacements = bool_fact_replacements(ssa, res.block_facts.get(&bid));
 
         let instructions = block.take_instructions();
         let mut kept = Vec::with_capacity(instructions.len());
         for instr in instructions {
-            // A single-result instruction whose result the lattice proved constant is one of the
-            // pure scalar folds (see `transfer`): its uses are aliased, so drop it.
+            // Purity gate: a single-result instruction whose result the analysis proved constant is
+            // dropped only when it is a pure scalar fold; its uses are aliased above either way.
             {
                 let mut results = instr.get_results();
                 if let (Some(r), None) = (results.next(), results.next()) {
-                    if matches!(res.lattice.get(r), Some(LatticeElement::Const(_))) {
+                    if const_set.contains(r) && instr.is_pure_scalar_fold() {
                         continue;
                     }
                 }
             }
+
             // A select with a constant condition aliases to the chosen arm even when the arms are
             // not constants.
             if let OpCode::Select {
@@ -984,26 +110,23 @@ fn rewrite(function: &mut HLFunction, ssa: &HLSSA, res: &LatticeResult) {
                 if_f,
             } = &instr
             {
-                if let LatticeElement::Const(c) = res.lookup_in_block(bid, *cond) {
-                    if let Some(b) = const_bool(&c) {
-                        replacements.insert(*result, if b { *if_t } else { *if_f });
-                        continue;
-                    }
+                if let Some(b) = cc.const_bool_in_block(fid, bid, *cond) {
+                    replacements.insert(*result, if b { *if_t } else { *if_f });
+                    continue;
                 }
             }
             let mut instr = instr;
             local_replacements.replace_inputs(&mut instr);
             kept.push(instr);
         }
+
         block.put_instructions(kept);
 
         if let Some(Terminator::JmpIf(cond, t, f)) = block.get_terminator() {
             let (cond, t, f) = (*cond, *t, *f);
-            if let LatticeElement::Const(c) = res.lookup_in_block(bid, cond) {
-                if let Some(b) = const_bool(&c) {
-                    let target = if b { t } else { f };
-                    block.set_terminator(Terminator::Jmp(target, vec![]));
-                }
+            if let Some(b) = cc.const_bool_in_block(fid, bid, cond) {
+                let target = if b { t } else { f };
+                block.set_terminator(Terminator::Jmp(target, vec![]));
             }
         }
         local_replacements.replace_terminator(block.get_terminator_mut());
@@ -1012,24 +135,34 @@ fn rewrite(function: &mut HLFunction, ssa: &HLSSA, res: &LatticeResult) {
     replacements.apply_to_function(function, ReplaceScope::Inputs);
 }
 
-fn bool_fact_replacements(ssa: &HLSSA, facts: Option<&BoolFacts>) -> ValueReplacements {
+/// Within `bid`, replace every value the analysis knows is a constant boolean (a branch predicate
+/// fact) with that constant.
+///
+/// Local and structure-preserving as the establishing branch is kept.
+fn bool_fact_replacements(
+    ssa: &HLSSA,
+    cc: &ClickCooper,
+    fid: FunctionId,
+    bid: BlockId,
+) -> ValueReplacements {
     let mut replacements = ValueReplacements::new();
-    let Some(facts) = facts else {
-        return replacements;
-    };
-
-    let mut facts: Vec<_> = facts.iter().collect();
-    facts.sort_by_key(|(value, _)| value.0);
-    for (value, known) in facts {
-        replacements.insert(*value, ssa.add_const((*bool_constant(*known)).clone()));
+    for (value, c) in cc.block_bool_facts(fid, bid) {
+        replacements.insert(value, ssa.add_const((*c).clone()));
     }
     replacements
 }
 
+// TESTS
+// ================================================================================================
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compiler::ssa::hlssa::Type;
+    use crate::compiler::{
+        Field,
+        analysis::click_cooper::tests::run_in_test,
+        ssa::hlssa::{BinaryArithOpKind, CastTarget, CmpKind, Constant, Type},
+    };
 
     /// `2 + 3 == 5` decides the branch: the comparison chain folds away, the `JmpIf` becomes a
     /// `Jmp` to the then-block, and the else-block is deleted.
@@ -1064,7 +197,8 @@ mod tests {
         f.get_block_mut(else_b)
             .set_terminator(Terminator::Return(vec![c2]));
 
-        SCCP::new().do_run(&mut ssa);
+        let cc = run_in_test(&ssa);
+        SCCP::new().do_run(&mut ssa, &cc);
 
         let f = ssa.get_unique_entrypoint();
         // Both instructions folded away.
@@ -1106,7 +240,8 @@ mod tests {
         merge_block.push_parameter(m_param, Type::field());
         merge_block.set_terminator(Terminator::Return(vec![m_param]));
 
-        SCCP::new().do_run(&mut ssa);
+        let cc = run_in_test(&ssa);
+        SCCP::new().do_run(&mut ssa, &cc);
 
         let f = ssa.get_unique_entrypoint();
         // All blocks reachable (unknown condition), but the merge value is the constant.
@@ -1155,7 +290,8 @@ mod tests {
         f.get_block_mut(exit)
             .set_terminator(Terminator::Return(vec![i_param]));
 
-        SCCP::new().do_run(&mut ssa);
+        let cc = run_in_test(&ssa);
+        SCCP::new().do_run(&mut ssa, &cc);
 
         let f = ssa.get_unique_entrypoint();
         // The loop-carried counter varies: nothing folds, all blocks survive.
@@ -1183,7 +319,8 @@ mod tests {
         });
         entry.set_terminator(Terminator::Return(vec![sum]));
 
-        SCCP::new().do_run(&mut ssa);
+        let cc = run_in_test(&ssa);
+        SCCP::new().do_run(&mut ssa, &cc);
 
         let f = ssa.get_unique_entrypoint();
         assert_eq!(f.get_entry().get_instructions().count(), 1);
@@ -1216,7 +353,8 @@ mod tests {
         });
         entry.set_terminator(Terminator::Return(vec![doubled]));
 
-        SCCP::new().do_run(&mut ssa);
+        let cc = run_in_test(&ssa);
+        SCCP::new().do_run(&mut ssa, &cc);
 
         let f = ssa.get_unique_entrypoint();
         assert_eq!(f.get_entry().get_instructions().count(), 2);
@@ -1248,7 +386,8 @@ mod tests {
         f.get_block_mut(exit)
             .set_terminator(Terminator::Return(vec![]));
 
-        SCCP::new().do_run(&mut ssa);
+        let cc = run_in_test(&ssa);
+        SCCP::new().do_run(&mut ssa, &cc);
     }
 
     /// A select whose condition is constant aliases to the chosen arm even when the arms are not
@@ -1271,7 +410,8 @@ mod tests {
         });
         entry.set_terminator(Terminator::Return(vec![sel]));
 
-        SCCP::new().do_run(&mut ssa);
+        let cc = run_in_test(&ssa);
+        SCCP::new().do_run(&mut ssa, &cc);
 
         let f = ssa.get_unique_entrypoint();
         assert_eq!(f.get_entry().get_instructions().count(), 0);
@@ -1319,7 +459,8 @@ mod tests {
         f.get_block_mut(else_b)
             .set_terminator(Terminator::Return(vec![arm_f, c_false]));
 
-        SCCP::new().do_run(&mut ssa);
+        let cc = run_in_test(&ssa);
+        SCCP::new().do_run(&mut ssa, &cc);
 
         let f = ssa.get_unique_entrypoint();
         assert_eq!(f.get_block(then_b).get_instructions().count(), 0);
@@ -1357,7 +498,8 @@ mod tests {
         });
         merge_block.set_terminator(Terminator::Return(vec![not_cond]));
 
-        SCCP::new().do_run(&mut ssa);
+        let cc = run_in_test(&ssa);
+        SCCP::new().do_run(&mut ssa, &cc);
 
         let f = ssa.get_unique_entrypoint();
         assert_eq!(f.get_block(merge).get_instructions().count(), 1);
@@ -1390,7 +532,8 @@ mod tests {
         f.get_block_mut(nested_else)
             .set_terminator(Terminator::Return(vec![]));
 
-        SCCP::new().do_run(&mut ssa);
+        let cc = run_in_test(&ssa);
+        SCCP::new().do_run(&mut ssa, &cc);
 
         let f = ssa.get_unique_entrypoint();
         assert_eq!(f.get_blocks().count(), 4);
@@ -1418,7 +561,8 @@ mod tests {
         });
         join_block.set_terminator(Terminator::Return(vec![not_cond]));
 
-        SCCP::new().do_run(&mut ssa);
+        let cc = run_in_test(&ssa);
+        SCCP::new().do_run(&mut ssa, &cc);
 
         let f = ssa.get_unique_entrypoint();
         assert_eq!(f.get_block(join).get_instructions().count(), 1);
@@ -1450,7 +594,8 @@ mod tests {
         merge_block.push_parameter(phi, Type::u(1));
         merge_block.set_terminator(Terminator::Return(vec![phi]));
 
-        SCCP::new().do_run(&mut ssa);
+        let cc = run_in_test(&ssa);
+        SCCP::new().do_run(&mut ssa, &cc);
 
         let f = ssa.get_unique_entrypoint();
         assert!(matches!(

--- a/compiler/src/compiler/ssa/hlssa/mod.rs
+++ b/compiler/src/compiler/ssa/hlssa/mod.rs
@@ -261,6 +261,62 @@ pub enum OpCode {
     },
 }
 
+impl OpCode {
+    /// `true` if `self` is capable of being a pure, side-effect-free, single-result scalar op that
+    /// can be folded to a constant and have the defining instruction deleted.
+    ///
+    /// Note that this requires the caller to verify that the operation's lack of side effects holds
+    /// in context (e.g. a given multiplication cannot overflow).
+    pub fn is_pure_scalar_fold(&self) -> bool {
+        match self {
+            OpCode::Cmp { .. }
+            | OpCode::BinaryArithOp { .. }
+            | OpCode::Cast { .. }
+            | OpCode::SExt { .. }
+            | OpCode::BitRange { .. }
+            | OpCode::Not { .. }
+            | OpCode::Select { .. }
+            | OpCode::MulConst { .. } => true,
+
+            OpCode::MkSeq { .. }
+            | OpCode::MkSeqOfBlob { .. }
+            | OpCode::MkRepeated { .. }
+            | OpCode::Alloc { .. }
+            | OpCode::Store { .. }
+            | OpCode::Load { .. }
+            | OpCode::Assert { .. }
+            | OpCode::AssertCmp { .. }
+            | OpCode::AssertR1C { .. }
+            | OpCode::Call { .. }
+            | OpCode::ArrayGet { .. }
+            | OpCode::ArraySet { .. }
+            | OpCode::SlicePush { .. }
+            | OpCode::SliceLen { .. }
+            | OpCode::ToBits { .. }
+            | OpCode::ToRadix { .. }
+            | OpCode::MemOp { .. }
+            | OpCode::WriteWitness { .. }
+            | OpCode::FreshWitness { .. }
+            | OpCode::NextDCoeff { .. }
+            | OpCode::BumpD { .. }
+            | OpCode::Constrain { .. }
+            | OpCode::Lookup { .. }
+            | OpCode::DLookup { .. }
+            | OpCode::Rangecheck { .. }
+            | OpCode::ReadGlobal { .. }
+            | OpCode::TupleProj { .. }
+            | OpCode::TupleRefProj { .. }
+            | OpCode::MkTuple { .. }
+            | OpCode::Todo { .. }
+            | OpCode::InitGlobal { .. }
+            | OpCode::DropGlobal { .. }
+            | OpCode::Spread { .. }
+            | OpCode::Unspread { .. }
+            | OpCode::Guard { .. } => false,
+        }
+    }
+}
+
 impl Instruction for OpCode {
     fn get_static_call_targets(&self) -> Vec<FunctionId> {
         match self {


### PR DESCRIPTION
This analysis is designed to handle constants, congruence, and reachability all in one go, and hence be used to drive downstream optimization passes. By keeping the analysis standalone we get a more comprehensive analysis that admits more in-depth optimization than multiple smaller analyses would.

This commit also uses the analysis in SCCP (without changing its functionality) as a demonstration that the analysis subset used there is correct. SCCP after this commit produces results that are byte-for-byte identical with SCCP before this commit.

SCCP will be subsumed by a future, more comprehensive, constprop/condprop/CSE pass.

Partial work toward #260. Contains some additional API surface to keep SCCP byte-for-byte identical. This will be removed when SCCP is replaced. It is intentionally intended to not change the corpus in any way at this stage.

Excluding comments and tests, the primary functional surface is ~1500 lines of the diff.

Closes #280.