### PR TITLE
Make Click-Cooper context-sensitive

### DIFF
--- a/compiler/src/compiler/analysis/click_cooper/congruence.rs
+++ b/compiler/src/compiler/analysis/click_cooper/congruence.rs
@@ -26,7 +26,7 @@ use crate::{
             BlockId, FunctionId, Instruction, Terminator, ValueId,
             hlssa::{
                 BinaryArithOpKind, CallTarget, CastTarget, CmpKind, Constant, HLFunction, OpCode,
-                ScalarFold,
+                ScalarFold, SequenceTargetType, SliceOpDir, Type,
             },
         },
     },
@@ -222,6 +222,15 @@ impl Congruence {
                 // value classes. Thus, two such calls with operandwise-congruent arguments yield
                 // congruent results (cross-call value numbering). Any other call result stays an
                 // opaque singleton.
+                //
+                // An *unconstrained* call is excluded (it stays opaque) for soundness, not just
+                // conservatism: its result is prover advice, not pinned by any constraint, so two
+                // such calls with congruent arguments are equal only in honest witness generation,
+                // never forced equal in-circuit. Congruence here means equal in *every* admissible
+                // witness, so numbering unconstrained results congruent would underconstrain the
+                // circuit. Such results are already tainted non-deterministic by
+                // `analyze_determinism`, so `call_det` returns `false` for them regardless; this
+                // guard makes the reason explicit.
                 if let OpCode::Call {
                     results,
                     function: CallTarget::Static(g),
@@ -427,6 +436,18 @@ enum OpKey {
     Not,
     Select,
 
+    // Pure, value-semantic sequence ops. These are *not* scalar-foldable for now, so they are
+    // value-numbered but never constant-folded. The non-value attributes (`seq_type`, `elem_type`,
+    // repeat count, push direction) ride in the key so differently-shaped sequences never share a
+    // class.
+    ArrayGet,
+    ArraySet,
+    SliceLen,
+    MkSeq(SequenceTargetType, Type),
+    MkRepeated(SequenceTargetType, usize, Type),
+    MkSeqOfBlob(Type),
+    SlicePush(SliceOpDir),
+
     /// Return position `usize` of a constrained static call to `FunctionId` whose result is a
     /// deterministic function of the call's arguments (its operands). Two such calls to the same
     /// callee with operandwise-congruent arguments are congruent.
@@ -471,10 +492,69 @@ pub(crate) fn pure_op_operands(instr: &OpCode) -> Option<Vec<ValueId>> {
 /// The pure, deterministic ops eligible for value numbering, paired with their operands and
 /// commutativity.
 ///
-/// Projects from [`OpCode::scalar_fold`] (the single source of truth for foldable scalar ops), so
-/// it cannot disagree with `is_pure_scalar_fold` / `solver::transfer` on the opcode set. The only
-/// ops it further excludes are witness casts, which are foldable in name but never value-numbered.
+/// Value numbering is a strict *superset* of [`OpCode::scalar_fold`]: it covers every foldable
+/// scalar op (minus witness casts, which are foldable in name but never value-numbered) **plus**
+/// the pure, value-semantic sequence ops, which are value-numbered here yet are not scalar-foldable
+/// (their aggregate results never enter the constant lattice). So it may disagree with
+/// `is_pure_scalar_fold` / `solver::transfer` on the sequence ops by design, but never on a scalar
+/// op.
 fn op_signature(instr: &OpCode) -> Option<(OpKey, Vec<ValueId>, bool)> {
+    // Sequence ops are pure and deterministic but not scalar-foldable, so they are matched directly
+    // rather than via `scalar_fold`. Sequence order is significant, so none are commutative.
+    match instr {
+        OpCode::ArrayGet { array, index, .. } => {
+            return Some((OpKey::ArrayGet, vec![*array, *index], false));
+        }
+        OpCode::ArraySet {
+            array,
+            index,
+            value,
+            ..
+        } => {
+            return Some((OpKey::ArraySet, vec![*array, *index, *value], false));
+        }
+        OpCode::SliceLen { slice, .. } => return Some((OpKey::SliceLen, vec![*slice], false)),
+        OpCode::MkSeq {
+            elems,
+            seq_type,
+            elem_type,
+            ..
+        } => {
+            return Some((
+                OpKey::MkSeq(*seq_type, elem_type.clone()),
+                elems.clone(),
+                false,
+            ));
+        }
+        OpCode::MkRepeated {
+            element,
+            seq_type,
+            count,
+            elem_type,
+            ..
+        } => {
+            return Some((
+                OpKey::MkRepeated(*seq_type, *count, elem_type.clone()),
+                vec![*element],
+                false,
+            ));
+        }
+        OpCode::MkSeqOfBlob {
+            element_type, blob, ..
+        } => {
+            return Some((OpKey::MkSeqOfBlob(element_type.clone()), vec![*blob], false));
+        }
+        OpCode::SlicePush {
+            dir, slice, values, ..
+        } => {
+            let mut operands = Vec::with_capacity(values.len() + 1);
+            operands.push(*slice);
+            operands.extend(values.iter().copied());
+            return Some((OpKey::SlicePush(*dir), operands, false));
+        }
+        _ => {}
+    }
+
     use BinaryArithOpKind::*;
     Some(match instr.scalar_fold()? {
         ScalarFold::Bin { kind, lhs, rhs } => {

--- a/compiler/src/compiler/analysis/click_cooper/congruence.rs
+++ b/compiler/src/compiler/analysis/click_cooper/congruence.rs
@@ -20,9 +20,15 @@ use std::sync::Arc;
 
 use crate::{
     collections::{HashMap, HashSet},
-    compiler::ssa::{
-        BlockId, Instruction, Terminator, ValueId,
-        hlssa::{BinaryArithOpKind, CastTarget, CmpKind, Constant, HLFunction, OpCode},
+    compiler::{
+        analysis::flow_analysis::CFG,
+        ssa::{
+            BlockId, FunctionId, Instruction, Terminator, ValueId,
+            hlssa::{
+                BinaryArithOpKind, CallTarget, CastTarget, CmpKind, Constant, HLFunction, OpCode,
+                ScalarFold,
+            },
+        },
     },
 };
 
@@ -47,6 +53,12 @@ pub(crate) struct Congruence {
     /// (allocated as `members.len()` and never deleted — classes only ever split, never merge), and
     /// the refinement loop sweeps it by index.
     members: Vec<Vec<ValueId>>,
+
+    /// Each value's dominance-aware leader.
+    ///
+    /// Populated by [`compute_leaders`](Congruence::compute_leaders); empty until then, so
+    /// [`leader`] is only meaningful on facts that have been finalized against their CFG.
+    leader_of: HashMap<ValueId, ValueId>,
 }
 
 impl Congruence {
@@ -66,25 +78,115 @@ impl Congruence {
         }
     }
 
-    /// A deterministic representative of `v`'s class (the smallest member by value id).
+    /// The leader of `v`'s class: the root-most member whose definition dominates `v`'s definition,
+    /// or returns `None` if `v` belongs to no class.
     ///
-    /// Note: this is *not* yet guaranteed to dominate the other members, so it is not a legal
-    /// redirect target on its own. The dominance-aware leader requires threading the `FlowAnalysis`
-    /// dominance into the congruence partition.
+    /// This leader is, by definition, available at every use of `v` and is hence a legal redirect
+    /// target. A consumer may replace every use of `v` with it.
+    ///
+    /// Populated by [`Self::compute_leaders`]. Without that finalize step, every member is its own
+    /// leader.
     pub(crate) fn leader(&self, v: ValueId) -> Option<ValueId> {
-        let &cid = self.class_of.get(&v)?;
-        self.members[cid].first().copied()
+        match self.leader_of.get(&v) {
+            Some(&l) => Some(l),
+            None => self.class_of.contains_key(&v).then_some(v),
+        }
+    }
+
+    /// Build the dominance-aware [`Self::leader`] of every member using `cfg`.
+    ///
+    /// Must be called before [`Self::leader`] is queried.
+    pub(crate) fn compute_leaders(&mut self, function: &HLFunction, cfg: &CFG) {
+        let entry = function.get_entry_id();
+
+        // Definition site of every value: `(block, rank)`, where a block parameter (φ) ranks before
+        // all instructions (`0`) and instruction `i`'s results rank `i + 1`. A member with no
+        // recorded site — an entry parameter or an interned constant referenced as an operand — is
+        // treated as defined at `(entry, 0)` and hence available throughout the function.
+        let mut def_site: HashMap<ValueId, (BlockId, usize)> = HashMap::default();
+        for (bid, block) in function.get_blocks() {
+            for p in block.get_parameter_values() {
+                def_site.insert(*p, (*bid, 0));
+            }
+            for (index, instr) in block.get_instructions().enumerate() {
+                for r in instr.get_results() {
+                    def_site.insert(*r, (*bid, index + 1));
+                }
+            }
+        }
+
+        // `def(w)` dominates `def(v)`: strict block dominance across blocks, or earlier rank within
+        // a block (with a value-id tie-break for two parameters of the same block, both available
+        // at block entry). `CFG::dominates` is reflexive, so it is only consulted across blocks.
+        let site = |v: ValueId| def_site.get(&v).copied().unwrap_or((entry, 0));
+        let dominates_def = |w: ValueId, v: ValueId| {
+            let (bw, rw) = site(w);
+            let (bv, rv) = site(v);
+            if bw == bv {
+                rw < rv || (rw == rv && w.0 < v.0)
+            } else {
+                cfg.dominates(bw, bv)
+            }
+        };
+
+        // A dominator-tree pre-order index per block: a linear extension of block dominance in
+        // which an ancestor block always precedes its descendants. Paired with the in-block rank
+        // and value id it gives a total `def_key` consistent with `dominates_def` — if `def(w)`
+        // dominates `def(v)` then `def_key(w) < def_key(v)`.
+        let preorder: HashMap<BlockId, usize> = cfg
+            .get_domination_pre_order()
+            .enumerate()
+            .map(|(i, b)| (b, i))
+            .collect();
+        let def_key = |v: ValueId| {
+            let (b, rank) = site(v);
+            (preorder.get(&b).copied().unwrap_or(usize::MAX), rank, v.0)
+        };
+
+        // For each member, the root-most class member dominating its definition. Every member that
+        // dominates `def(v)` lies on `v`'s dominator chain, so all such members are mutually
+        // comparable and the root-most is well-defined and order-independent.
+        //
+        // Sorting the class into `def_key` order (a linear extension of dominance) lets a single
+        // stack pass replace the quadratic all-pairs scan: the stack holds the current dominator
+        // chain (root → nearest). For each `v` we drop chain members that do not dominate it (by
+        // transitivity, whatever remains does); the chain's base is then `v`'s root-most dominating
+        // peer — its leader — or `v` itself when the chain is empty.
+        let mut leader_of = HashMap::default();
+        for class in &self.members {
+            let mut sorted = class.clone();
+            sorted.sort_by_key(|&v| def_key(v));
+
+            let mut chain: Vec<ValueId> = Vec::new();
+            for &v in &sorted {
+                while let Some(&top) = chain.last() {
+                    if dominates_def(top, v) {
+                        break;
+                    }
+                    chain.pop();
+                }
+                let leader = chain.first().copied().unwrap_or(v);
+                leader_of.insert(v, leader);
+                chain.push(v);
+            }
+        }
+        self.leader_of = leader_of;
     }
 
     /// Solve the partition for `function` over the converged reachability state.
     ///
-    /// `const_of` reports the unconditional constant of a value (the constants+reachability lattice),
-    /// used for the const→congruence seeding.
+    /// `const_of` reports the unconditional constant of a value (the constants+reachability
+    /// lattice), used for the const→congruence seeding.
+    ///
+    /// `call_det(g, j)` reports whether return position `j` of a static callee `g` is a
+    /// deterministic function of its arguments. A constrained static call whose result is thusly
+    /// deterministic is value-numbered cross-call, everything else stays opaque.
     pub(crate) fn build(
         function: &HLFunction,
         reachable: &HashSet<BlockId>,
         exec_edges: &HashSet<(BlockId, BlockId)>,
         const_of: impl Fn(ValueId) -> Option<Arc<Constant>>,
+        call_det: impl Fn(FunctionId, usize) -> bool,
     ) -> Congruence {
         let entry = function.get_entry_id();
 
@@ -114,6 +216,35 @@ impl Congruence {
                 for input in instr.get_inputs() {
                     universe.insert(*input);
                 }
+
+                // A constrained static call whose result is a deterministic function of its
+                // arguments is numbered structurally by `(callee, return-index)` over the argument
+                // value classes. Thus, two such calls with operandwise-congruent arguments yield
+                // congruent results (cross-call value numbering). Any other call result stays an
+                // opaque singleton.
+                if let OpCode::Call {
+                    results,
+                    function: CallTarget::Static(g),
+                    args,
+                    unconstrained: false,
+                } = instr
+                {
+                    for (j, r) in results.iter().enumerate() {
+                        universe.insert(*r);
+                        let node = if call_det(*g, j) {
+                            Node::Op {
+                                key: OpKey::CallDet(*g, j),
+                                operands: args.clone(),
+                                commutative: false,
+                            }
+                        } else {
+                            Node::Opaque
+                        };
+                        nodes.insert(*r, node);
+                    }
+                    continue;
+                }
+
                 match op_signature(instr) {
                     Some((key, operands, commutative)) => {
                         let mut results = instr.get_results();
@@ -128,6 +259,7 @@ impl Congruence {
                                 },
                             );
                         }
+
                         // Pure folds are single-result; any extra results are opaque (defensive).
                         for r in results {
                             universe.insert(*r);
@@ -244,7 +376,13 @@ impl Congruence {
             }
         }
 
-        Congruence { class_of, members }
+        // Leaders are finalized separately by `compute_leaders` once a CFG is available; the
+        // transient summary-phase partition that never exposes `leader` skips it.
+        Congruence {
+            class_of,
+            members,
+            leader_of: HashMap::default(),
+        }
     }
 }
 
@@ -288,6 +426,11 @@ enum OpKey {
     BitRange(usize, usize),
     Not,
     Select,
+
+    /// Return position `usize` of a constrained static call to `FunctionId` whose result is a
+    /// deterministic function of the call's arguments (its operands). Two such calls to the same
+    /// callee with operandwise-congruent arguments are congruent.
+    CallDet(FunctionId, usize),
 }
 
 /// The operand-free label that seeds the initial classes.
@@ -316,12 +459,25 @@ enum Sig {
     Opaque(ValueId),
 }
 
+/// The value operands of a pure, deterministic value-numbering op, or `None` if `instr` is not such
+/// an op (memory, witnesses, calls, …).
+///
+/// Shared with the interprocedural determinism analysis ([`super::summary`]) so the two agree on
+/// exactly which opcodes are deterministic functions of their operands — a single source of truth.
+pub(crate) fn pure_op_operands(instr: &OpCode) -> Option<Vec<ValueId>> {
+    op_signature(instr).map(|(_, operands, _)| operands)
+}
+
 /// The pure, deterministic ops eligible for value numbering, paired with their operands and
 /// commutativity.
+///
+/// Projects from [`OpCode::scalar_fold`] (the single source of truth for foldable scalar ops), so
+/// it cannot disagree with `is_pure_scalar_fold` / `solver::transfer` on the opcode set. The only
+/// ops it further excludes are witness casts, which are foldable in name but never value-numbered.
 fn op_signature(instr: &OpCode) -> Option<(OpKey, Vec<ValueId>, bool)> {
     use BinaryArithOpKind::*;
-    Some(match instr {
-        OpCode::BinaryArithOp { kind, lhs, rhs, .. } => {
+    Some(match instr.scalar_fold()? {
+        ScalarFold::Bin { kind, lhs, rhs } => {
             let (key, commutative) = match kind {
                 Add => (OpKey::Add, true),
                 Sub => (OpKey::Sub, false),
@@ -334,75 +490,35 @@ fn op_signature(instr: &OpCode) -> Option<(OpKey, Vec<ValueId>, bool)> {
                 Shl => (OpKey::Shl, false),
                 Shr => (OpKey::Shr, false),
             };
-            (key, vec![*lhs, *rhs], commutative)
+            (key, vec![lhs, rhs], commutative)
         }
-        OpCode::Cmp { kind, lhs, rhs, .. } => match kind {
-            CmpKind::Eq => (OpKey::CmpEq, vec![*lhs, *rhs], true),
-            CmpKind::Lt => (OpKey::CmpLt, vec![*lhs, *rhs], false),
+        ScalarFold::Cmp { kind, lhs, rhs } => match kind {
+            CmpKind::Eq => (OpKey::CmpEq, vec![lhs, rhs], true),
+            CmpKind::Lt => (OpKey::CmpLt, vec![lhs, rhs], false),
         },
-        OpCode::MulConst { const_val, var, .. } => (OpKey::MulConst, vec![*const_val, *var], true),
-        OpCode::Cast { value, target, .. } => match target {
+        ScalarFold::MulConst { const_val, var } => (OpKey::MulConst, vec![const_val, var], true),
+        ScalarFold::Cast { target, value } => match target {
             CastTarget::Nop | CastTarget::Field | CastTarget::U(_) | CastTarget::I(_) => {
-                (OpKey::Cast(target.clone()), vec![*value], false)
+                (OpKey::Cast(target.clone()), vec![value], false)
             }
+            // Foldable scalar ops, but never value-numbered: a witness cast is opaque.
             CastTarget::WitnessOf
             | CastTarget::ValueOf
             | CastTarget::ArrayToSlice
             | CastTarget::Map(_) => return None,
         },
-        OpCode::SExt {
+        ScalarFold::SExt {
             value,
             from_bits,
             to_bits,
-            ..
-        } => (OpKey::SExt(*from_bits, *to_bits), vec![*value], false),
-        OpCode::BitRange {
+        } => (OpKey::SExt(from_bits, to_bits), vec![value], false),
+        ScalarFold::BitRange {
             value,
             offset,
             width,
-            ..
-        } => (OpKey::BitRange(*offset, *width), vec![*value], false),
-        OpCode::Not { value, .. } => (OpKey::Not, vec![*value], false),
-        OpCode::Select {
-            cond, if_t, if_f, ..
-        } => (OpKey::Select, vec![*cond, *if_t, *if_f], false),
-
-        // Not pure/deterministic value-numbering candidates.
-        OpCode::MkSeq { .. }
-        | OpCode::MkSeqOfBlob { .. }
-        | OpCode::MkRepeated { .. }
-        | OpCode::Alloc { .. }
-        | OpCode::Store { .. }
-        | OpCode::Load { .. }
-        | OpCode::Assert { .. }
-        | OpCode::AssertCmp { .. }
-        | OpCode::AssertR1C { .. }
-        | OpCode::Call { .. }
-        | OpCode::ArrayGet { .. }
-        | OpCode::ArraySet { .. }
-        | OpCode::SlicePush { .. }
-        | OpCode::SliceLen { .. }
-        | OpCode::ToBits { .. }
-        | OpCode::ToRadix { .. }
-        | OpCode::MemOp { .. }
-        | OpCode::WriteWitness { .. }
-        | OpCode::FreshWitness { .. }
-        | OpCode::NextDCoeff { .. }
-        | OpCode::BumpD { .. }
-        | OpCode::Constrain { .. }
-        | OpCode::Lookup { .. }
-        | OpCode::DLookup { .. }
-        | OpCode::Rangecheck { .. }
-        | OpCode::ReadGlobal { .. }
-        | OpCode::TupleProj { .. }
-        | OpCode::TupleRefProj { .. }
-        | OpCode::MkTuple { .. }
-        | OpCode::Todo { .. }
-        | OpCode::InitGlobal { .. }
-        | OpCode::DropGlobal { .. }
-        | OpCode::Spread { .. }
-        | OpCode::Unspread { .. }
-        | OpCode::Guard { .. } => return None,
+        } => (OpKey::BitRange(offset, width), vec![value], false),
+        ScalarFold::Not { value } => (OpKey::Not, vec![value], false),
+        ScalarFold::Select { cond, if_t, if_f } => (OpKey::Select, vec![cond, if_t, if_f], false),
     })
 }
 

--- a/compiler/src/compiler/analysis/click_cooper/lattice.rs
+++ b/compiler/src/compiler/analysis/click_cooper/lattice.rs
@@ -232,7 +232,11 @@ pub(crate) fn eval_cmp(kind: CmpKind, a: &Constant, b: &Constant) -> Option<Cons
     }
 }
 
-/// Folds a field multiplication operation.
+/// Folds a field multiplication operation (the transfer for `MulConst`).
+///
+/// This is deliberately *not* `eval_binary(Mul, ..)`: `MulConst` is field-domain, where
+/// multiplication is modular and total, so it must not inherit the integer width/overflow rules
+/// `eval_binary` applies to `U`/`I` operands. Non-field operands therefore do not fold.
 pub(crate) fn eval_field_mul(a: &Constant, b: &Constant) -> Option<Constant> {
     match (a, b) {
         (Constant::Field(x), Constant::Field(y)) => Some(Constant::Field(*x * *y)),

--- a/compiler/src/compiler/analysis/click_cooper/lattice.rs
+++ b/compiler/src/compiler/analysis/click_cooper/lattice.rs
@@ -232,29 +232,6 @@ pub(crate) fn eval_cmp(kind: CmpKind, a: &Constant, b: &Constant) -> Option<Cons
     }
 }
 
-/// Folds a field multiplication operation (the transfer for `MulConst`).
-///
-/// This is deliberately *not* `eval_binary(Mul, ..)`: `MulConst` is field-domain, where
-/// multiplication is modular and total, so it must not inherit the integer width/overflow rules
-/// `eval_binary` applies to `U`/`I` operands. Non-field operands therefore do not fold.
-pub(crate) fn eval_field_mul(a: &Constant, b: &Constant) -> Option<Constant> {
-    match (a, b) {
-        (Constant::Field(x), Constant::Field(y)) => Some(Constant::Field(*x * *y)),
-        (
-            Constant::U(..)
-            | Constant::I(..)
-            | Constant::Field(_)
-            | Constant::FnPtr(_)
-            | Constant::Blob(_),
-            Constant::U(..)
-            | Constant::I(..)
-            | Constant::Field(_)
-            | Constant::FnPtr(_)
-            | Constant::Blob(_),
-        ) => None,
-    }
-}
-
 /// Folds a constant cast operation.
 ///
 /// HLSSA casts are raw-bits conversions (sign extension is the separate `SExt` op). Integers

--- a/compiler/src/compiler/analysis/click_cooper/mod.rs
+++ b/compiler/src/compiler/analysis/click_cooper/mod.rs
@@ -100,6 +100,12 @@
 //!   pass per `(function, context)` — as `specialize` already does for the unconditional facts —
 //!   would let a context-specialized assert or branch expose more facts, and would warrant adding
 //!   the `_in` variants.
+//! - **Aggregate Constant Folding:** The pure, value-semantic sequence ops (`MkSeq`, `MkRepeated`,
+//!   `MkSeqOfBlob`, `ArrayGet`, `ArraySet`, `SlicePush`, `SliceLen`) are value-numbered (see
+//!   `congruence::op_signature`) but never constant-folded. The `Constness` lattice carries only a
+//!   scalar `Arc<Constant>` and the fold functions are scalar, so it cannot represent an aggregate
+//!   constant. Future work can widen the lattice to handle aggregate constants and transfer
+//!   functions.
 
 mod conditional;
 mod congruence;
@@ -544,7 +550,7 @@ pub(crate) mod tests {
             Terminator,
             hlssa::{
                 BinaryArithOpKind, CallTarget, CastTarget, CmpKind, Constant, HLSSA, OpCode,
-                ScalarFold, Type,
+                ScalarFold, SequenceTargetType, SliceOpDir, Type,
             },
         },
     };
@@ -556,11 +562,14 @@ pub(crate) mod tests {
         ClickCooper::run(ssa, &flow, &types)
     }
 
-    /// `OpCode::scalar_fold` is the single source of truth for "foldable scalar op". This locks the
-    /// three projections that read it: `is_pure_scalar_fold` agrees with `scalar_fold().is_some()`,
-    /// and value numbering (`pure_op_operands`, backed by `op_signature`) only ever fires on a
-    /// foldable op. The one deliberate asymmetry — a witness cast is foldable but never
-    /// value-numbered — is asserted explicitly so it cannot be silently dropped.
+    /// `OpCode::scalar_fold` is the single source of truth for "foldable *scalar* op", and value
+    /// numbering is a strict superset of it.
+    ///
+    /// This locks the projections that read both: `is_pure_scalar_fold` agrees with
+    /// `scalar_fold().is_some()`; value numbering (`pure_op_operands`, backed by `op_signature`)
+    /// fires on every foldable scalar op *except* witness casts, **and additionally** on the pure
+    /// sequence ops, which are not scalar-foldable. Both deliberate asymmetries are asserted below
+    /// so neither can be silently dropped.
     #[test]
     fn scalar_fold_is_the_single_classifier() {
         use super::congruence::pure_op_operands;
@@ -643,6 +652,62 @@ pub(crate) mod tests {
             Some(ScalarFold::Cast { .. })
         ));
         assert!(pure_op_operands(&witness_cast).is_none());
+
+        // The other deliberate asymmetry: pure sequence ops ARE value-numbered but are NOT
+        // scalar-foldable (their aggregate results never enter the constant lattice).
+        let elem = Type::field();
+        let sequence_ops: Vec<OpCode> = vec![
+            OpCode::ArrayGet {
+                result: v(),
+                array: v(),
+                index: v(),
+            },
+            OpCode::ArraySet {
+                result: v(),
+                array: v(),
+                index: v(),
+                value: v(),
+            },
+            OpCode::SliceLen {
+                result: v(),
+                slice: v(),
+            },
+            OpCode::MkSeq {
+                result: v(),
+                elems: vec![v(), v()],
+                seq_type: SequenceTargetType::Array(2),
+                elem_type: elem.clone(),
+            },
+            OpCode::MkRepeated {
+                result: v(),
+                element: v(),
+                seq_type: SequenceTargetType::Slice,
+                count: 3,
+                elem_type: elem.clone(),
+            },
+            OpCode::MkSeqOfBlob {
+                result: v(),
+                element_type: elem.clone(),
+                blob: v(),
+            },
+            OpCode::SlicePush {
+                dir: SliceOpDir::Back,
+                result: v(),
+                slice: v(),
+                values: vec![v()],
+            },
+        ];
+        for instr in &sequence_ops {
+            assert!(
+                !instr.is_pure_scalar_fold(),
+                "{instr:?} should not be scalar-foldable"
+            );
+            assert!(instr.scalar_fold().is_none());
+            assert!(
+                pure_op_operands(instr).is_some(),
+                "{instr:?} should be value-numbered"
+            );
+        }
 
         // Representative non-folds: not foldable, not value-numbered, no `ScalarFold`.
         let non_folds: Vec<OpCode> = vec![
@@ -763,6 +828,81 @@ pub(crate) mod tests {
         let mut expected = vec![a, b, c];
         expected.sort();
         assert_eq!(cc.congruence_class(fid, a), expected);
+    }
+
+    /// Pure sequence ops are value-numbered: two `ArrayGet`s of the same array at the same index
+    /// are congruent (a different index is not), `MkSeq`s congruent elementwise are congruent, and
+    /// the sequence shape (`seq_type`, `elem_type`) carried in the key keeps differently-shaped
+    /// `MkSeq`s apart.
+    #[test]
+    fn array_ops_are_value_numbered() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let (arr, i, j) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+        let (g1, g2, g3) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+        let (s1, s2, s3, s4) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let f = ssa.get_unique_entrypoint_mut();
+        f.get_entry_mut()
+            .push_parameter(arr, Type::field().array_of(4));
+        f.get_entry_mut().push_parameter(i, Type::u(32));
+        f.get_entry_mut().push_parameter(j, Type::u(32));
+        let entry = f.get_entry_mut();
+        // g1, g2 are arr[i]; g3 is arr[j].
+        entry.push_instruction(OpCode::ArrayGet {
+            result: g1,
+            array: arr,
+            index: i,
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: g2,
+            array: arr,
+            index: i,
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: g3,
+            array: arr,
+            index: j,
+        });
+        // s1 and s2 are the same array `[arr[i], arr[j]]` built twice — congruent elementwise.
+        entry.push_instruction(OpCode::MkSeq {
+            result: s1,
+            elems: vec![g1, g3],
+            seq_type: SequenceTargetType::Array(2),
+            elem_type: Type::field(),
+        });
+        entry.push_instruction(OpCode::MkSeq {
+            result: s2,
+            elems: vec![g2, g3],
+            seq_type: SequenceTargetType::Array(2),
+            elem_type: Type::field(),
+        });
+        // s3 differs only in sequence kind (Slice), s4 only in element type (u32): neither merges.
+        entry.push_instruction(OpCode::MkSeq {
+            result: s3,
+            elems: vec![g1, g3],
+            seq_type: SequenceTargetType::Slice,
+            elem_type: Type::field(),
+        });
+        entry.push_instruction(OpCode::MkSeq {
+            result: s4,
+            elems: vec![g1, g3],
+            seq_type: SequenceTargetType::Array(2),
+            elem_type: Type::u(32),
+        });
+        entry.set_terminator(Terminator::Return(vec![g1, g2, g3, s1, s2, s3, s4]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        assert!(cc.known_equal(fid, g1, g2)); // arr[i] ≡ arr[i]
+        assert!(!cc.known_equal(fid, g1, g3)); // arr[i] ≢ arr[j]
+        assert!(cc.known_equal(fid, s1, s2)); // elementwise-congruent arrays
+        assert!(!cc.known_equal(fid, s1, s3)); // different seq_type
+        assert!(!cc.known_equal(fid, s1, s4)); // different elem_type
     }
 
     /// φ-operands come from *executable* edges only: a parameter whose value differs solely on a
@@ -1896,5 +2036,89 @@ pub(crate) mod tests {
 
         let cc = run_in_test(&ssa);
         assert!(cc.known_equal(main_id, r1, r2));
+    }
+
+    /// A callee that returns a pure transform of an array parameter (`p[0]`) is a deterministic
+    /// function of its argument now that sequence ops are value-numbered, so two calls with
+    /// congruent array arguments yield congruent results. Before this change the `ArrayGet` tainted
+    /// the return as non-deterministic and the calls stayed distinct.
+    #[test]
+    fn cross_call_congruence_for_array_returning_callee() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let pick = ssa.add_function("pick".to_string());
+        let p = ssa.fresh_value();
+        let elem = ssa.fresh_value();
+        let c0 = ssa.add_const(Constant::U(32, 0));
+
+        // pick(p) = p[0] — deterministic in its array argument.
+        {
+            let hf = ssa.get_function_mut(pick);
+            hf.add_return_type(Type::field());
+            hf.get_entry_mut()
+                .push_parameter(p, Type::field().array_of(1));
+            hf.get_entry_mut().push_instruction(OpCode::ArrayGet {
+                result: elem,
+                array: p,
+                index: c0,
+            });
+            hf.get_entry_mut()
+                .set_terminator(Terminator::Return(vec![elem]));
+        }
+
+        let (x, y) = (ssa.fresh_value(), ssa.fresh_value());
+        let (a, b, d) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+        let (r1, r2, r3) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+        {
+            let mf = ssa.get_function_mut(main_id);
+            mf.add_return_type(Type::field());
+            mf.add_return_type(Type::field());
+            mf.add_return_type(Type::field());
+            mf.get_entry_mut().push_parameter(x, Type::field());
+            mf.get_entry_mut().push_parameter(y, Type::field());
+            let entry = mf.get_entry_mut();
+            // `a` and `b` are congruent single-element arrays (`[x]`); `d` is `[y]`.
+            entry.push_instruction(OpCode::MkSeq {
+                result: a,
+                elems: vec![x],
+                seq_type: SequenceTargetType::Array(1),
+                elem_type: Type::field(),
+            });
+            entry.push_instruction(OpCode::MkSeq {
+                result: b,
+                elems: vec![x],
+                seq_type: SequenceTargetType::Array(1),
+                elem_type: Type::field(),
+            });
+            entry.push_instruction(OpCode::MkSeq {
+                result: d,
+                elems: vec![y],
+                seq_type: SequenceTargetType::Array(1),
+                elem_type: Type::field(),
+            });
+            entry.push_instruction(OpCode::Call {
+                results: vec![r1],
+                function: CallTarget::Static(pick),
+                args: vec![a],
+                unconstrained: false,
+            });
+            entry.push_instruction(OpCode::Call {
+                results: vec![r2],
+                function: CallTarget::Static(pick),
+                args: vec![b],
+                unconstrained: false,
+            });
+            entry.push_instruction(OpCode::Call {
+                results: vec![r3],
+                function: CallTarget::Static(pick),
+                args: vec![d],
+                unconstrained: false,
+            });
+            entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
+        }
+
+        let cc = run_in_test(&ssa);
+        assert!(cc.known_equal(main_id, r1, r2)); // congruent array args ⇒ congruent results
+        assert!(!cc.known_equal(main_id, r1, r3)); // distinct array arg ⇒ distinct result
     }
 }

--- a/compiler/src/compiler/analysis/click_cooper/mod.rs
+++ b/compiler/src/compiler/analysis/click_cooper/mod.rs
@@ -1,20 +1,24 @@
 //! A Click–Cooper-style combined optimistic analysis.
 //!
 //! An analysis that handles **constants**, **reachability** and **congruence** (using optimistic
-//! AWZ value numbering). It is designed to drive constant/condition propagation and PRE; a
-//! context-sensitive interprocedural layer is planned (see
-//! [Deferred Improvements](#deferred-improvements)). The combination is _at least_ as precise as
+//! AWZ value numbering), plus a context-sensitive **interprocedural** (1-CFA) layer. It is designed
+//! to drive constant/condition propagation and PRE. The combination is _at least_ as precise as
 //! running the factors separately and alternating to a fixpoint (Click & Cooper, _Combining
 //! Analyses, Combining Optimizations_, TOPLAS 1995).
 //!
-//! It operates over two kinds of facts:
+//! It operates over three kinds of facts:
 //!
 //! - **Intraprocedural facts** are those within a given function and are derived from a
 //!   Wegman-Zadeck constants and reachability fixpoint with a structural-congruence partition over
 //!   the reachability state.
+//! - **Interprocedural facts** refine the intraprocedural view across calls: polymorphic
+//!   jump-function summaries (a `return_const` holding for any arguments, a `return Param(i)`
+//!   pass-through) and 1-CFA per-`(function, context)` specialization seeding callee parameters
+//!   with the caller's argument constants, plus determinism-gated *cross-call congruence* (two
+//!   constrained static calls to one callee with congruent arguments yield congruent results).
 //! - **Conditional facts** are ones derived from asserts, equalities, disequalities, and unpinned
 //!   witness forwarding. They are computed post-convergence over the same reachability state plus
-//!   GFG dominance, and are intentionally disjoint from the unconditional view.
+//!   CFG dominance, and are intentionally disjoint from the unconditional view.
 //!
 //! **Unconditional facts** are those which hold on any path so that any use (replacing a use,
 //! deleting a pure definition, or pruning an unreachable block) maintains soundness. **Conditional
@@ -33,6 +37,14 @@
 //! - **Congruence:** Two values are congruent iff computed by the same operator from operand-wise
 //!   congruent inputs, hence equal in all runs. Congruence never asserts an equality an adversarial
 //!   witness could validate.
+//! - **Interprocedural Constants:** A `return_const` jump function holds for any arguments; a
+//!   `return Param(i)` pass-through equals argument `i` exactly. Per-context parameter seeds are
+//!   the meet of the argument constants over *every* static call path mapped to that context, so a
+//!   per-context constant holds on every concrete invocation in that context.
+//! - **Cross-Call Congruence:** A constrained static call's result is value-numbered by
+//!   `(callee, return-index)` over its argument classes only when the callee's return is a
+//!   deterministic function of its arguments; equal arguments then force an equal result. A
+//!   non-deterministic return (e.g. one carrying a fresh witness) stays opaque.
 //! - **Conditional Facts:** Assert-derived constants, equalities, and disequalities hold only on
 //!   accepting runs that preserve their establishing constraint, so they are exposed only through
 //!   dedicated queries. An assert, being a global constraint that holds at every point of an
@@ -54,6 +66,12 @@
 //!   of edge/value events.
 //! - **Congruence:** Partition refinement only ever *splits* classes, and the class count is
 //!   bounded by the value count, so it stabilises in at most `|values|` rounds.
+//! - **Determinism / Interprocedural Summaries:** The determinism bits and the `ReturnJump` lattice
+//!   are finite, and a caller is re-queued only when a callee's summary strictly changed, so each
+//!   call-graph worklist reaches a fixpoint.
+//! - **1-CFA Specialization:** Contexts are `K`-limited call strings over finitely many call sites,
+//!   hence finite. Per-context parameter seeds move monotonically down the finite-height constant
+//!   lattice, and a context is re-queued only when newly discovered or its seed lowered.
 //!
 //! # Deferred Improvements
 //!
@@ -70,24 +88,26 @@
 //!   granularity via *strict* dominance/post-dominance, so a use in the asserting block itself
 //!   (after the assert) is not yet claimed. Index-precise program points would recover it; soundness
 //!   is unaffected.
-//! - **Dominance-Aware Congruence Leader:** [`ClickCooper::leader`] returns the smallest-id class
-//!   member, which is not necessarily a dominating definition; a redirecting consumer (CSE/PRE)
-//!   needs the dominating member, which requires threading `FlowAnalysis` dominance into the
-//!   congruence partition.
-//! - **Interprocedural (1-CFA) Layer:** A context-sensitive interprocedural layer — polymorphic
-//!   jump-function summaries (a `return_const` jump function holding for any arguments, a
-//!   `return Param(i)` pass-through equal to argument `i`) plus 1-CFA per-`(function, k-limited
-//!   call-string)` specialization, mirroring the two-phase structure of `analysis/points_to` — was
-//!   prototyped and then removed pending a consumer that exploits it. SCCP, the only current
-//!   consumer, reads intraprocedural facts only, so the layer was deferred to keep the analysis
-//!   lean; it can be reinstated (along with its `*_in` context-keyed queries) with its first
-//!   interprocedural consumer. The deferred layer also did not propagate cross-call structural
-//!   congruence (e.g. `f(x); f(y)` with `x ≡ y` yielding congruent results).
+//! - **Symbolic Interprocedural Congruence:** Cross-call congruence currently requires that *all*
+//!   arguments are congruent and is gated on a whole-return determinism bit; it does not graft a
+//!   callee's return expression into the caller, so it cannot relate `f(x)` to an open expression
+//!   over `x`, nor see that a return ignores some argument. A symbolic return jump function would
+//!   recover both.
+//! - **Per-context Conditional Facts:** The assert/disequality/witness-forwarding conditional facts
+//!   are computed once per function and not refined per 1-CFA context, so they have no `_in(f, ctx,
+//!   …)` query: a caller reads them through the intraprocedural methods, whose (sound,
+//!   context-independent) answer is a per-context under-approximation. Recomputing the conditional
+//!   pass per `(function, context)` — as `specialize` already does for the unconditional facts —
+//!   would let a context-specialized assert or branch expose more facts, and would warrant adding
+//!   the `_in` variants.
 
 mod conditional;
 mod congruence;
 mod lattice;
 mod solver;
+mod summary;
+
+pub use crate::compiler::analysis::call_string::Context;
 
 use std::sync::Arc;
 
@@ -99,6 +119,7 @@ use crate::{
                 conditional::ConditionalFacts,
                 lattice::{Constness, bool_constant},
                 solver::{FunctionFacts, FunctionSolver},
+                summary::{compute_determinism, compute_summaries, specialize},
             },
             flow_analysis::FlowAnalysis,
             types::TypeInfo,
@@ -125,11 +146,13 @@ pub struct ClickCooper {
     /// Per-function **intraprocedural** converged facts (parameters and call results `Bottom`).
     functions: HashMap<FunctionId, FunctionFacts>,
 
-    /// Per-function **conditional** side facts (assert-derived constants/equalities, branch
-    /// disequalities, unpinned-witness forwarding).
+    /// Per-`(function, context)` interprocedurally-refined facts (1-CFA), built from the
+    /// polymorphic jump-function summaries.
+    contexts: HashMap<(FunctionId, Context), FunctionFacts>,
+
+    /// Per-function **conditional** facts.
     ///
-    /// Held in their own fields read by their own queries, entirely disjoint from the unconditional
-    /// view above.
+    /// They are intentionally disjoint from the unconditional views above.
     conditional: HashMap<FunctionId, ConditionalFacts>,
 }
 
@@ -149,16 +172,33 @@ impl ClickCooper {
         // interned program-wide.
         let consts = ssa.const_snapshot();
 
-        // Per-function intraprocedural facts: parameters and call results `Bottom`. The conditional
-        // side facts are computed from the same converged state plus CFG dominance, kept in a
-        // disjoint map so the unconditional view is untouched.
+        // Phase 0: per-`(callee, return)` determinism, used below to value-number deterministic
+        // static-call results cross-call. It only refines congruence (never the constant lattice or
+        // reachability), so it leaves the SCCP-visible facts byte-identical.
+        let det = compute_determinism(ssa, flow);
+
+        // Per-function intraprocedural facts: parameters and call results `Bottom` (no summaries
+        // here). The conditional side facts are computed from the same converged state plus CFG
+        // dominance, kept in a disjoint map so the unconditional view is untouched.
+        //
+        // This solve MUST stay summary-free: SCCP reads `functions` (via `const_of`/
+        // `new_const_values`/`is_reachable`) and relies on `Call` staying `Bottom`, so that every
+        // constant-valued result it aliases or deletes is a pure scalar fold. Wiring summaries in
+        // here would let a constrained `Call` result become `Const` and break that contract (an
+        // `assert!` in SCCP's `rewrite` guards against it).
         let mut functions = HashMap::default();
         let mut conditional = HashMap::default();
         for fid in ssa.get_function_ids() {
             let function = ssa.get_function(fid);
-            let mut solver = FunctionSolver::new(function, &consts);
+            let mut solver = FunctionSolver::new(function, &consts).with_determinism(&det);
             solver.run();
-            let facts = solver.into_facts();
+            let mut facts = solver.into_facts();
+
+            // Finalize dominance-aware congruence leaders against the function's CFG, so `leader`
+            // returns a legal redirect target.
+            facts
+                .congruence
+                .compute_leaders(function, flow.get_function_cfg(fid));
             let cond = conditional::build(
                 function,
                 &facts,
@@ -170,38 +210,71 @@ impl ClickCooper {
             functions.insert(fid, facts);
         }
 
+        // Handle the interprocedural layer using polymorphic jump-function summaries then
+        // contextual facts on the 1-CFA.
+        let summaries = compute_summaries(ssa, flow, &consts, &det);
+        let contexts = specialize(ssa, flow, &consts, &summaries, &det);
+
         ClickCooper {
             consts,
             functions,
+            contexts,
             conditional,
         }
     }
 }
 
-/// Unconditional queries — facts that hold in **every** run.
+/// Private query helpers shared by the public query impls.
+impl ClickCooper {
+    /// The intraprocedural facts of `f`, or `None` if `f` was not analyzed.
+    fn facts(&self, f: FunctionId) -> Option<&FunctionFacts> {
+        self.functions.get(&f)
+    }
+
+    /// The context-specialized (1-CFA) facts of `f` under `ctx`, or `None`.
+    fn facts_in(&self, f: FunctionId, ctx: &Context) -> Option<&FunctionFacts> {
+        self.contexts.get(&(f, ctx.clone()))
+    }
+
+    /// The constant `v` holds in `facts`, or `None`: interned constants first, then the constant
+    /// lattice.
+    fn const_in_facts(
+        consts: &HLSSAConstantsSnapshot,
+        facts: Option<&FunctionFacts>,
+        v: ValueId,
+    ) -> Option<Arc<Constant>> {
+        if let Some(c) = consts.get(&v) {
+            return Some(c.clone());
+        }
+        match facts?.lattice.get(&v) {
+            Some(Constness::Const(c)) => Some(c.clone()),
+            Some(Constness::Top) | Some(Constness::Bottom) | None => None,
+        }
+    }
+}
+
+/// Unconditional intraprocedural queries — facts that hold in **every** run.
 ///
-/// Using them to replace uses, delete pure defs, or prune unreachable blocks is accept-set
-/// preserving. This impl block contains both the intraprocedural and interprocedural queries.
+/// Using them to replace uses, delete pure defs, or prune unreachable blocks is always correctness
+/// preserving.
 impl ClickCooper {
     /// The constant `v` provably holds in `f` in *every* run, or `None`.
     ///
     /// Interned constants and the global constant lattice only; path-sensitive branch facts are
     /// excluded.
     pub fn const_of(&self, f: FunctionId, v: ValueId) -> Option<Arc<Constant>> {
-        Self::const_in_facts(&self.consts, self.functions.get(&f), v)
+        Self::const_in_facts(&self.consts, self.facts(f), v)
     }
 
     /// `true` if `bid` reachable in `f`.
     pub fn is_reachable(&self, f: FunctionId, bid: BlockId) -> bool {
-        self.functions
-            .get(&f)
+        self.facts(f)
             .is_some_and(|facts| facts.reachable.contains(&bid))
     }
 
     /// `true` if the CFG edge `from -> to` proven executable in `f`.
     pub fn is_executable_edge(&self, f: FunctionId, from: BlockId, to: BlockId) -> bool {
-        self.functions
-            .get(&f)
+        self.facts(f)
             .is_some_and(|facts| facts.exec_edges.contains(&(from, to)))
     }
 
@@ -209,7 +282,7 @@ impl ClickCooper {
     ///
     /// Excludes already-interned constant values and conditional branch facts.
     pub fn new_const_values(&self, f: FunctionId) -> Vec<(ValueId, Arc<Constant>)> {
-        let Some(facts) = self.functions.get(&f) else {
+        let Some(facts) = self.facts(f) else {
             return Vec::new();
         };
         facts
@@ -224,45 +297,88 @@ impl ClickCooper {
 
     /// `true` if `a` and `b` are proven *structurally* congruent in `f`.
     pub fn known_equal(&self, f: FunctionId, a: ValueId, b: ValueId) -> bool {
-        self.functions
-            .get(&f)
+        self.facts(f)
             .is_some_and(|facts| facts.congruence.known_equal(a, b))
     }
 
     /// Every value structurally congruent to `v` in `f` (including `v`), sorted by value id.
     pub fn congruence_class(&self, f: FunctionId, v: ValueId) -> Vec<ValueId> {
-        self.functions
-            .get(&f)
+        self.facts(f)
             .map(|facts| facts.congruence.class_members(v))
             .unwrap_or_default()
     }
 
-    /// A deterministic representative of `v`'s congruence class in `f` (smallest member by value
-    /// id).
-    ///
-    /// Not yet guaranteed to dominate the class, so it is not a legal redirect target on its own;
-    /// the dominance-aware leader requires threading the (already-available) `FlowAnalysis`
-    /// dominance into the congruence partition.
+    /// The leader of `v`'s congruence class in `f`: the root-most congruent member whose definition
+    /// dominates `v`'s definition (`v` itself when no other member does).
     pub fn leader(&self, f: FunctionId, v: ValueId) -> Option<ValueId> {
-        self.functions
-            .get(&f)
-            .and_then(|facts| facts.congruence.leader(v))
+        self.facts(f).and_then(|facts| facts.congruence.leader(v))
     }
 }
 
-/// Conditional queries — facts established by a branch or assert that hold only downstream of the
-/// establishing control flow.
+/// Unconditional interprocedural queries — the 1-CFA per-`(function, context)` refinement.
 ///
-/// These let Mavros be stricter on adversarial inputs, so they are sound *only* under
-/// constraint-preserving use: a local, structure-preserving rewrite that keeps the establishing
-/// branch/assert (never folding away the constraint that proves the fact).
+/// These read the specialized `contexts` map (never the SCCP-visible `functions` view), so they are
+/// disjoint from the intraprocedural queries above. They are unconditional facts *within* their
+/// context: a caller's argument constants seed the callee's parameters, and constant-returning
+/// calls fold.
+impl ClickCooper {
+    /// The constant `v` provably holds in `f` under calling context `ctx`, or `None`.
+    pub fn const_of_in(&self, f: FunctionId, ctx: &Context, v: ValueId) -> Option<Arc<Constant>> {
+        Self::const_in_facts(&self.consts, self.facts_in(f, ctx), v)
+    }
+
+    /// `true` if `a` and `b` are proven structurally congruent in `f` under context `ctx`.
+    pub fn known_equal_in(&self, f: FunctionId, ctx: &Context, a: ValueId, b: ValueId) -> bool {
+        self.facts_in(f, ctx)
+            .is_some_and(|facts| facts.congruence.known_equal(a, b))
+    }
+
+    /// Every value congruent to `v` in `f` under context `ctx` (including `v`), sorted by value id.
+    pub fn congruence_class_in(&self, f: FunctionId, ctx: &Context, v: ValueId) -> Vec<ValueId> {
+        self.facts_in(f, ctx)
+            .map(|facts| facts.congruence.class_members(v))
+            .unwrap_or_default()
+    }
+
+    /// The leader of `v`'s congruence class in `f` under context `ctx` (a legal redirect target, as
+    /// in [`Self::leader`]).
+    pub fn leader_in(&self, f: FunctionId, ctx: &Context, v: ValueId) -> Option<ValueId> {
+        self.facts_in(f, ctx)
+            .and_then(|facts| facts.congruence.leader(v))
+    }
+
+    /// The contexts `f` was specialized in (sorted), for enumerating its per-context facts.
+    pub fn contexts_of(&self, f: FunctionId) -> Vec<Context> {
+        let mut out: Vec<Context> = self
+            .contexts
+            .keys()
+            .filter(|(g, _)| *g == f)
+            .map(|(_, ctx)| ctx.clone())
+            .collect();
+        out.sort();
+        out
+    }
+}
+
+/// Intraprocedural conditional queries — facts established by a branch or assert.
+///
+/// They are sound *only* under constraint-preserving use: a local, structure-preserving rewrite
+/// that keeps the establishing branch/assert (never folding away the constraint that proves the
+/// fact).
+///
+/// These are **intraprocedural** and hence have no context. A conditional fact is established by
+/// control flow *internal to `f`* (a dominating assert, a branch predicate, a witness write), so it
+/// holds in *every* calling context. A context only adds parameter constants and prunes blocks, so
+/// it can make a block unreachable but can never invalidate a fact on a block that remains
+/// reachable. The intraprocedural answer is thus a sound **under-approximation** of the per-context
+/// one.
 impl ClickCooper {
     /// The constant `v` holds on entry to `bid` in `f`, honoring path-sensitive branch facts.
     pub fn const_in_block(&self, f: FunctionId, bid: BlockId, v: ValueId) -> Option<Arc<Constant>> {
         if let Some(c) = self.consts.get(&v) {
             return Some(c.clone());
         }
-        let facts = self.functions.get(&f)?;
+        let facts = self.facts(f)?;
         if let Some(known) = facts.block_facts.get(&bid).and_then(|m| m.get(&v)) {
             return Some(bool_constant(*known));
         }
@@ -271,12 +387,7 @@ impl ClickCooper {
 
     /// `Some(...)` if `v` known true/false on entry to `bid` in `f` (a branch predicate fact).
     pub fn bool_fact(&self, f: FunctionId, bid: BlockId, v: ValueId) -> Option<bool> {
-        self.functions
-            .get(&f)?
-            .block_facts
-            .get(&bid)?
-            .get(&v)
-            .copied()
+        self.facts(f)?.block_facts.get(&bid)?.get(&v).copied()
     }
 
     /// If `v` is an (in-block) constant boolean, get its value, honoring branch facts, or `None`
@@ -289,7 +400,7 @@ impl ClickCooper {
     /// The branch predicate facts at entry to `bid` in `f`, as `(value, bool-constant)` pairs
     /// sorted by value id.
     pub fn block_bool_facts(&self, f: FunctionId, bid: BlockId) -> Vec<(ValueId, Arc<Constant>)> {
-        let Some(facts) = self.functions.get(&f) else {
+        let Some(facts) = self.facts(f) else {
             return Vec::new();
         };
         let Some(m) = facts.block_facts.get(&bid) else {
@@ -349,33 +460,92 @@ impl ClickCooper {
     }
 }
 
-/// Private query helper shared by [`Self::const_of`] and [`Self::const_in_block`].
+/// Interprocedural conditional queries — the per-context analogs of the *branch-fact*
+/// intraprocedural conditional queries above (e.g. for a clone of `f` specialized to `ctx`).
+///
+/// They are sound *only* under constraint-preserving use: a local, structure-preserving rewrite
+/// that keeps the establishing branch (never folding away the constraint that proves the fact).
 impl ClickCooper {
-    /// The constant `v` holds in `facts`, or `None`: interned constants first, then the constant
-    /// lattice.
-    fn const_in_facts(
-        consts: &HLSSAConstantsSnapshot,
-        facts: Option<&FunctionFacts>,
+    /// [`Self::const_in_block`] under calling context `ctx`.
+    ///
+    /// Honors the context-specialized branch facts, so a context that folds more branches is more
+    /// precise.
+    pub fn const_in_block_in(
+        &self,
+        f: FunctionId,
+        ctx: &Context,
+        bid: BlockId,
         v: ValueId,
     ) -> Option<Arc<Constant>> {
-        if let Some(c) = consts.get(&v) {
+        if let Some(c) = self.consts.get(&v) {
             return Some(c.clone());
         }
-        match facts?.lattice.get(&v) {
-            Some(Constness::Const(c)) => Some(c.clone()),
-            Some(Constness::Top) | Some(Constness::Bottom) | None => None,
+        let facts = self.facts_in(f, ctx)?;
+        if let Some(known) = facts.block_facts.get(&bid).and_then(|m| m.get(&v)) {
+            return Some(bool_constant(*known));
         }
+        Self::const_in_facts(&self.consts, Some(facts), v)
+    }
+
+    /// [`Self::bool_fact`] under calling context `ctx`.
+    pub fn bool_fact_in(
+        &self,
+        f: FunctionId,
+        ctx: &Context,
+        bid: BlockId,
+        v: ValueId,
+    ) -> Option<bool> {
+        self.facts_in(f, ctx)?
+            .block_facts
+            .get(&bid)?
+            .get(&v)
+            .copied()
+    }
+
+    /// [`Self::const_bool_in_block`] under calling context `ctx`.
+    pub fn const_bool_in_block_in(
+        &self,
+        f: FunctionId,
+        ctx: &Context,
+        bid: BlockId,
+        v: ValueId,
+    ) -> Option<bool> {
+        self.const_in_block_in(f, ctx, bid, v)
+            .and_then(|c| lattice::const_bool(&c))
+    }
+
+    /// [`Self::block_bool_facts`] under calling context `ctx`.
+    pub fn block_bool_facts_in(
+        &self,
+        f: FunctionId,
+        ctx: &Context,
+        bid: BlockId,
+    ) -> Vec<(ValueId, Arc<Constant>)> {
+        let Some(facts) = self.facts_in(f, ctx) else {
+            return Vec::new();
+        };
+        let Some(m) = facts.block_facts.get(&bid) else {
+            return Vec::new();
+        };
+        let mut out: Vec<(ValueId, Arc<Constant>)> =
+            m.iter().map(|(v, b)| (*v, bool_constant(*b))).collect();
+        out.sort_by_key(|(v, _)| v.0);
+        out
     }
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use super::{ClickCooper, FlowAnalysis};
+    use super::{ClickCooper, Context, FlowAnalysis};
     use crate::compiler::{
+        Field,
         analysis::types::Types,
         ssa::{
             Terminator,
-            hlssa::{BinaryArithOpKind, CastTarget, CmpKind, Constant, HLSSA, OpCode, Type},
+            hlssa::{
+                BinaryArithOpKind, CallTarget, CastTarget, CmpKind, Constant, HLSSA, OpCode,
+                ScalarFold, Type,
+            },
         },
     };
 
@@ -384,6 +554,125 @@ pub(crate) mod tests {
         let flow = FlowAnalysis::run(ssa);
         let types = Types::new().run(ssa, &flow);
         ClickCooper::run(ssa, &flow, &types)
+    }
+
+    /// `OpCode::scalar_fold` is the single source of truth for "foldable scalar op". This locks the
+    /// three projections that read it: `is_pure_scalar_fold` agrees with `scalar_fold().is_some()`,
+    /// and value numbering (`pure_op_operands`, backed by `op_signature`) only ever fires on a
+    /// foldable op. The one deliberate asymmetry — a witness cast is foldable but never
+    /// value-numbered — is asserted explicitly so it cannot be silently dropped.
+    #[test]
+    fn scalar_fold_is_the_single_classifier() {
+        use super::congruence::pure_op_operands;
+
+        let ssa = HLSSA::with_main("main".to_string());
+        let main = ssa.get_unique_entrypoint_id();
+        let v = || ssa.fresh_value();
+
+        // One instance of every foldable scalar op, each paired with the `ScalarFold` variant it
+        // must decompose to.
+        let foldable: Vec<OpCode> = vec![
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: v(),
+                lhs: v(),
+                rhs: v(),
+            },
+            OpCode::Cmp {
+                kind: CmpKind::Eq,
+                result: v(),
+                lhs: v(),
+                rhs: v(),
+            },
+            OpCode::MulConst {
+                result: v(),
+                const_val: v(),
+                var: v(),
+            },
+            OpCode::Cast {
+                result: v(),
+                value: v(),
+                target: CastTarget::Field,
+            },
+            OpCode::SExt {
+                result: v(),
+                value: v(),
+                from_bits: 8,
+                to_bits: 32,
+            },
+            OpCode::BitRange {
+                result: v(),
+                value: v(),
+                offset: 0,
+                width: 8,
+            },
+            OpCode::Not {
+                result: v(),
+                value: v(),
+            },
+            OpCode::Select {
+                result: v(),
+                cond: v(),
+                if_t: v(),
+                if_f: v(),
+            },
+        ];
+        for instr in &foldable {
+            assert!(instr.is_pure_scalar_fold(), "{instr:?} should be foldable");
+            assert_eq!(
+                instr.is_pure_scalar_fold(),
+                instr.scalar_fold().is_some(),
+                "is_pure_scalar_fold must equal scalar_fold().is_some() for {instr:?}"
+            );
+            // Every foldable op except a witness cast is value-numbered.
+            assert!(
+                pure_op_operands(instr).is_some(),
+                "{instr:?} should be value-numbered"
+            );
+        }
+
+        // The deliberate asymmetry: a witness cast IS a scalar fold but is NOT value-numbered.
+        let witness_cast = OpCode::Cast {
+            result: v(),
+            value: v(),
+            target: CastTarget::WitnessOf,
+        };
+        assert!(witness_cast.is_pure_scalar_fold());
+        assert!(matches!(
+            witness_cast.scalar_fold(),
+            Some(ScalarFold::Cast { .. })
+        ));
+        assert!(pure_op_operands(&witness_cast).is_none());
+
+        // Representative non-folds: not foldable, not value-numbered, no `ScalarFold`.
+        let non_folds: Vec<OpCode> = vec![
+            OpCode::Assert { value: v() },
+            OpCode::Store {
+                ptr: v(),
+                value: v(),
+            },
+            OpCode::Load {
+                result: v(),
+                ptr: v(),
+            },
+            OpCode::Call {
+                results: vec![v()],
+                function: CallTarget::Static(main),
+                args: vec![v()],
+                unconstrained: false,
+            },
+        ];
+        for instr in &non_folds {
+            assert!(
+                !instr.is_pure_scalar_fold(),
+                "{instr:?} should not be foldable"
+            );
+            assert!(instr.scalar_fold().is_none());
+            assert!(
+                pure_op_operands(instr).is_none(),
+                "{instr:?} should not be value-numbered"
+            );
+        }
     }
 
     /// Two values that fold to the *same* constant are congruent, even when computed differently —
@@ -602,6 +891,180 @@ pub(crate) mod tests {
         let cc = run_in_test(&ssa);
         assert!(cc.known_equal(fid, i, j)); // loop-carried congruence
         assert!(cc.known_equal(fid, i2, j2)); // and their parallel updates
+
+        // The dominance-aware leader is the member at the dominating definition: the two header
+        // parameters share a definition site (block entry), so the lower-id one leads; in the body,
+        // the earlier `i2` leads the later `j2`.
+        assert_eq!(cc.leader(fid, i), Some(i));
+        assert_eq!(cc.leader(fid, j), Some(i));
+        assert_eq!(cc.leader(fid, i2), Some(i2));
+        assert_eq!(cc.leader(fid, j2), Some(i2));
+    }
+
+    /// A congruent definition that dominates another is its leader (a legal redirect target); the
+    /// dominated occurrence redirects to the dominating one, and the dominating one leads itself.
+    #[test]
+    fn leader_is_dominating_definition() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let (x, y, a, b) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let next = f.add_block();
+        f.get_entry_mut().push_parameter(x, Type::field());
+        f.get_entry_mut().push_parameter(y, Type::field());
+        // `a = x + y` in the entry, recomputed as `b = x + y` in a strictly dominated block.
+        f.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: y,
+        });
+        f.get_entry_mut()
+            .set_terminator(Terminator::Jmp(next, vec![]));
+        let next_block = f.get_block_mut(next);
+        next_block.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: y,
+        });
+        next_block.set_terminator(Terminator::Return(vec![a, b]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        assert!(cc.known_equal(fid, a, b));
+        assert_eq!(cc.leader(fid, a), Some(a)); // dominating definition leads itself
+        assert_eq!(cc.leader(fid, b), Some(a)); // dominated occurrence redirects to it
+    }
+
+    /// Two congruent ops in one block: the earlier one (by instruction index) leads the later.
+    #[test]
+    fn leader_is_earlier_in_block() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let (x, y, a, b) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let f = ssa.get_unique_entrypoint_mut();
+        f.get_entry_mut().push_parameter(x, Type::field());
+        f.get_entry_mut().push_parameter(y, Type::field());
+        let entry = f.get_entry_mut();
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: y,
+        });
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: y,
+        });
+        entry.set_terminator(Terminator::Return(vec![a, b]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        assert!(cc.known_equal(fid, a, b));
+        assert_eq!(cc.leader(fid, a), Some(a));
+        assert_eq!(cc.leader(fid, b), Some(a));
+    }
+
+    /// Congruent occurrences in two incomparable branches (and one at the merge) have no single
+    /// dominating member, so each is its own leader — the leader is never a non-dominating member,
+    /// so no illegal cross-branch redirect is offered.
+    #[test]
+    fn leader_never_crosses_incomparable_branches() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let (cond, x, y, a, b, c) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let e1 = f.add_block();
+        let e2 = f.add_block();
+        let merge = f.add_block();
+        f.get_entry_mut().push_parameter(cond, Type::u(1));
+        f.get_entry_mut().push_parameter(x, Type::field());
+        f.get_entry_mut().push_parameter(y, Type::field());
+        f.get_entry_mut()
+            .set_terminator(Terminator::JmpIf(cond, e1, e2));
+        // `x + y` recomputed in both incomparable branches and again at the merge.
+        let e1_block = f.get_block_mut(e1);
+        e1_block.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: y,
+        });
+        e1_block.set_terminator(Terminator::Jmp(merge, vec![]));
+        let e2_block = f.get_block_mut(e2);
+        e2_block.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: y,
+        });
+        e2_block.set_terminator(Terminator::Jmp(merge, vec![]));
+        let merge_block = f.get_block_mut(merge);
+        merge_block.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: c,
+            lhs: x,
+            rhs: y,
+        });
+        merge_block.set_terminator(Terminator::Return(vec![a, b, c]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        // All three are congruent...
+        assert!(cc.known_equal(fid, a, b));
+        assert!(cc.known_equal(fid, a, c));
+        // ...but none dominates another, so each leads itself (no cross-branch redirect).
+        assert_eq!(cc.leader(fid, a), Some(a));
+        assert_eq!(cc.leader(fid, b), Some(b));
+        assert_eq!(cc.leader(fid, c), Some(c));
+    }
+
+    /// A computed value proven constant is congruent to the interned constant of the same value, and
+    /// that constant — available throughout the function — is its leader.
+    #[test]
+    fn leader_of_constant_class_is_the_interned_constant() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c2 = ssa.add_const(Constant::U(32, 2));
+        let c3 = ssa.add_const(Constant::U(32, 3));
+        let c5 = ssa.add_const(Constant::U(32, 5));
+        let a = ssa.fresh_value();
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let entry = f.get_entry_mut();
+        // `a = 2 + 3` folds to 5, congruent to the interned constant `c5`.
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: c2,
+            rhs: c3,
+        });
+        entry.set_terminator(Terminator::Return(vec![a, c5]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+        assert!(cc.known_equal(fid, a, c5));
+        assert_eq!(cc.leader(fid, a), Some(c5)); // the constant dominates everywhere
+        assert_eq!(cc.leader(fid, c5), Some(c5));
     }
 
     /// Assert-vacuum soundness: `assert(x == 5)` pins `x` to 5 *conditionally* in dominated blocks,
@@ -999,5 +1462,439 @@ pub(crate) mod tests {
         assert!(cc.asserted_equal(fid, mid, y, x));
         // `y` is undefined at `entry`, so the equality is withheld there.
         assert!(!cc.asserted_equal(fid, entry_id, x, y));
+    }
+
+    /// A callee that returns a constant: the call result folds interprocedurally in the caller's
+    /// context, while the SCCP-visible intraprocedural view leaves it `Bottom`.
+    #[test]
+    fn interproc_constant_return_folds_at_call_site() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let helper = ssa.add_function("helper".to_string());
+        let c5 = ssa.add_const(Constant::Field(Field::from(5u64)));
+        let r = ssa.fresh_value();
+
+        {
+            let hf = ssa.get_function_mut(helper);
+            hf.add_return_type(Type::field());
+            hf.get_entry_mut()
+                .set_terminator(Terminator::Return(vec![c5]));
+        }
+        {
+            let mf = ssa.get_function_mut(main_id);
+            mf.add_return_type(Type::field());
+            let entry = mf.get_entry_mut();
+            entry.push_instruction(OpCode::Call {
+                results: vec![r],
+                function: CallTarget::Static(helper),
+                args: vec![],
+                unconstrained: false,
+            });
+            entry.set_terminator(Terminator::Return(vec![r]));
+        }
+
+        let cc = run_in_test(&ssa);
+        assert_eq!(
+            cc.const_of_in(main_id, &Context::empty(), r).as_deref(),
+            Some(&Constant::Field(Field::from(5u64)))
+        );
+        // The intraprocedural view (what SCCP reads) never folds a call result.
+        assert_eq!(cc.const_of(main_id, r), None);
+    }
+
+    /// A pass-through callee (returns its parameter): the result takes the argument's constant at
+    /// the call site, and the callee's parameter is seeded to it per context.
+    #[test]
+    fn interproc_passthrough_seeds_param_and_result() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let id = ssa.add_function("id".to_string());
+        let p = ssa.fresh_value();
+        let c7 = ssa.add_const(Constant::Field(Field::from(7u64)));
+        let r = ssa.fresh_value();
+
+        {
+            let hf = ssa.get_function_mut(id);
+            hf.add_return_type(Type::field());
+            hf.get_entry_mut().push_parameter(p, Type::field());
+            hf.get_entry_mut()
+                .set_terminator(Terminator::Return(vec![p]));
+        }
+        {
+            let mf = ssa.get_function_mut(main_id);
+            mf.add_return_type(Type::field());
+            let entry = mf.get_entry_mut();
+            entry.push_instruction(OpCode::Call {
+                results: vec![r],
+                function: CallTarget::Static(id),
+                args: vec![c7],
+                unconstrained: false,
+            });
+            entry.set_terminator(Terminator::Return(vec![r]));
+        }
+
+        let cc = run_in_test(&ssa);
+        assert_eq!(
+            cc.const_of_in(main_id, &Context::empty(), r).as_deref(),
+            Some(&Constant::Field(Field::from(7u64)))
+        );
+        let ctxs = cc.contexts_of(id);
+        assert_eq!(ctxs.len(), 1);
+        assert_eq!(
+            cc.const_of_in(id, &ctxs[0], p).as_deref(),
+            Some(&Constant::Field(Field::from(7u64)))
+        );
+    }
+
+    /// The context-parameterized conditional queries. The branch-fact family
+    /// (`const_in_block_in`) is context-*precise* — it sees the per-context parameter constant the
+    /// intraprocedural query cannot — while the assert/witness family forwards to the (sound,
+    /// context-independent) intraprocedural facts.
+    #[test]
+    fn context_parameterized_conditional_queries() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let id = ssa.add_function("id".to_string());
+        let p = ssa.fresh_value();
+        let c7 = ssa.add_const(Constant::Field(Field::from(7u64)));
+        let r = ssa.fresh_value();
+
+        {
+            let hf = ssa.get_function_mut(id);
+            hf.add_return_type(Type::field());
+            hf.get_entry_mut().push_parameter(p, Type::field());
+            hf.get_entry_mut()
+                .set_terminator(Terminator::Return(vec![p]));
+        }
+        {
+            let mf = ssa.get_function_mut(main_id);
+            mf.add_return_type(Type::field());
+            let entry = mf.get_entry_mut();
+            entry.push_instruction(OpCode::Call {
+                results: vec![r],
+                function: CallTarget::Static(id),
+                args: vec![c7],
+                unconstrained: false,
+            });
+            entry.set_terminator(Terminator::Return(vec![r]));
+        }
+
+        let entry_id = ssa.get_function(id).get_entry_id();
+        let cc = run_in_test(&ssa);
+        let ctxs = cc.contexts_of(id);
+        assert_eq!(ctxs.len(), 1);
+        let ctx = &ctxs[0];
+
+        // Intraprocedurally `p` is unconstrained; under the single call context it is the constant 7.
+        assert_eq!(cc.const_in_block(id, entry_id, p), None);
+        assert_eq!(
+            cc.const_in_block_in(id, ctx, entry_id, p).as_deref(),
+            Some(&Constant::Field(Field::from(7u64)))
+        );
+    }
+
+    /// Two call sites of one helper get distinct contexts with distinct per-context parameter
+    /// constants — the 1-CFA win.
+    #[test]
+    fn interproc_two_call_sites_are_distinguished() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let id = ssa.add_function("id".to_string());
+        let p = ssa.fresh_value();
+        let c5 = ssa.add_const(Constant::Field(Field::from(5u64)));
+        let c7 = ssa.add_const(Constant::Field(Field::from(7u64)));
+        let (r5, r7) = (ssa.fresh_value(), ssa.fresh_value());
+
+        {
+            let hf = ssa.get_function_mut(id);
+            hf.add_return_type(Type::field());
+            hf.get_entry_mut().push_parameter(p, Type::field());
+            hf.get_entry_mut()
+                .set_terminator(Terminator::Return(vec![p]));
+        }
+        {
+            let mf = ssa.get_function_mut(main_id);
+            mf.add_return_type(Type::field());
+            let entry = mf.get_entry_mut();
+            entry.push_instruction(OpCode::Call {
+                results: vec![r5],
+                function: CallTarget::Static(id),
+                args: vec![c5],
+                unconstrained: false,
+            });
+            entry.push_instruction(OpCode::Call {
+                results: vec![r7],
+                function: CallTarget::Static(id),
+                args: vec![c7],
+                unconstrained: false,
+            });
+            entry.set_terminator(Terminator::Return(vec![r5, r7]));
+        }
+
+        let cc = run_in_test(&ssa);
+        assert_eq!(
+            cc.const_of_in(main_id, &Context::empty(), r5).as_deref(),
+            Some(&Constant::Field(Field::from(5u64)))
+        );
+        assert_eq!(
+            cc.const_of_in(main_id, &Context::empty(), r7).as_deref(),
+            Some(&Constant::Field(Field::from(7u64)))
+        );
+        let ctxs = cc.contexts_of(id);
+        assert_eq!(ctxs.len(), 2, "two call sites → two contexts");
+        let seen: Vec<Constant> = ctxs
+            .iter()
+            .filter_map(|ctx| cc.const_of_in(id, ctx, p).map(|c| (*c).clone()))
+            .collect();
+        assert_eq!(seen.len(), 2);
+        assert!(seen.contains(&Constant::Field(Field::from(5u64))));
+        assert!(seen.contains(&Constant::Field(Field::from(7u64))));
+    }
+
+    /// An unconstrained call's result is advice, not circuit-constrained: it never folds (even when
+    /// the callee returns a constant) and stays an opaque singleton.
+    #[test]
+    fn unconstrained_call_result_is_opaque() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let helper = ssa.add_function("helper".to_string());
+        let c5 = ssa.add_const(Constant::Field(Field::from(5u64)));
+        let (r1, r2) = (ssa.fresh_value(), ssa.fresh_value());
+
+        {
+            let hf = ssa.get_function_mut(helper);
+            hf.add_return_type(Type::field());
+            hf.get_entry_mut()
+                .set_terminator(Terminator::Return(vec![c5]));
+        }
+        {
+            let mf = ssa.get_function_mut(main_id);
+            mf.add_return_type(Type::field());
+            mf.add_return_type(Type::field());
+            let entry = mf.get_entry_mut();
+            entry.push_instruction(OpCode::Call {
+                results: vec![r1],
+                function: CallTarget::Static(helper),
+                args: vec![],
+                unconstrained: true,
+            });
+            entry.push_instruction(OpCode::Call {
+                results: vec![r2],
+                function: CallTarget::Static(helper),
+                args: vec![],
+                unconstrained: true,
+            });
+            entry.set_terminator(Terminator::Return(vec![r1, r2]));
+        }
+
+        let cc = run_in_test(&ssa);
+        // Even interprocedurally, an unconstrained result is never folded ...
+        assert_eq!(cc.const_of_in(main_id, &Context::empty(), r1), None);
+        assert_eq!(cc.const_of(main_id, r1), None);
+        // ... and two such results are not merged.
+        assert!(!cc.known_equal(main_id, r1, r2));
+    }
+
+    /// Cross-call congruence: a callee whose return is a deterministic function of its arguments is
+    /// value-numbered cross-call, so two calls with congruent arguments yield congruent results —
+    /// and a call with a non-congruent argument does not.
+    #[test]
+    fn cross_call_congruence_for_deterministic_callee() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let dbl = ssa.add_function("dbl".to_string());
+        let p = ssa.fresh_value();
+        let psum = ssa.fresh_value();
+
+        // dbl(p) = p + p — deterministic in its argument.
+        {
+            let hf = ssa.get_function_mut(dbl);
+            hf.add_return_type(Type::field());
+            hf.get_entry_mut().push_parameter(p, Type::field());
+            hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: psum,
+                lhs: p,
+                rhs: p,
+            });
+            hf.get_entry_mut()
+                .set_terminator(Terminator::Return(vec![psum]));
+        }
+
+        let c1 = ssa.add_const(Constant::Field(Field::from(1u64)));
+        let (x, y) = (ssa.fresh_value(), ssa.fresh_value());
+        let (a, b) = (ssa.fresh_value(), ssa.fresh_value());
+        let (r1, r2, r3) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+        {
+            let mf = ssa.get_function_mut(main_id);
+            mf.add_return_type(Type::field());
+            mf.add_return_type(Type::field());
+            mf.add_return_type(Type::field());
+            mf.get_entry_mut().push_parameter(x, Type::field());
+            mf.get_entry_mut().push_parameter(y, Type::field());
+            let entry = mf.get_entry_mut();
+            // `a` and `b` are structurally congruent (both `x + 1`); `y` is distinct.
+            entry.push_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: a,
+                lhs: x,
+                rhs: c1,
+            });
+            entry.push_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: b,
+                lhs: x,
+                rhs: c1,
+            });
+            entry.push_instruction(OpCode::Call {
+                results: vec![r1],
+                function: CallTarget::Static(dbl),
+                args: vec![a],
+                unconstrained: false,
+            });
+            entry.push_instruction(OpCode::Call {
+                results: vec![r2],
+                function: CallTarget::Static(dbl),
+                args: vec![b],
+                unconstrained: false,
+            });
+            entry.push_instruction(OpCode::Call {
+                results: vec![r3],
+                function: CallTarget::Static(dbl),
+                args: vec![y],
+                unconstrained: false,
+            });
+            entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
+        }
+
+        let cc = run_in_test(&ssa);
+        assert!(cc.known_equal(main_id, r1, r2)); // congruent args ⇒ congruent results
+        assert!(!cc.known_equal(main_id, r1, r3)); // distinct arg ⇒ distinct result
+    }
+
+    /// A callee whose return carries a fresh witness is *not* a deterministic function of its
+    /// arguments, so its results are never numbered cross-call — two such calls stay distinct (the
+    /// determinism gate that protects the free-witness non-merge prohibition).
+    #[test]
+    fn cross_call_no_congruence_for_nondeterministic_callee() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let rnd = ssa.add_function("rnd".to_string());
+        let w = ssa.fresh_value();
+
+        {
+            let hf = ssa.get_function_mut(rnd);
+            hf.add_return_type(Type::field());
+            hf.get_entry_mut().push_instruction(OpCode::FreshWitness {
+                result: w,
+                result_type: Type::field(),
+            });
+            hf.get_entry_mut()
+                .set_terminator(Terminator::Return(vec![w]));
+        }
+        let (r1, r2) = (ssa.fresh_value(), ssa.fresh_value());
+        {
+            let mf = ssa.get_function_mut(main_id);
+            mf.add_return_type(Type::field());
+            mf.add_return_type(Type::field());
+            let entry = mf.get_entry_mut();
+            entry.push_instruction(OpCode::Call {
+                results: vec![r1],
+                function: CallTarget::Static(rnd),
+                args: vec![],
+                unconstrained: false,
+            });
+            entry.push_instruction(OpCode::Call {
+                results: vec![r2],
+                function: CallTarget::Static(rnd),
+                args: vec![],
+                unconstrained: false,
+            });
+            entry.set_terminator(Terminator::Return(vec![r1, r2]));
+        }
+
+        let cc = run_in_test(&ssa);
+        assert!(!cc.known_equal(main_id, r1, r2));
+    }
+
+    /// Determinism is interprocedural: `outer` is deterministic because the `inner` it calls is, so
+    /// its results are numbered cross-call too.
+    #[test]
+    fn cross_call_congruence_is_transitive() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let inner = ssa.add_function("inner".to_string());
+        let outer = ssa.add_function("outer".to_string());
+
+        let ip = ssa.fresh_value();
+        let isum = ssa.fresh_value();
+        {
+            let hf = ssa.get_function_mut(inner);
+            hf.add_return_type(Type::field());
+            hf.get_entry_mut().push_parameter(ip, Type::field());
+            hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: isum,
+                lhs: ip,
+                rhs: ip,
+            });
+            hf.get_entry_mut()
+                .set_terminator(Terminator::Return(vec![isum]));
+        }
+        let op = ssa.fresh_value();
+        let ores = ssa.fresh_value();
+        {
+            let hf = ssa.get_function_mut(outer);
+            hf.add_return_type(Type::field());
+            hf.get_entry_mut().push_parameter(op, Type::field());
+            hf.get_entry_mut().push_instruction(OpCode::Call {
+                results: vec![ores],
+                function: CallTarget::Static(inner),
+                args: vec![op],
+                unconstrained: false,
+            });
+            hf.get_entry_mut()
+                .set_terminator(Terminator::Return(vec![ores]));
+        }
+
+        let c1 = ssa.add_const(Constant::Field(Field::from(1u64)));
+        let x = ssa.fresh_value();
+        let (a, b) = (ssa.fresh_value(), ssa.fresh_value());
+        let (r1, r2) = (ssa.fresh_value(), ssa.fresh_value());
+        {
+            let mf = ssa.get_function_mut(main_id);
+            mf.add_return_type(Type::field());
+            mf.add_return_type(Type::field());
+            mf.get_entry_mut().push_parameter(x, Type::field());
+            let entry = mf.get_entry_mut();
+            entry.push_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: a,
+                lhs: x,
+                rhs: c1,
+            });
+            entry.push_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: b,
+                lhs: x,
+                rhs: c1,
+            });
+            entry.push_instruction(OpCode::Call {
+                results: vec![r1],
+                function: CallTarget::Static(outer),
+                args: vec![a],
+                unconstrained: false,
+            });
+            entry.push_instruction(OpCode::Call {
+                results: vec![r2],
+                function: CallTarget::Static(outer),
+                args: vec![b],
+                unconstrained: false,
+            });
+            entry.set_terminator(Terminator::Return(vec![r1, r2]));
+        }
+
+        let cc = run_in_test(&ssa);
+        assert!(cc.known_equal(main_id, r1, r2));
     }
 }

--- a/compiler/src/compiler/analysis/click_cooper/solver.rs
+++ b/compiler/src/compiler/analysis/click_cooper/solver.rs
@@ -14,10 +14,11 @@ use crate::{
                 Constness, bool_constness, const_bool, const_join, eval_binary, eval_bit_range,
                 eval_cast, eval_cmp, eval_field_mul, eval_not, eval_sext,
             },
+            summary::{DetSummaries, FnSummary, ReturnJump},
         },
         ssa::{
-            BlockId, Instruction, Terminator, ValueId,
-            hlssa::{Constant, HLFunction, HLSSAConstantsSnapshot, OpCode},
+            BlockId, FunctionId, Instruction, Terminator, ValueId,
+            hlssa::{CallTarget, Constant, HLFunction, HLSSAConstantsSnapshot, OpCode, ScalarFold},
         },
     },
 };
@@ -62,7 +63,7 @@ pub(crate) struct FunctionFacts {
 // ================================================================================================
 
 /// The fact solver for a single function.
-pub(crate) struct FunctionSolver<'f, 'c> {
+pub(crate) struct FunctionSolver<'f, 'c, 's> {
     /// The function being solved.
     function: &'f HLFunction,
 
@@ -95,9 +96,26 @@ pub(crate) struct FunctionSolver<'f, 'c> {
 
     /// For each value: the sites that read it. `None` marks the block's terminator.
     uses: HashMap<ValueId, Vec<(BlockId, Option<usize>)>>,
+
+    /// Interprocedural jump-function summaries, used to fold the results of constrained static
+    /// `Call`s into the constant lattice.
+    ///
+    /// `None` (the default) is the intraprocedural mode the SCCP-visible facts use: every `Call`
+    /// result is `Bottom`.
+    summaries: Option<&'s HashMap<FunctionId, FnSummary>>,
+
+    /// Per-`(callee, return-index)` determinism bits, used when building the congruence partition
+    /// to number deterministic static-call results cross-call.
+    ///
+    /// `None` (the default) leaves every call result opaque, identical to the prior behavior.
+    det: Option<&'s DetSummaries>,
+
+    /// Entry-parameter seeds for a context-sensitive solve: an entry parameter maps to the constant
+    /// the calling context proved for the matching argument. Absent params default to `Bottom`.
+    param_seeds: HashMap<ValueId, Constness>,
 }
 
-impl<'f, 'c> FunctionSolver<'f, 'c> {
+impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
     pub(crate) fn new(function: &'f HLFunction, consts: &'c HLSSAConstantsSnapshot) -> Self {
         let mut uses: HashMap<ValueId, Vec<(BlockId, Option<usize>)>> = HashMap::default();
         for (bid, block) in function.get_blocks() {
@@ -129,15 +147,43 @@ impl<'f, 'c> FunctionSolver<'f, 'c> {
             edge_worklist: Vec::new(),
             value_worklist: Vec::new(),
             uses,
+            summaries: None,
+            det: None,
+            param_seeds: HashMap::default(),
         }
+    }
+
+    /// Fold constrained static `Call` results via these interprocedural summaries.
+    pub(crate) fn with_summaries(mut self, summaries: &'s HashMap<FunctionId, FnSummary>) -> Self {
+        self.summaries = Some(summaries);
+        self
+    }
+
+    /// Number deterministic static-call results cross-call using these determinism bits.
+    pub(crate) fn with_determinism(mut self, det: &'s DetSummaries) -> Self {
+        self.det = Some(det);
+        self
+    }
+
+    /// Seed entry parameters with the calling context's argument constants.
+    pub(crate) fn with_param_seeds(mut self, seeds: HashMap<ValueId, Constness>) -> Self {
+        self.param_seeds = seeds;
+        self
     }
 
     pub(crate) fn run(&mut self) {
         let entry = self.function.get_entry_id();
 
-        // Entry parameters are the function's arguments — unknown (`Bottom`) intraprocedurally.
+        // Entry parameters are the function's arguments. Intraprocedurally they are unknown
+        // (`Bottom`); a context-sensitive solve seeds them with the calling context's argument
+        // constants via `param_seeds`.
         for (p, _) in self.function.get_entry().get_parameters() {
-            self.lattice.insert(*p, Constness::Bottom);
+            let seed = self
+                .param_seeds
+                .get(p)
+                .cloned()
+                .unwrap_or(Constness::Bottom);
+            self.lattice.insert(*p, seed);
         }
         self.reachable.insert(entry);
         self.block_facts.insert(entry, BoolFacts::default());
@@ -159,16 +205,19 @@ impl<'f, 'c> FunctionSolver<'f, 'c> {
 
     /// Convert the solver into facts.
     pub(crate) fn into_facts(self) -> FunctionFacts {
-        let congruence =
-            Congruence::build(
-                self.function,
-                &self.reachable,
-                &self.exec_edges,
-                |v| match self.lattice_of(v) {
-                    Constness::Const(c) => Some(c),
-                    Constness::Top | Constness::Bottom => None,
-                },
-            );
+        let det = self.det;
+        let congruence = Congruence::build(
+            self.function,
+            &self.reachable,
+            &self.exec_edges,
+            |v| match self.lattice_of(v) {
+                Constness::Const(c) => Some(c),
+                Constness::Top | Constness::Bottom => None,
+            },
+            |g, j| {
+                det.is_some_and(|d| d.get(&g).and_then(|rets| rets.get(j)).copied() == Some(true))
+            },
+        );
 
         FunctionFacts {
             lattice: self.lattice,
@@ -350,22 +399,16 @@ impl<'f, 'c> FunctionSolver<'f, 'c> {
         }
 
         let params: Vec<ValueId> = block.get_parameter_values().copied().collect();
-        let mut updates = Vec::with_capacity(indices.map_or(params.len(), <[usize]>::len));
 
+        // Recompute the chosen parameters in place: `indices` selects which, and `None` recomputes
+        // them all (the common full-recompute path).
+        let recompute = |this: &mut Self, i: usize| {
+            let lat = this.join_param(b, preds, i);
+            this.set_lattice(params[i], lat);
+        };
         match indices {
-            Some(indices) => {
-                for &i in indices {
-                    updates.push((params[i], self.join_param(b, preds, i)));
-                }
-            }
-            None => {
-                for i in 0..params.len() {
-                    updates.push((params[i], self.join_param(b, preds, i)));
-                }
-            }
-        }
-        for (p, lat) in updates {
-            self.set_lattice(p, lat);
+            Some(indices) => indices.iter().for_each(|&i| recompute(self, i)),
+            None => (0..params.len()).for_each(|i| recompute(self, i)),
         }
     }
 
@@ -449,115 +492,98 @@ impl<'f, 'c> FunctionSolver<'f, 'c> {
 
     /// The transfer function: new lattice values for the instruction's results.
     fn transfer(&self, bid: BlockId, instr: &OpCode) -> Vec<(ValueId, Constness)> {
-        match instr {
-            OpCode::BinaryArithOp {
-                kind,
-                result,
-                lhs,
-                rhs,
-            } => vec![(
-                *result,
-                self.eval2(bid, *lhs, *rhs, |a, b| eval_binary(*kind, a, b)),
-            )],
-            OpCode::Cmp {
-                kind,
-                result,
-                lhs,
-                rhs,
-            } => vec![(
-                *result,
-                self.eval2(bid, *lhs, *rhs, |a, b| eval_cmp(*kind, a, b)),
-            )],
-            OpCode::MulConst {
-                result,
-                const_val,
-                var,
-            } => vec![(*result, self.eval2(bid, *const_val, *var, eval_field_mul))],
-            OpCode::Cast {
-                result,
-                value,
-                target,
-            } => vec![(*result, self.eval1(bid, *value, |v| eval_cast(target, v)))],
-            OpCode::SExt {
-                result,
+        // A constrained static `Call` folds its results via the callee's interprocedural
+        // jump-function summary (when summaries are supplied). Without summaries every result is
+        // `Bottom`. It is not a scalar fold, so it is handled before the `scalar_fold` projection.
+        if let OpCode::Call {
+            results,
+            function,
+            args,
+            unconstrained,
+        } = instr
+        {
+            return self.eval_call(bid, function, args, results, *unconstrained);
+        }
+
+        // Foldable scalar ops are evaluated; everything else (memory, witness ops, asserts,
+        // sequences, ...) is overdefined. `scalar_fold` is the single source of truth for which
+        // opcodes are foldable, so this can never disagree with `OpCode::is_pure_scalar_fold` or
+        // `op_signature` — no cross-classifier assertion is needed.
+        let Some(fold) = instr.scalar_fold() else {
+            return instr
+                .get_results()
+                .map(|r| (*r, Constness::Bottom))
+                .collect();
+        };
+
+        let value = match fold {
+            ScalarFold::Bin { kind, lhs, rhs } => {
+                self.eval2(bid, lhs, rhs, |a, b| eval_binary(kind, a, b))
+            }
+            ScalarFold::Cmp { kind, lhs, rhs } => {
+                self.eval2(bid, lhs, rhs, |a, b| eval_cmp(kind, a, b))
+            }
+            ScalarFold::MulConst { const_val, var } => {
+                self.eval2(bid, const_val, var, eval_field_mul)
+            }
+            ScalarFold::Cast { target, value } => self.eval1(bid, value, |v| eval_cast(target, v)),
+            ScalarFold::SExt {
                 value,
                 from_bits,
                 to_bits,
-            } => vec![(
-                *result,
-                self.eval1(bid, *value, |v| eval_sext(v, *from_bits, *to_bits)),
-            )],
-            OpCode::BitRange {
-                result,
+            } => self.eval1(bid, value, |v| eval_sext(v, from_bits, to_bits)),
+            ScalarFold::BitRange {
                 value,
                 offset,
                 width,
-            } => vec![(
-                *result,
-                self.eval1(bid, *value, |v| eval_bit_range(v, *offset, *width)),
-            )],
-            OpCode::Not { result, value } => vec![(*result, self.eval1(bid, *value, eval_not))],
-            OpCode::Select {
-                result,
-                cond,
-                if_t,
-                if_f,
-            } => vec![(*result, self.eval_select(bid, *cond, *if_t, *if_f))],
+            } => self.eval1(bid, value, |v| eval_bit_range(v, offset, width)),
+            ScalarFold::Not { value } => self.eval1(bid, value, eval_not),
+            ScalarFold::Select { cond, if_t, if_f } => self.eval_select(bid, cond, if_t, if_f),
+        };
 
-            // Everything else — including `Call`, whose result is unknown intraprocedurally, is
-            // overdefined. The rewrite relies on this: a constant-valued instruction result is
-            // always the output of one of the pure scalar ops above. Spelled out variant by variant
-            // (no catch-all) so that adding an opcode forces a decision here.
-            OpCode::Call { .. }
-            | OpCode::MkSeq { .. }
-            | OpCode::MkSeqOfBlob { .. }
-            | OpCode::MkRepeated { .. }
-            | OpCode::Alloc { .. }
-            | OpCode::Store { .. }
-            | OpCode::Load { .. }
-            | OpCode::Assert { .. }
-            | OpCode::AssertCmp { .. }
-            | OpCode::AssertR1C { .. }
-            | OpCode::ArrayGet { .. }
-            | OpCode::ArraySet { .. }
-            | OpCode::SlicePush { .. }
-            | OpCode::SliceLen { .. }
-            | OpCode::ToBits { .. }
-            | OpCode::ToRadix { .. }
-            | OpCode::MemOp { .. }
-            | OpCode::WriteWitness { .. }
-            | OpCode::FreshWitness { .. }
-            | OpCode::NextDCoeff { .. }
-            | OpCode::BumpD { .. }
-            | OpCode::Constrain { .. }
-            | OpCode::Lookup { .. }
-            | OpCode::DLookup { .. }
-            | OpCode::Rangecheck { .. }
-            | OpCode::ReadGlobal { .. }
-            | OpCode::TupleProj { .. }
-            | OpCode::TupleRefProj { .. }
-            | OpCode::MkTuple { .. }
-            | OpCode::Todo { .. }
-            | OpCode::InitGlobal { .. }
-            | OpCode::DropGlobal { .. }
-            | OpCode::Spread { .. }
-            | OpCode::Unspread { .. }
-            | OpCode::Guard { .. } => {
-                // Single source of truth: anything overdefined here must not be classified as a
-                // deletable pure scalar fold, or SCCP would drop a side-effecting / constrained
-                // instruction whose result it aliased to a constant. The reverse direction (a fold
-                // wrongly marked non-foldable) is caught by the byte-identical corpus gate.
-                debug_assert!(
-                    !instr.is_pure_scalar_fold(),
-                    "transfer treats {instr:?} as overdefined but OpCode::is_pure_scalar_fold \
-                     classifies it as a deletable fold; the two must agree"
-                );
-                instr
-                    .get_results()
-                    .map(|r| (*r, Constness::Bottom))
-                    .collect()
-            }
+        // Every scalar fold is single-result; map keeps that contract without an `unwrap`.
+        instr.get_results().map(|r| (*r, value.clone())).collect()
+    }
+
+    /// Fold a `Call`'s results through the callee's jump-function summary.
+    ///
+    /// Only constrained static calls to a summarized function fold; an unconstrained call (results
+    /// are advice, not circuit-constrained), a dynamic call (unknown target), or a summary-less /
+    /// non-interprocedural solve leaves every result `Bottom`. A `Param(i)` jump function resolves
+    /// to the *in-context* constant of argument `i`, so a passthrough callee yields per-call-site
+    /// constant results without re-solving the callee.
+    fn eval_call(
+        &self,
+        bid: BlockId,
+        function: &CallTarget,
+        args: &[ValueId],
+        results: &[ValueId],
+        unconstrained: bool,
+    ) -> Vec<(ValueId, Constness)> {
+        let all_bottom = || results.iter().map(|r| (*r, Constness::Bottom)).collect();
+        if unconstrained {
+            return all_bottom();
         }
+        let (Some(summaries), CallTarget::Static(g)) = (self.summaries, function) else {
+            return all_bottom();
+        };
+        let Some(summary) = summaries.get(g) else {
+            return all_bottom();
+        };
+        results
+            .iter()
+            .enumerate()
+            .map(|(j, r)| {
+                let c = match summary.returns.get(j) {
+                    Some(ReturnJump::Const(c)) => Constness::Const(c.clone()),
+                    Some(ReturnJump::Param(i)) if *i < args.len() => {
+                        self.lattice_in_block(bid, args[*i])
+                    }
+                    _ => Constness::Bottom,
+                };
+                (*r, c)
+            })
+            .collect()
     }
 
     /// Evaluate a 1-argument function `f` on `v` in the context of `bid`.

--- a/compiler/src/compiler/analysis/click_cooper/solver.rs
+++ b/compiler/src/compiler/analysis/click_cooper/solver.rs
@@ -12,7 +12,7 @@ use crate::{
             congruence::Congruence,
             lattice::{
                 Constness, bool_constness, const_bool, const_join, eval_binary, eval_bit_range,
-                eval_cast, eval_cmp, eval_field_mul, eval_not, eval_sext,
+                eval_cast, eval_cmp, eval_not, eval_sext,
             },
             summary::{DetSummaries, FnSummary, ReturnJump},
         },
@@ -523,9 +523,11 @@ impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
             ScalarFold::Cmp { kind, lhs, rhs } => {
                 self.eval2(bid, lhs, rhs, |a, b| eval_cmp(kind, a, b))
             }
-            ScalarFold::MulConst { const_val, var } => {
-                self.eval2(bid, const_val, var, eval_field_mul)
-            }
+
+            // `MulConst` is `const_val(field) * var(WitnessOf<…>)`. `var` is always a witness, so
+            // it is never a lattice `Const` — the fold could never fire (and field-domain
+            // multiplication must never inherit integer `Mul` width/overflow rules).
+            ScalarFold::MulConst { .. } => Constness::Bottom,
             ScalarFold::Cast { target, value } => self.eval1(bid, value, |v| eval_cast(target, v)),
             ScalarFold::SExt {
                 value,

--- a/compiler/src/compiler/analysis/click_cooper/summary.rs
+++ b/compiler/src/compiler/analysis/click_cooper/summary.rs
@@ -1,0 +1,504 @@
+//! The interprocedural layer: a return-determinism pass (Phase 0), polymorphic jump-function
+//! summaries (Phase 1) and 1-CFA per-context specialization (Phase 2), mirroring the two-phase
+//! structure of `analysis/points_to`.
+//!
+//! # Phase 0: Return Determinism
+//!
+//! [`compute_determinism`] records, per function and per return position, whether that return is a
+//! *deterministic function of the function's arguments*.
+//!
+//! It is a greatest-fixpoint: every return starts assumed deterministic and a return is lowered to
+//! non-deterministic when its value's backward slice reaches a non-deterministic source (a fresh
+//! witness, a memory read, a global, an unconstrained or dynamic call, …) or a non-deterministic
+//! callee return. These bits drive the *cross-call congruence* in [`super::congruence`]: two
+//! constrained static calls to one callee with operandwise-congruent arguments produce congruent
+//! results exactly when the callee's return is deterministic.
+//!
+//! # Phase 1: Summaries
+//!
+//! [`compute_summaries`] runs a call-graph worklist and, for each function, records a
+//! [`ReturnJump`] per return position. The return is a `Const`, a pass-through of a formal
+//! parameter (`Param(i)`), or `Bottom`.
+//!
+//! A function is solved with its callees' current summaries (so a return that forwards a
+//! constant-returning call is itself `Const`), but with parameters left `Bottom` — the summary is
+//! *polymorphic* over call sites. The summary lattice is finite, so the worklist converges.
+//!
+//! # Phase 2: Specialization
+//!
+//! [`specialize`] re-solves each reachable `(function, context)` with its entry parameters seeded
+//! by the calling context's argument constants, so two call sites of one helper get distinct
+//! per-context constants. A context is a `k`-limited call string ([`K`]).
+//!
+//! This is sound without an address-token exclusion as a context's parameter seeds are the **meet**
+//! of the argument constants over _every_ static call path that reaches it. Thus, a per-context
+//! constant holds on every concrete invocation mapped to that context. Seeds are monotone and
+//! contexts finite, so the specialization worklist converges.
+
+use std::{collections::VecDeque, sync::Arc};
+
+use crate::{
+    collections::{HashMap, HashSet},
+    compiler::{
+        analysis::{
+            call_string::Context,
+            click_cooper::{
+                congruence::pure_op_operands,
+                lattice::{Constness, const_join},
+                solver::{FunctionFacts, FunctionSolver},
+            },
+            flow_analysis::FlowAnalysis,
+        },
+        ssa::{
+            FunctionId, Instruction, Terminator, ValueId,
+            hlssa::{CallTarget, Constant, HLSSA, HLSSAConstantsSnapshot, OpCode},
+        },
+    },
+};
+
+// CONSTANTS
+// ================================================================================================
+
+/// Call-string depth for the context-sensitive (Phase 2) pass — 1-CFA.
+const K: usize = 1;
+
+// DETERMINISM (PHASE 0)
+// ================================================================================================
+
+/// Per-function return-position determinism: `det[g][j] == true` iff return position `j` of `g` is a
+/// deterministic function of `g`'s arguments.
+pub(crate) type DetSummaries = HashMap<FunctionId, Vec<bool>>;
+
+/// Solve every function's per-return determinism to a fixpoint over the call graph.
+pub(crate) fn compute_determinism(ssa: &HLSSA, flow: &FlowAnalysis) -> DetSummaries {
+    // Optimistic: every return position starts deterministic; the worklist only ever lowers a bit to
+    // false. A return is deterministic if its body's non-deterministic sources never reach it, which
+    // (for a recursive function) holds at the greatest fixpoint started from "all true".
+    call_graph_fixpoint(
+        ssa,
+        flow,
+        |f| vec![true; ssa.get_function(f).get_returns().len()],
+        |f, det| analyze_determinism(ssa, det, f),
+    )
+}
+
+/// Project `fid`'s per-return determinism given its callees' current bits.
+///
+/// A value is **non-deterministic** ("tainted") if produced by a non-deterministic source, by a
+/// pure operator/φ with a tainted operand, or by a constrained static call whose corresponding
+/// return is non-deterministic (or which is passed a tainted argument). Taint is propagated forward
+/// to a fixpoint, *ignoring reachability* (a value tainted only on a dead edge is conservatively
+/// kept tainted, which is sound). Return `j` is deterministic iff no `Return`'s `j`-th value is
+/// tainted.
+fn analyze_determinism(ssa: &HLSSA, det: &DetSummaries, fid: FunctionId) -> Vec<bool> {
+    let func = ssa.get_function(fid);
+    let arity = func.get_returns().len();
+    if arity == 0 {
+        return Vec::new();
+    }
+
+    let mut tainted: HashSet<ValueId> = HashSet::default();
+    loop {
+        let mut changed = false;
+        for (_, block) in func.get_blocks() {
+            for instr in block.get_instructions() {
+                let results: Vec<ValueId> = instr.get_results().copied().collect();
+                if results.is_empty() {
+                    continue;
+                }
+                let taints: Vec<bool> = if let Some(operands) = pure_op_operands(instr) {
+                    // A pure value-numbering op (single result): tainted iff some operand is.
+                    let t = operands.iter().any(|o| tainted.contains(o));
+                    vec![t; results.len()]
+                } else if let OpCode::Call {
+                    function: CallTarget::Static(g),
+                    args,
+                    unconstrained: false,
+                    ..
+                } = instr
+                {
+                    // A constrained static call: result `j` is deterministic only if the callee's
+                    // return `j` is and every argument is.
+                    let arg_tainted = args.iter().any(|a| tainted.contains(a));
+                    (0..results.len())
+                        .map(|j| {
+                            arg_tainted || det.get(g).and_then(|r| r.get(j)).copied() != Some(true)
+                        })
+                        .collect()
+                } else {
+                    // A non-deterministic source: witnesses, memory, globals, lookups, unconstrained
+                    // / dynamic calls, and anything else not a deterministic function of operands.
+                    vec![true; results.len()]
+                };
+                for (r, t) in results.iter().zip(taints) {
+                    if t && tainted.insert(*r) {
+                        changed = true;
+                    }
+                }
+            }
+
+            // A φ (block parameter) is tainted if any incoming jump-arg at its index is tainted.
+            if let Some(Terminator::Jmp(target, args)) = block.get_terminator() {
+                let params: Vec<ValueId> = func
+                    .get_block(*target)
+                    .get_parameter_values()
+                    .copied()
+                    .collect();
+                for (i, a) in args.iter().enumerate() {
+                    if i < params.len() && tainted.contains(a) && tainted.insert(params[i]) {
+                        changed = true;
+                    }
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    let mut det_bits = vec![true; arity];
+    for (_, block) in func.get_blocks() {
+        if let Some(Terminator::Return(vals)) = block.get_terminator() {
+            for (j, v) in vals.iter().enumerate() {
+                if j < arity && tainted.contains(v) {
+                    det_bits[j] = false;
+                }
+            }
+        }
+    }
+    det_bits
+}
+
+// SUMMARIES (PHASE 1)
+// ================================================================================================
+
+/// How one return value relates to a function's formals — a constant-propagation jump function.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum ReturnJump {
+    /// Always this constant, regardless of arguments.
+    Const(Arc<Constant>),
+
+    /// Equal to formal parameter `i` (a pass-through): at a call site the result takes argument
+    /// `i`'s constant.
+    ///
+    /// Also a congruence pass-through (`result ≡ arg i`).
+    Param(usize),
+
+    /// Unknown.
+    Bottom,
+}
+
+/// A function's interprocedural summary: a jump function per return position.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct FnSummary {
+    pub returns: Vec<ReturnJump>,
+}
+
+/// Phase 1: solve every function's polymorphic summary to a fixpoint over the call graph.
+pub(crate) fn compute_summaries(
+    ssa: &HLSSA,
+    flow: &FlowAnalysis,
+    consts: &HLSSAConstantsSnapshot,
+    det: &DetSummaries,
+) -> HashMap<FunctionId, FnSummary> {
+    // Polymorphic over call sites: callees folded via their current summaries, parameters `Bottom`.
+    call_graph_fixpoint(
+        ssa,
+        flow,
+        |_| FnSummary::default(),
+        |f, summaries| analyze_function(ssa, consts, det, f, summaries),
+    )
+}
+
+/// Solve `fid` polymorphically (parameters `Bottom`, callees folded via `summaries`) and project
+/// its return jump functions.
+fn analyze_function(
+    ssa: &HLSSA,
+    consts: &HLSSAConstantsSnapshot,
+    det: &DetSummaries,
+    fid: FunctionId,
+    summaries: &HashMap<FunctionId, FnSummary>,
+) -> FnSummary {
+    let func = ssa.get_function(fid);
+    let arity = func.get_returns().len();
+    if arity == 0 {
+        return FnSummary::default();
+    }
+
+    let mut solver = FunctionSolver::new(func, consts)
+        .with_summaries(summaries)
+        .with_determinism(det);
+    solver.run();
+    let facts = solver.into_facts();
+
+    let params: Vec<ValueId> = param_values(ssa, fid);
+    let returns: Vec<&Vec<ValueId>> = func
+        .get_blocks()
+        .filter(|(bid, _)| facts.reachable.contains(*bid))
+        .filter_map(|(_, block)| match block.get_terminator() {
+            Some(Terminator::Return(vals)) => Some(vals),
+            _ => None,
+        })
+        .collect();
+
+    // No reachable return (the function always traps): nothing flows out.
+    if returns.is_empty() {
+        return FnSummary {
+            returns: vec![ReturnJump::Bottom; arity],
+        };
+    }
+
+    let jumps = (0..arity)
+        .map(|j| return_jump(consts, &facts, &params, &returns, j))
+        .collect();
+    FnSummary { returns: jumps }
+}
+
+/// The jump function for return position `j`, joined over every reachable `Return`.
+fn return_jump(
+    consts: &HLSSAConstantsSnapshot,
+    facts: &FunctionFacts,
+    params: &[ValueId],
+    returns: &[&Vec<ValueId>],
+    j: usize,
+) -> ReturnJump {
+    // Constant only if every reachable return yields the same constant at position `j`.
+    let mut c = Constness::Top;
+    let mut all_present = true;
+    for vals in returns {
+        match vals.get(j) {
+            Some(rv) => c = const_join(c, value_const(consts, facts, *rv)),
+            None => all_present = false,
+        }
+    }
+    if let Constness::Const(k) = c {
+        return ReturnJump::Const(k);
+    }
+    if !all_present {
+        return ReturnJump::Bottom;
+    }
+
+    // Otherwise a pass-through if some single parameter is congruent to the return on *every* path.
+    // One scratch set, refined monotonically to the running intersection: later returns only
+    // re-check the shrinking candidate set, and an empty intersection short-circuits the rest.
+    let mut candidates: Option<HashSet<usize>> = None;
+    for vals in returns {
+        let rv = vals[j];
+        match &mut candidates {
+            None => {
+                candidates = Some(
+                    (0..params.len())
+                        .filter(|&i| rv == params[i] || facts.congruence.known_equal(rv, params[i]))
+                        .collect(),
+                );
+            }
+            Some(set) => {
+                set.retain(|&i| rv == params[i] || facts.congruence.known_equal(rv, params[i]));
+                if set.is_empty() {
+                    break;
+                }
+            }
+        }
+    }
+    match candidates.and_then(|set| set.iter().min().copied()) {
+        Some(i) => ReturnJump::Param(i),
+        None => ReturnJump::Bottom,
+    }
+}
+
+// SPECIALIZATION (PHASE 2)
+// ================================================================================================
+
+/// Phase 2: re-solve every reachable `(function, context)` with parameters seeded by the calling
+/// context's argument constants.
+pub(crate) fn specialize(
+    ssa: &HLSSA,
+    flow: &FlowAnalysis,
+    consts: &HLSSAConstantsSnapshot,
+    summaries: &HashMap<FunctionId, FnSummary>,
+    det: &DetSummaries,
+) -> HashMap<(FunctionId, Context), FunctionFacts> {
+    let main = ssa.get_unique_entrypoint_id();
+
+    // Entry-parameter values per function, collected once and borrowed throughout: the worklist
+    // would otherwise re-walk a function's parameters on every dequeue and every visited call site.
+    let param_index: HashMap<FunctionId, Vec<ValueId>> = ssa
+        .get_function_ids()
+        .map(|f| (f, param_values(ssa, f)))
+        .collect();
+
+    // Per-context entry-parameter seeds, met over all reaching static call paths. A `Top` seed
+    // means "no path seen yet"; joining the first argument constant replaces it.
+    let mut seeds: HashMap<(FunctionId, Context), Vec<Constness>> = HashMap::default();
+    let mut results: HashMap<(FunctionId, Context), FunctionFacts> = HashMap::default();
+    let mut in_worklist: HashSet<(FunctionId, Context)> = HashSet::default();
+    let mut worklist: VecDeque<(FunctionId, Context)> = VecDeque::new();
+
+    // `main`'s arguments are external inputs: `Bottom`.
+    let start = (main, Context::empty());
+    seeds.insert(
+        start.clone(),
+        vec![Constness::Bottom; param_index[&main].len()],
+    );
+    in_worklist.insert(start.clone());
+    worklist.push_back(start);
+
+    while let Some((f, ctx)) = worklist.pop_front() {
+        in_worklist.remove(&(f, ctx.clone()));
+
+        let params = &param_index[&f];
+        let seed_vec = seeds
+            .get(&(f, ctx.clone()))
+            .cloned()
+            .unwrap_or_else(|| vec![Constness::Bottom; params.len()]);
+        let seed_map: HashMap<ValueId, Constness> = params
+            .iter()
+            .copied()
+            .zip(seed_vec.into_iter().map(seed_or_bottom))
+            .collect();
+
+        let func = ssa.get_function(f);
+        let mut solver = FunctionSolver::new(func, consts)
+            .with_summaries(summaries)
+            .with_determinism(det)
+            .with_param_seeds(seed_map);
+        solver.run();
+        let mut facts = solver.into_facts();
+
+        // Build the dominance-aware congruence leaders so `leader_in` yields a legal redirect
+        // target.
+        facts
+            .congruence
+            .compute_leaders(func, flow.get_function_cfg(f));
+
+        // Propagate argument constants from each reachable static call into the callee's context.
+        for (bid, block) in func.get_blocks() {
+            if !facts.reachable.contains(bid) {
+                continue;
+            }
+
+            for instr in block.get_instructions() {
+                let OpCode::Call {
+                    results: call_results,
+                    function: CallTarget::Static(g),
+                    args,
+                    unconstrained: false,
+                } = instr
+                else {
+                    continue;
+                };
+
+                let g = *g;
+                if !summaries.contains_key(&g) {
+                    continue;
+                }
+
+                let site = call_results.first().or_else(|| args.first()).copied();
+                let g_ctx = match site {
+                    Some(v) => ctx.push((f, v), K),
+                    None => ctx.clone(),
+                };
+                let g_params = &param_index[&g];
+
+                let entry = seeds
+                    .entry((g, g_ctx.clone()))
+                    .or_insert_with(|| vec![Constness::Top; g_params.len()]);
+                let mut grew = false;
+                for i in 0..g_params.len() {
+                    let arg = match args.get(i) {
+                        Some(a) => value_const(consts, &facts, *a),
+                        None => Constness::Bottom,
+                    };
+                    let joined = const_join(entry[i].clone(), arg);
+                    if joined != entry[i] {
+                        entry[i] = joined;
+                        grew = true;
+                    }
+                }
+
+                let unseen = !results.contains_key(&(g, g_ctx.clone()));
+                if (grew || unseen) && in_worklist.insert((g, g_ctx.clone())) {
+                    worklist.push_back((g, g_ctx));
+                }
+            }
+        }
+
+        results.insert((f, ctx), facts);
+    }
+
+    results
+}
+
+// HELPERS
+// ================================================================================================
+
+/// Solve a per-function fact to a fixpoint over the call graph.
+///
+/// Every function starts at `init(f)`. The worklist is seeded callee-first (post-order from `main`,
+/// then any function unreachable from `main` so none is dropped) and `analyze(f, &map)` re-runs
+/// whenever a callee's fact changed, until nothing moves. The accumulator is passed to `analyze`, so
+/// a function is solved against its callees' current facts.
+fn call_graph_fixpoint<T: PartialEq>(
+    ssa: &HLSSA,
+    flow: &FlowAnalysis,
+    init: impl Fn(FunctionId) -> T,
+    analyze: impl Fn(FunctionId, &HashMap<FunctionId, T>) -> T,
+) -> HashMap<FunctionId, T> {
+    let main = ssa.get_unique_entrypoint_id();
+    let fids: Vec<FunctionId> = ssa.get_function_ids().collect();
+    let mut map: HashMap<FunctionId, T> = fids.iter().map(|f| (*f, init(*f))).collect();
+
+    let call_graph = flow.get_call_graph();
+    let mut order: Vec<FunctionId> = call_graph
+        .get_post_order(main)
+        .filter(|f| map.contains_key(f))
+        .collect();
+    let mut queued: HashSet<FunctionId> = order.iter().copied().collect();
+    for f in &fids {
+        if queued.insert(*f) {
+            order.push(*f);
+        }
+    }
+    let mut worklist: VecDeque<FunctionId> = order.into();
+
+    while let Some(f) = worklist.pop_front() {
+        queued.remove(&f);
+        let new = analyze(f, &map);
+        if map[&f] != new {
+            map.insert(f, new);
+            for c in call_graph.get_callers(f) {
+                if map.contains_key(&c) && queued.insert(c) {
+                    worklist.push_back(c);
+                }
+            }
+        }
+    }
+    map
+}
+
+/// The entry-parameter values of `f`, in order.
+fn param_values(ssa: &HLSSA, f: FunctionId) -> Vec<ValueId> {
+    ssa.get_function(f)
+        .get_entry()
+        .get_parameters()
+        .map(|(p, _)| *p)
+        .collect()
+}
+
+/// The unconditional constant of `v` in a solved function: an interned constant, the lattice's
+/// constant, or `Bottom` (a reachable, used value is never left at `Top`).
+fn value_const(consts: &HLSSAConstantsSnapshot, facts: &FunctionFacts, v: ValueId) -> Constness {
+    if let Some(c) = consts.get(&v) {
+        return Constness::Const(c.clone());
+    }
+    facts.lattice.get(&v).cloned().unwrap_or(Constness::Bottom)
+}
+
+/// A `Top` seed (no reaching path recorded) means the parameter is effectively unconstrained for
+/// the solve, so it is started at `Bottom`.
+fn seed_or_bottom(c: Constness) -> Constness {
+    match c {
+        Constness::Top => Constness::Bottom,
+        other => other,
+    }
+}

--- a/compiler/src/compiler/analysis/click_cooper/summary.rs
+++ b/compiler/src/compiler/analysis/click_cooper/summary.rs
@@ -126,8 +126,9 @@ fn analyze_determinism(ssa: &HLSSA, det: &DetSummaries, fid: FunctionId) -> Vec<
                         })
                         .collect()
                 } else {
-                    // A non-deterministic source: witnesses, memory, globals, lookups, unconstrained
-                    // / dynamic calls, and anything else not a deterministic function of operands.
+                    // A non-deterministic source: witnesses, memory, globals, lookups, dynamic or
+                    // unconstrained calls, and anything else not a deterministic function of its
+                    // operands.
                     vec![true; results.len()]
                 };
                 for (r, t) in results.iter().zip(taints) {

--- a/compiler/src/compiler/passes/sparse_conditional_constant_propagation.rs
+++ b/compiler/src/compiler/passes/sparse_conditional_constant_propagation.rs
@@ -95,7 +95,15 @@ fn rewrite(function: &mut HLFunction, ssa: &HLSSA, cc: &ClickCooper, fid: Functi
             {
                 let mut results = instr.get_results();
                 if let (Some(r), None) = (results.next(), results.next()) {
-                    if const_set.contains(r) && instr.is_pure_scalar_fold() {
+                    let is_const = const_set.contains(r);
+                    assert!(
+                        !is_const || instr.is_pure_scalar_fold(),
+                        "ICE::SCCP: result {r:?} of non-pure-scalar instruction {instr:?} is in the \
+                         constant set; the intraprocedural ClickCooper facts must never fold a \
+                         non-pure-scalar op to a constant"
+                    );
+
+                    if is_const && instr.is_pure_scalar_fold() {
                         continue;
                     }
                 }

--- a/compiler/src/compiler/ssa/hlssa/mod.rs
+++ b/compiler/src/compiler/ssa/hlssa/mod.rs
@@ -1723,7 +1723,7 @@ pub enum CmpKind {
 // SEQUENCE TYPE
 // ================================================================================================
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SequenceTargetType {
     Array(usize),
     Slice,
@@ -1936,7 +1936,7 @@ impl Display for Endianness {
 // SLICE OPERAND DIRECTION
 // ================================================================================================
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SliceOpDir {
     Front,
     Back,

--- a/compiler/src/compiler/ssa/hlssa/mod.rs
+++ b/compiler/src/compiler/ssa/hlssa/mod.rs
@@ -10,6 +10,7 @@ use crate::compiler::ssa::{
     Block, Function, FunctionId, Instruction, Located, SSA, SSAConstants, SSAConstantsSnapshot,
     ValueId,
 };
+
 pub use type_system::{MAX_SUPPORTED_SIGNED_BITS, MAX_SUPPORTED_UNSIGNED_BITS, Type, TypeExpr};
 
 // HLSSA
@@ -262,21 +263,56 @@ pub enum OpCode {
 }
 
 impl OpCode {
-    /// `true` if `self` is capable of being a pure, side-effect-free, single-result scalar op that
-    /// can be folded to a constant and have the defining instruction deleted.
-    ///
-    /// Note that this requires the caller to verify that the operation's lack of side effects holds
-    /// in context (e.g. a given multiplication cannot overflow).
-    pub fn is_pure_scalar_fold(&self) -> bool {
+    /// The [`ScalarFold`] decomposition of `self`, or `None` for any op that is not a pure
+    /// single-result scalar fold (memory, witness ops, asserts, sequences, calls, ...).
+    pub fn scalar_fold(&self) -> Option<ScalarFold<'_>> {
         match self {
-            OpCode::Cmp { .. }
-            | OpCode::BinaryArithOp { .. }
-            | OpCode::Cast { .. }
-            | OpCode::SExt { .. }
-            | OpCode::BitRange { .. }
-            | OpCode::Not { .. }
-            | OpCode::Select { .. }
-            | OpCode::MulConst { .. } => true,
+            OpCode::BinaryArithOp { kind, lhs, rhs, .. } => Some(ScalarFold::Bin {
+                kind: *kind,
+                lhs: *lhs,
+                rhs: *rhs,
+            }),
+            OpCode::Cmp { kind, lhs, rhs, .. } => Some(ScalarFold::Cmp {
+                kind: *kind,
+                lhs: *lhs,
+                rhs: *rhs,
+            }),
+            OpCode::MulConst { const_val, var, .. } => Some(ScalarFold::MulConst {
+                const_val: *const_val,
+                var: *var,
+            }),
+            OpCode::Cast { value, target, .. } => Some(ScalarFold::Cast {
+                target,
+                value: *value,
+            }),
+            OpCode::SExt {
+                value,
+                from_bits,
+                to_bits,
+                ..
+            } => Some(ScalarFold::SExt {
+                value: *value,
+                from_bits: *from_bits,
+                to_bits: *to_bits,
+            }),
+            OpCode::BitRange {
+                value,
+                offset,
+                width,
+                ..
+            } => Some(ScalarFold::BitRange {
+                value: *value,
+                offset: *offset,
+                width: *width,
+            }),
+            OpCode::Not { value, .. } => Some(ScalarFold::Not { value: *value }),
+            OpCode::Select {
+                cond, if_t, if_f, ..
+            } => Some(ScalarFold::Select {
+                cond: *cond,
+                if_t: *if_t,
+                if_f: *if_f,
+            }),
 
             OpCode::MkSeq { .. }
             | OpCode::MkSeqOfBlob { .. }
@@ -312,8 +348,17 @@ impl OpCode {
             | OpCode::DropGlobal { .. }
             | OpCode::Spread { .. }
             | OpCode::Unspread { .. }
-            | OpCode::Guard { .. } => false,
+            | OpCode::Guard { .. } => None,
         }
+    }
+
+    /// `true` if `self` is a pure, side-effect-free, single-result scalar op that can be folded to
+    /// a constant and have the defining instruction deleted. See [`ScalarFold`].
+    ///
+    /// Note that this requires the caller to verify that the operation's lack of side effects holds
+    /// in context (e.g. a given multiplication cannot overflow).
+    pub fn is_pure_scalar_fold(&self) -> bool {
+        self.scalar_fold().is_some()
     }
 }
 
@@ -1621,6 +1666,24 @@ impl Instruction for OpCode {
 
 pub type HLFunction = Function<OpCode, Type>;
 pub type HLBlock = Block<OpCode, Type>;
+
+// SCALAR FOLD
+// ================================================================================================
+
+/// A pure, side-effect-free, single-result scalar op that may fold to a constant, decomposed into
+/// its operation and operands.
+///
+/// This is the **single source of truth** that defines which opcodes are foldable scalar ops.
+pub enum ScalarFold<'a> {
+    Bin { kind: BinaryArithOpKind, lhs: ValueId, rhs: ValueId },
+    Cmp { kind: CmpKind, lhs: ValueId, rhs: ValueId },
+    MulConst { const_val: ValueId, var: ValueId },
+    Cast { target: &'a CastTarget, value: ValueId },
+    SExt { value: ValueId, from_bits: usize, to_bits: usize },
+    BitRange { value: ValueId, offset: usize, width: usize },
+    Not { value: ValueId },
+    Select { cond: ValueId, if_t: ValueId, if_f: ValueId },
+}
 
 // CALL TARGET
 // ================================================================================================


### PR DESCRIPTION
The previous version of the analysis was designed to include the major backbone, but not the features needed for more-proficient optimizations upstream. This commit adds additional functionality to Click-Cooper that enables it to perform more-detailed, interprocedural analyses that approximate whole-program analysis.

Partial work for #260.