### PR TITLE
Implement writebacks in Click-Cooper

### DIFF
--- a/compiler/src/compiler/analysis/click_cooper/mod.rs
+++ b/compiler/src/compiler/analysis/click_cooper/mod.rs
@@ -25,6 +25,21 @@
 //! facts** are those established through control flow (branches, assertions, witness operations)
 //! that are only correct to use in contexts where the establishing constraints are preserved.
 //!
+//! # Combined-Fixpoint Writeback
+//!
+//! The constant and reachability factors feed congruence (constants seed the partition,
+//! reachability scopes φ-operands), and congruence feeds *back*: a comparison whose operands are
+//! proven congruent is a constant the lattice alone cannot derive — `x == y` is unconditionally
+//! `true` and `x < y` unconditionally `false` when `x` and `y` are congruent.
+//!
+//! Each solve therefore alternates: solve constants/reachability, build congruence, promote those
+//! comparison results to constants, and re-solve so the new constants fold branches and cascade (a
+//! folded branch prunes an edge, which re-scopes φ-operands, which can expose further congruences
+//! and constants). This repeats until no new fact appears. It is monotone — promotions only grow,
+//! executable edges only shrink — so it converges, and it is strictly stronger than running the
+//! constant and congruence factors separately. This is what makes the analysis "combined" rather
+//! than merely "staged".
+//!
 //! # Correctness
 //!
 //! This analysis is **sound** because each fact class is sound, with the reasoning given as
@@ -37,6 +52,11 @@
 //! - **Congruence:** Two values are congruent iff computed by the same operator from operand-wise
 //!   congruent inputs, hence equal in all runs. Congruence never asserts an equality an adversarial
 //!   witness could validate.
+//! - **Combined-Fixpoint Writeback:** A comparison of congruent operands is folded to a constant
+//!   only via `known_equal`, which holds in every run under any advice (two free witnesses are
+//!   never made congruent), so `x == y → true` / `x < y → false` are exact. The resulting edge
+//!   folding reuses the reachability mechanism above; only the (pure, scalar) comparison result is
+//!   promoted, so the fact stays safe to replace, delete, or prune on.
 //! - **Interprocedural Constants:** A `return_const` jump function holds for any arguments; a
 //!   `return Param(i)` pass-through equals argument `i` exactly. Per-context parameter seeds are
 //!   the meet of the argument constants over *every* static call path mapped to that context, so a
@@ -77,13 +97,6 @@
 //!
 //! The following are improvements planned for the future of this analysis.
 //!
-//! - **Combined-Fixpoint Writebacks:** Congruence runs as a single pass over the converged
-//!   reachability rather than interleaved with the constant worklist, because the reverse couplings
-//!   are not wired: a congruence class with a `Const` member does not promote its peers into the
-//!   (SCCP-visible) constant lattice, and a branch condition congruent to a constant does not fold
-//!   an edge. These pay off only in a consumer that exploits the full combined fixpoint; until such
-//!   a consumer exists, omitting them keeps SCCP's output unchanged. A future consumer can recover
-//!   the promotion by composing [`ClickCooper::known_equal`] with [`ClickCooper::const_of`].
 //! - **Assert Facts at Index Granularity:** Assert-derived facts are attributed at block-entry
 //!   granularity via *strict* dominance/post-dominance, so a use in the asserting block itself
 //!   (after the assert) is not yet claimed. Index-precise program points would recover it; soundness
@@ -122,7 +135,7 @@ use crate::{
             click_cooper::{
                 conditional::ConditionalFacts,
                 lattice::{Constness, bool_constant},
-                solver::{FunctionFacts, FunctionSolver},
+                solver::{FunctionFacts, solve_with_writeback},
                 summary::{compute_determinism, compute_summaries, specialize},
             },
             flow_analysis::FlowAnalysis,
@@ -195,9 +208,14 @@ impl ClickCooper {
         let mut conditional = HashMap::default();
         for fid in ssa.get_function_ids() {
             let function = ssa.get_function(fid);
-            let mut solver = FunctionSolver::new(function, &consts).with_determinism(&det);
-            solver.run();
-            let mut facts = solver.into_facts();
+
+            // Combined-fixpoint writeback (intraprocedural, summary-free): solve constants +
+            // reachability, then fold a comparison of congruent operands to a constant and re-solve
+            // until no new fact appears (see `solve_with_writeback`). `summaries = None` keeps every
+            // `Call` result `Bottom` — the contract SCCP reads `functions` under — and round 0 has
+            // empty promotions, so a function with no such comparison is solved once and unchanged.
+            let mut facts =
+                solve_with_writeback(function, &consts, &det, None, &HashMap::default());
 
             // Finalize dominance-aware congruence leaders against the function's CFG, so `leader`
             // returns a legal redirect target.
@@ -324,8 +342,13 @@ impl ClickCooper {
 ///
 /// These read the specialized `contexts` map (never the SCCP-visible `functions` view), so they are
 /// disjoint from the intraprocedural queries above. They are unconditional facts *within* their
-/// context: a caller's argument constants seed the callee's parameters, and constant-returning
-/// calls fold.
+/// context: a caller's argument constants seed the callee's parameters, constant-returning calls
+/// fold, and the combined-fixpoint writeback folds comparisons of congruent operands per context.
+///
+/// A consumer must respect two contracts these facts inherit. First, a `const_of_in` / `leader_in`
+/// answer is conditional on the context `ctx`, so it must drive a context-specialized rewrite only
+/// — never lift it into a context-independent edit. Second, when a writeback-folded constant is a
+/// `WitnessOf`-typed comparison result, the substitution must keep it witness-typed.
 impl ClickCooper {
     /// The constant `v` provably holds in `f` under calling context `ctx`, or `None`.
     pub fn const_of_in(&self, f: FunctionId, ctx: &Context, v: ValueId) -> Option<Arc<Constant>> {
@@ -1685,10 +1708,224 @@ pub(crate) mod tests {
         );
     }
 
-    /// The context-parameterized conditional queries. The branch-fact family
-    /// (`const_in_block_in`) is context-*precise* — it sees the per-context parameter constant the
-    /// intraprocedural query cannot — while the assert/witness family forwards to the (sound,
-    /// context-independent) intraprocedural facts.
+    /// Interprocedural writeback through a summary: a callee that *returns* a comparison of
+    /// congruent operands gets a `Const` summary return-jump (the writeback runs in the polymorphic
+    /// summary solve), so the call result folds in the caller's context. Without it the return jump
+    /// is `Bottom` and the call result is unknown.
+    #[test]
+    fn interproc_writeback_folds_congruent_comparison_return() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let g = ssa.add_function("g".to_string());
+        let c1 = ssa.add_const(Constant::U(32, 1));
+        let (x, a, b, eq) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+        let (x0, r) = (ssa.fresh_value(), ssa.fresh_value());
+
+        // g(x) = ((x + 1) == (x + 1)) — a vacuous comparison of congruent operands.
+        {
+            let gf = ssa.get_function_mut(g);
+            gf.add_return_type(Type::u(1));
+            gf.get_entry_mut().push_parameter(x, Type::u(32));
+            let entry = gf.get_entry_mut();
+            entry.push_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: a,
+                lhs: x,
+                rhs: c1,
+            });
+            entry.push_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: b,
+                lhs: x,
+                rhs: c1,
+            });
+            entry.push_instruction(OpCode::Cmp {
+                kind: CmpKind::Eq,
+                result: eq,
+                lhs: a,
+                rhs: b,
+            });
+            entry.set_terminator(Terminator::Return(vec![eq]));
+        }
+        {
+            let mf = ssa.get_function_mut(main_id);
+            mf.add_return_type(Type::u(1));
+            mf.get_entry_mut().push_parameter(x0, Type::u(32));
+            let entry = mf.get_entry_mut();
+            entry.push_instruction(OpCode::Call {
+                results: vec![r],
+                function: CallTarget::Static(g),
+                args: vec![x0],
+                unconstrained: false,
+            });
+            entry.set_terminator(Terminator::Return(vec![r]));
+        }
+
+        let cc = run_in_test(&ssa);
+        // The summary return-jump is `Const(true)`, so the call result folds in the caller context.
+        assert_eq!(
+            cc.const_of_in(main_id, &Context::empty(), r).as_deref(),
+            Some(&Constant::U(1, 1))
+        );
+        // The intraprocedural view (what SCCP reads) never folds a call result.
+        assert_eq!(cc.const_of(main_id, r), None);
+    }
+
+    /// Interprocedural writeback in a specialized context: a comparison of congruent operands kept
+    /// *internal* to a callee folds in that callee's per-context facts (read via `const_of_in`).
+    /// This exercises the writeback in `specialize`'s per-context solve specifically — the fold is
+    /// observable only through `contexts`, which the summary solve does not populate.
+    #[test]
+    fn interproc_writeback_folds_congruent_comparison_in_context() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let g = ssa.add_function("g".to_string());
+        let c1 = ssa.add_const(Constant::U(32, 1));
+        let (x, a, b, eq) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+        let (x0, r) = (ssa.fresh_value(), ssa.fresh_value());
+
+        // g(x) computes `eq = (x + 1) == (x + 1)` but returns `x`, so `eq` is observable only
+        // through g's per-context facts.
+        {
+            let gf = ssa.get_function_mut(g);
+            gf.add_return_type(Type::u(32));
+            gf.get_entry_mut().push_parameter(x, Type::u(32));
+            let entry = gf.get_entry_mut();
+            entry.push_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: a,
+                lhs: x,
+                rhs: c1,
+            });
+            entry.push_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: b,
+                lhs: x,
+                rhs: c1,
+            });
+            entry.push_instruction(OpCode::Cmp {
+                kind: CmpKind::Eq,
+                result: eq,
+                lhs: a,
+                rhs: b,
+            });
+            entry.set_terminator(Terminator::Return(vec![x]));
+        }
+        {
+            let mf = ssa.get_function_mut(main_id);
+            mf.add_return_type(Type::u(32));
+            mf.get_entry_mut().push_parameter(x0, Type::u(32));
+            let entry = mf.get_entry_mut();
+            entry.push_instruction(OpCode::Call {
+                results: vec![r],
+                function: CallTarget::Static(g),
+                args: vec![x0],
+                unconstrained: false,
+            });
+            entry.set_terminator(Terminator::Return(vec![r]));
+        }
+
+        let cc = run_in_test(&ssa);
+        let ctxs = cc.contexts_of(g);
+        assert_eq!(ctxs.len(), 1);
+        // The internal comparison folds within g's single context.
+        assert_eq!(
+            cc.const_of_in(g, &ctxs[0], eq).as_deref(),
+            Some(&Constant::U(1, 1))
+        );
+        // Intraprocedurally (no context) the call result in main is still not folded.
+        assert_eq!(cc.const_of(main_id, r), None);
+    }
+
+    /// The interprocedural writeback terminates under recursion: a self-recursive callee with a
+    /// vacuous comparison in its body still reaches a fixpoint (the summary solve stays monotone),
+    /// and the comparison folds in every context.
+    #[test]
+    fn interproc_writeback_terminates_under_recursion() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let g = ssa.add_function("g".to_string());
+        let c1 = ssa.add_const(Constant::U(32, 1));
+        let (x, a, b, eq, t) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+        let (x0, r) = (ssa.fresh_value(), ssa.fresh_value());
+
+        // g(x) = { eq = (x + 1) == (x + 1); let _ = g(x); eq } — self-recursive.
+        {
+            let gf = ssa.get_function_mut(g);
+            gf.add_return_type(Type::u(1));
+            gf.get_entry_mut().push_parameter(x, Type::u(32));
+            let entry = gf.get_entry_mut();
+            entry.push_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: a,
+                lhs: x,
+                rhs: c1,
+            });
+            entry.push_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: b,
+                lhs: x,
+                rhs: c1,
+            });
+            entry.push_instruction(OpCode::Cmp {
+                kind: CmpKind::Eq,
+                result: eq,
+                lhs: a,
+                rhs: b,
+            });
+            entry.push_instruction(OpCode::Call {
+                results: vec![t],
+                function: CallTarget::Static(g),
+                args: vec![x],
+                unconstrained: false,
+            });
+            entry.set_terminator(Terminator::Return(vec![eq]));
+        }
+        {
+            let mf = ssa.get_function_mut(main_id);
+            mf.add_return_type(Type::u(1));
+            mf.get_entry_mut().push_parameter(x0, Type::u(32));
+            let entry = mf.get_entry_mut();
+            entry.push_instruction(OpCode::Call {
+                results: vec![r],
+                function: CallTarget::Static(g),
+                args: vec![x0],
+                unconstrained: false,
+            });
+            entry.set_terminator(Terminator::Return(vec![r]));
+        }
+
+        let cc = run_in_test(&ssa);
+        let ctxs = cc.contexts_of(g);
+        assert!(!ctxs.is_empty());
+        for ctx in &ctxs {
+            assert_eq!(
+                cc.const_of_in(g, ctx, eq).as_deref(),
+                Some(&Constant::U(1, 1))
+            );
+        }
+    }
+
+    /// The context-parameterized conditional queries. The branch-fact family (`const_in_block_in`)
+    /// is context-*precise* — it sees the per-context parameter constant the intraprocedural query
+    /// cannot — while the assert/witness family forwards to the (sound, context-independent)
+    /// intraprocedural facts.
     #[test]
     fn context_parameterized_conditional_queries() {
         let mut ssa = HLSSA::with_main("main".to_string());
@@ -2119,5 +2356,367 @@ pub(crate) mod tests {
         let cc = run_in_test(&ssa);
         assert!(cc.known_equal(main_id, r1, r2)); // congruent array args ⇒ congruent results
         assert!(!cc.known_equal(main_id, r1, r3)); // distinct array arg ⇒ distinct result
+    }
+
+    /// The headline combined-fixpoint writeback: `CmpEq(a, b)` with `a` and `b` proven congruent
+    /// folds to `true` even though neither is constant, and the false edge of the branch it decides
+    /// is pruned. Neither SCCP (operands not constant) nor plain GVN (does not fold comparisons)
+    /// reaches this alone.
+    #[test]
+    fn cmp_eq_of_congruent_operands_folds_and_prunes_dead_edge() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c1 = ssa.add_const(Constant::U(32, 1));
+        let (x, a, b, eq) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let then_b = f.add_block();
+        let else_b = f.add_block();
+        f.get_entry_mut().push_parameter(x, Type::u(32));
+        let entry = f.get_entry_mut();
+        // a = x + 1 and b = x + 1 are structurally congruent but not constant.
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: a,
+            rhs: b,
+        });
+        entry.set_terminator(Terminator::JmpIf(eq, then_b, else_b));
+        f.get_block_mut(then_b)
+            .set_terminator(Terminator::Return(vec![a]));
+        f.get_block_mut(else_b)
+            .set_terminator(Terminator::Return(vec![b]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let entry_id = ssa.get_unique_entrypoint().get_entry_id();
+        let cc = run_in_test(&ssa);
+
+        assert!(cc.known_equal(fid, a, b));
+        // The comparison is now an unconditional constant `true`.
+        assert_eq!(cc.const_of(fid, eq).as_deref(), Some(&Constant::U(1, 1)));
+        // ...so the branch is decided: only the then-edge is executable.
+        assert!(cc.is_executable_edge(fid, entry_id, then_b));
+        assert!(!cc.is_executable_edge(fid, entry_id, else_b));
+        assert!(cc.is_reachable(fid, then_b));
+        assert!(!cc.is_reachable(fid, else_b));
+    }
+
+    /// The writeback cascades: deciding a congruence-derived branch prunes an edge, leaving a merge
+    /// parameter with a single constant in-edge — a constant SCCP alone (which sees both edges live)
+    /// cannot derive.
+    #[test]
+    fn writeback_cascades_to_downstream_constant() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c1 = ssa.add_const(Constant::U(32, 1));
+        let c5 = ssa.add_const(Constant::U(32, 5));
+        let c7 = ssa.add_const(Constant::U(32, 7));
+        let (x, a, b, eq, p) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let then_b = f.add_block();
+        let else_b = f.add_block();
+        let merge = f.add_block();
+        f.get_entry_mut().push_parameter(x, Type::u(32));
+        let entry = f.get_entry_mut();
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: a,
+            rhs: b,
+        });
+        entry.set_terminator(Terminator::JmpIf(eq, then_b, else_b));
+        // The dead else-edge would carry a different constant, forcing the merge to ⊥ under SCCP
+        // alone.
+        f.get_block_mut(then_b)
+            .set_terminator(Terminator::Jmp(merge, vec![c5]));
+        f.get_block_mut(else_b)
+            .set_terminator(Terminator::Jmp(merge, vec![c7]));
+        let merge_block = f.get_block_mut(merge);
+        merge_block.push_parameter(p, Type::u(32));
+        merge_block.set_terminator(Terminator::Return(vec![p]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        assert!(!cc.is_reachable(fid, else_b));
+        assert_eq!(cc.const_of(fid, p).as_deref(), Some(&Constant::U(32, 5)));
+    }
+
+    /// Guard: a comparison of values that are *not* congruent stays unfolded and both branch targets
+    /// stay reachable.
+    #[test]
+    fn cmp_eq_of_noncongruent_operands_is_not_folded() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let (x, y, eq) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let then_b = f.add_block();
+        let else_b = f.add_block();
+        f.get_entry_mut().push_parameter(x, Type::u(32));
+        f.get_entry_mut().push_parameter(y, Type::u(32));
+        let entry = f.get_entry_mut();
+        entry.push_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: x,
+            rhs: y,
+        });
+        entry.set_terminator(Terminator::JmpIf(eq, then_b, else_b));
+        f.get_block_mut(then_b)
+            .set_terminator(Terminator::Return(vec![x]));
+        f.get_block_mut(else_b)
+            .set_terminator(Terminator::Return(vec![y]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        assert!(!cc.known_equal(fid, x, y));
+        assert_eq!(cc.const_of(fid, eq), None);
+        assert!(cc.is_reachable(fid, then_b));
+        assert!(cc.is_reachable(fid, else_b));
+    }
+
+    /// Soundness boundary: two free witnesses are never congruent, so a comparison of them is never
+    /// folded — the writeback cannot fabricate an equality an adversarial witness could break.
+    #[test]
+    fn free_witnesses_are_not_congruent_so_comparison_not_folded() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let (w1, w2, eq) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let entry = f.get_entry_mut();
+        entry.push_instruction(OpCode::FreshWitness {
+            result: w1,
+            result_type: Type::field(),
+        });
+        entry.push_instruction(OpCode::FreshWitness {
+            result: w2,
+            result_type: Type::field(),
+        });
+        entry.push_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: w1,
+            rhs: w2,
+        });
+        entry.set_terminator(Terminator::Return(vec![eq]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        assert!(!cc.known_equal(fid, w1, w2));
+        assert_eq!(cc.const_of(fid, eq), None);
+    }
+
+    /// The writeback adds nothing when no comparison has congruent operands: a plain non-constant
+    /// computation yields no new constants (so a function without such a comparison is unchanged).
+    #[test]
+    fn writeback_is_noop_without_congruent_comparison() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c1 = ssa.add_const(Constant::U(32, 1));
+        let (x, a) = (ssa.fresh_value(), ssa.fresh_value());
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let entry = f.get_entry_mut();
+        entry.push_parameter(x, Type::u(32));
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.set_terminator(Terminator::Return(vec![a]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        assert_eq!(cc.const_of(fid, a), None);
+        assert!(cc.new_const_values(fid).is_empty());
+    }
+
+    /// `CmpLt(a, b)` with `a` and `b` congruent folds to `false` — `x < x` is never true.
+    #[test]
+    fn cmp_lt_of_congruent_operands_folds_false() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c1 = ssa.add_const(Constant::U(32, 1));
+        let (x, a, b, lt) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let f = ssa.get_unique_entrypoint_mut();
+        f.get_entry_mut().push_parameter(x, Type::u(32));
+        let entry = f.get_entry_mut();
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_instruction(OpCode::Cmp {
+            kind: CmpKind::Lt,
+            result: lt,
+            lhs: a,
+            rhs: b,
+        });
+        entry.set_terminator(Terminator::Return(vec![lt]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        assert!(cc.known_equal(fid, a, b));
+        assert_eq!(cc.const_of(fid, lt).as_deref(), Some(&Constant::U(1, 0)));
+    }
+
+    /// A comparison of congruent operands folds to a constant `true` even when it is *witnessed*
+    /// (its result is `WitnessOf`-typed, as emitted by witness spilling / AD lowering) — the
+    /// must-equal fact holds either way. Keeping the substituted constant witness-typed is the
+    /// consumer's job; see the SCCP test `witnessed_constant_is_cast_to_witness_of`.
+    #[test]
+    fn witnessed_comparison_of_congruent_operands_is_promoted() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let (w, ww, n, nn) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let entry = f.get_entry_mut();
+        entry.push_parameter(w, Type::witness_of(Type::u(32)));
+        entry.push_parameter(n, Type::u(32));
+        // Witnessed comparison: an operand is `WitnessOf`, so the result is `WitnessOf(u1)`.
+        entry.push_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: ww,
+            lhs: w,
+            rhs: w,
+        });
+        // Plain comparison: result is `u1`.
+        entry.push_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: nn,
+            lhs: n,
+            rhs: n,
+        });
+        entry.set_terminator(Terminator::Return(vec![ww, nn]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        // Both compare congruent (identical) operands, so both fold to `true` — the witnessed one
+        // too. (SCCP then keeps `ww` witness-typed via a cast; the analysis fact is the same.)
+        assert!(cc.known_equal(fid, w, w));
+        assert!(cc.known_equal(fid, n, n));
+        assert_eq!(cc.const_of(fid, ww).as_deref(), Some(&Constant::U(1, 1)));
+        assert_eq!(cc.const_of(fid, nn).as_deref(), Some(&Constant::U(1, 1)));
+    }
+
+    /// Combined-analysis win unreachable to either factor alone: two loop-carried parallel induction
+    /// variables are congruent (optimistic GVN), so `i == j` folds to `true` even though neither `i`
+    /// nor `j` is constant.
+    #[test]
+    fn loop_carried_congruent_comparison_folds_true() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c0 = ssa.add_const(Constant::U(32, 0));
+        let c1 = ssa.add_const(Constant::U(32, 1));
+        let c10 = ssa.add_const(Constant::U(32, 10));
+        let (i, j, lt, eq, i2, j2) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let header = f.add_block();
+        let body = f.add_block();
+        let exit = f.add_block();
+
+        f.get_entry_mut()
+            .set_terminator(Terminator::Jmp(header, vec![c0, c0]));
+        let header_block = f.get_block_mut(header);
+        header_block.push_parameter(i, Type::u(32));
+        header_block.push_parameter(j, Type::u(32));
+        header_block.push_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: i,
+            rhs: j,
+        });
+        header_block.push_instruction(OpCode::Cmp {
+            kind: CmpKind::Lt,
+            result: lt,
+            lhs: i,
+            rhs: c10,
+        });
+        header_block.set_terminator(Terminator::JmpIf(lt, body, exit));
+        let body_block = f.get_block_mut(body);
+        body_block.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: i2,
+            lhs: i,
+            rhs: c1,
+        });
+        body_block.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: j2,
+            lhs: j,
+            rhs: c1,
+        });
+        body_block.set_terminator(Terminator::Jmp(header, vec![i2, j2]));
+        f.get_block_mut(exit)
+            .set_terminator(Terminator::Return(vec![i, j]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        assert!(cc.known_equal(fid, i, j));
+        assert_eq!(cc.const_of(fid, eq).as_deref(), Some(&Constant::U(1, 1)));
     }
 }

--- a/compiler/src/compiler/analysis/click_cooper/solver.rs
+++ b/compiler/src/compiler/analysis/click_cooper/solver.rs
@@ -13,14 +13,17 @@ use crate::{
         analysis::click_cooper::{
             congruence::Congruence,
             lattice::{
-                Constness, bool_constness, const_bool, const_join, eval_binary, eval_bit_range,
-                eval_cast, eval_cmp, eval_not, eval_sext,
+                Constness, bool_constant, bool_constness, const_bool, const_join, eval_binary,
+                eval_bit_range, eval_cast, eval_cmp, eval_not, eval_sext,
             },
             summary::{DetSummaries, FnSummary, ReturnJump},
         },
         ssa::{
             BlockId, FunctionId, Instruction, Terminator, ValueId,
-            hlssa::{CallTarget, Constant, HLFunction, HLSSAConstantsSnapshot, OpCode, ScalarFold},
+            hlssa::{
+                CallTarget, CmpKind, Constant, HLFunction, HLSSAConstantsSnapshot, OpCode,
+                ScalarFold,
+            },
         },
     },
 };
@@ -31,6 +34,16 @@ use crate::{
 /// Per-block branch predicate facts: a value known true/false on entry to the block, recorded only
 /// when every executable incoming edge proves the same boolean.
 pub(crate) type BoolFacts = HashMap<ValueId, bool>;
+
+// CONSTANTS
+// ================================================================================================
+
+/// The maximum number of per-function solver rounds in the combined-fixpoint writeback (round 0 is
+/// the base solve; the rest refine with congruence-derived promotions).
+///
+/// The writeback is monotone and converges well before this, so it is only a backstop in case of an
+/// algorithmic bug. Real cascades are one or two rounds deep at most.
+const MAX_WRITEBACK_ROUNDS: usize = 8;
 
 // FUNCTION FACTS
 // ================================================================================================
@@ -115,6 +128,15 @@ pub(crate) struct FunctionSolver<'f, 'c, 's> {
     /// Entry-parameter seeds for a context-sensitive solve: an entry parameter maps to the constant
     /// the calling context proved for the matching argument. Absent params default to `Bottom`.
     param_seeds: HashMap<ValueId, Constness>,
+
+    /// Values promoted to a constant by the combined-fixpoint writeback — congruence-derived
+    /// must-equal facts (e.g. `CmpEq(x, y)` with `known_equal(x, y)` folds to `true`).
+    ///
+    /// `None` (the default) is the base solve. When present, a promoted value takes precedence
+    /// over its own (weaker) transfer result in `lattice_of`/`lattice_in_block` — exactly as the
+    /// interned-const snapshot does — and `set_lattice` refuses to lower it, so the value's own
+    /// `Bottom` transfer can never `const_join` the promotion back down.
+    promotions: Option<&'s HashMap<ValueId, Arc<Constant>>>,
 }
 
 impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
@@ -152,6 +174,7 @@ impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
             summaries: None,
             det: None,
             param_seeds: HashMap::default(),
+            promotions: None,
         }
     }
 
@@ -170,6 +193,18 @@ impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
     /// Seed entry parameters with the calling context's argument constants.
     pub(crate) fn with_param_seeds(mut self, seeds: HashMap<ValueId, Constness>) -> Self {
         self.param_seeds = seeds;
+        self
+    }
+
+    /// Seed congruence-derived must-equal constants (the combined-fixpoint writeback).
+    ///
+    /// A promoted value takes precedence over its own transfer, so the worklist propagates the
+    /// stronger fact.
+    pub(crate) fn with_promotions(
+        mut self,
+        promotions: &'s HashMap<ValueId, Arc<Constant>>,
+    ) -> Self {
+        self.promotions = Some(promotions);
         self
     }
 
@@ -208,6 +243,10 @@ impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
     /// Convert the solver into facts.
     pub(crate) fn into_facts(self) -> FunctionFacts {
         let det = self.det;
+        let promotions = self.promotions;
+
+        // `lattice_of` already consults the promotions, so the rebuilt congruence labels a promoted
+        // value by its constant (folding it together with structurally-equal constants).
         let congruence = Congruence::build(
             self.function,
             &self.reachable,
@@ -221,8 +260,19 @@ impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
             },
         );
 
+        // Materialise the promotions into the returned lattice: they live in the borrowed
+        // `promotions` map, not in `self.lattice`, so `const_of`/`new_const_values` would not see
+        // them otherwise. A promoted value is an instruction result, never interned, so there is no
+        // collision with the snapshot.
+        let mut lattice = self.lattice;
+        if let Some(promotions) = promotions {
+            for (v, c) in promotions {
+                lattice.insert(*v, Constness::Const(c.clone()));
+            }
+        }
+
         FunctionFacts {
-            lattice: self.lattice,
+            lattice,
             reachable: self.reachable,
             exec_edges: self.exec_edges,
             block_facts: self.block_facts,
@@ -253,11 +303,20 @@ impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
         if let Some(c) = self.consts.get(&v) {
             return Constness::Const(c.clone());
         }
+        if let Some(c) = self.promotions.and_then(|p| p.get(&v)) {
+            return Constness::Const(c.clone());
+        }
         self.lattice.get(&v).cloned().unwrap_or(Constness::Top)
     }
 
     fn lattice_in_block(&self, bid: BlockId, v: ValueId) -> Constness {
         if let Some(c) = self.consts.get(&v) {
+            return Constness::Const(c.clone());
+        }
+
+        // A promotion is an *unconditional* must-equal, so it dominates the path-sensitive branch
+        // facts just as the interned constant above does.
+        if let Some(c) = self.promotions.and_then(|p| p.get(&v)) {
             return Constness::Const(c.clone());
         }
         if let Some(value) = self.block_facts.get(&bid).and_then(|facts| facts.get(&v)) {
@@ -268,6 +327,13 @@ impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
 
     /// Lower `v` to `join(current, new)`, scheduling its users if the value changed.
     fn set_lattice(&mut self, v: ValueId, new: Constness) {
+        // A promoted value is pinned to its congruence-derived constant: its own transfer (which
+        // does not see the congruence) must never lower it. Interned consts are never instruction
+        // results so never reach here; promoted values are, hence this explicit guard.
+        if self.promotions.is_some_and(|p| p.contains_key(&v)) {
+            return;
+        }
+
         let old = self.lattice_of(v);
         let joined = const_join(old.clone(), new);
         if joined != old {
@@ -643,4 +709,114 @@ impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
             ),
         }
     }
+}
+
+// COMBINED-FIXPOINT WRITEBACK
+// ================================================================================================
+
+/// Solve `function` to the combined-fixpoint writeback.
+///
+/// Each round solves the function, then folds every comparison of congruent operands to a constant
+/// (see [`derive_promotions`]) and accumulates the new must-equal facts into `promotions`. If that
+/// set grew, the next round re-solves with them — which prunes branches and cascades through
+/// reachability and congruence — otherwise the combined fixpoint is reached.
+///
+/// The first round runs with an empty `promotions`, so it is a plain base solve. The loop is
+/// monotone (promotions only grow, executable edges only shrink, congruence only coarsens) over
+/// finite domains, so it converges; [`MAX_WRITEBACK_ROUNDS`] is only a backstop.
+///
+/// `summaries`/`param_seeds` select the solve mode and are layered with the accumulating promotions
+/// identically every round:
+///
+/// - **Intraprocedural:** `summaries = None`, empty `param_seeds`.
+/// - **Polymorphic Summary Solve:** `summaries = Some`, empty `param_seeds`;
+/// - **Context-Specialized Solve:** `summaries = Some`, the context's seeds.
+pub(crate) fn solve_with_writeback(
+    function: &HLFunction,
+    consts: &HLSSAConstantsSnapshot,
+    det: &DetSummaries,
+    summaries: Option<&HashMap<FunctionId, FnSummary>>,
+    param_seeds: &HashMap<ValueId, Constness>,
+) -> FunctionFacts {
+    // The accumulator starts empty, so the first iteration is a plain base solve:
+    // `with_promotions(&{})` is byte-identical to passing no promotions (every query short-circuits
+    // to `None`, `set_lattice`'s guard is `false`, and `into_facts` materialises nothing).
+    let mut promotions: HashMap<ValueId, Arc<Constant>> = HashMap::default();
+    let mut facts = None;
+    for _ in 0..MAX_WRITEBACK_ROUNDS {
+        let mut solver = FunctionSolver::new(function, consts)
+            .with_determinism(det)
+            .with_param_seeds(param_seeds.clone())
+            .with_promotions(&promotions);
+        if let Some(summaries) = summaries {
+            solver = solver.with_summaries(summaries);
+        }
+        solver.run();
+        let solved = solver.into_facts();
+
+        // Fold every newly-foldable comparison of congruent operands; re-solve only if the set grew,
+        // otherwise the combined fixpoint is reached.
+        let before = promotions.len();
+        for (v, c) in derive_promotions(function, &solved) {
+            promotions.entry(v).or_insert(c);
+        }
+        let converged = promotions.len() == before;
+        facts = Some(solved);
+        if converged {
+            break;
+        }
+    }
+    facts.expect("the writeback loop always runs at least one round")
+}
+
+/// The congruence-derived must-equal constants in `facts`: a comparison of two provably-congruent
+/// operands folds to a constant the constants lattice alone cannot derive.
+///
+/// - `CmpEq(x, y)` with `known_equal(x, y)` is unconditionally `true` (`x == y` in every run).
+/// - `CmpLt(x, y)` with `known_equal(x, y)` is unconditionally `false` (`x < x` is never true).
+///
+/// Both are *must-equal* facts of the same strength as congruence itself — congruence never unifies
+/// two free witnesses — so feeding them back into the lattice (where they fold branches and
+/// cascade) keeps the analysis sound. Only the comparison *result* is promoted; it is a pure scalar
+/// `Cmp` fold, so a consumer may alias and delete it. Results already proven constant are skipped,
+/// so the outer fixpoint converges once no new fact appears.
+///
+/// A `WitnessOf`-typed comparison result (a witnessed comparison from witness spilling / AD
+/// lowering) is promoted just like any other when vacuous — the must-equal fact holds either way —
+/// but the consumer needs to keep the substituted constant witness-typed.
+fn derive_promotions(
+    function: &HLFunction,
+    facts: &FunctionFacts,
+) -> HashMap<ValueId, Arc<Constant>> {
+    let mut out: HashMap<ValueId, Arc<Constant>> = HashMap::default();
+    for (bid, block) in function.get_blocks() {
+        if !facts.reachable.contains(bid) {
+            continue;
+        }
+        for instr in block.get_instructions() {
+            let folded = match instr.scalar_fold() {
+                Some(ScalarFold::Cmp {
+                    kind: CmpKind::Eq,
+                    lhs,
+                    rhs,
+                }) if facts.congruence.known_equal(lhs, rhs) => true,
+                Some(ScalarFold::Cmp {
+                    kind: CmpKind::Lt,
+                    lhs,
+                    rhs,
+                }) if facts.congruence.known_equal(lhs, rhs) => false,
+                _ => continue,
+            };
+
+            // A `Cmp` is single-result; skip any result the lattice already proved constant so the
+            // promotion set only ever grows with genuinely new facts.
+            for r in instr.get_results() {
+                if matches!(facts.lattice.get(r), Some(Constness::Const(_))) {
+                    continue;
+                }
+                out.insert(*r, bool_constant(folded));
+            }
+        }
+    }
+    out
 }

--- a/compiler/src/compiler/analysis/click_cooper/summary.rs
+++ b/compiler/src/compiler/analysis/click_cooper/summary.rs
@@ -44,7 +44,7 @@ use crate::{
             click_cooper::{
                 congruence::pure_op_operands,
                 lattice::{Constness, const_join},
-                solver::{FunctionFacts, FunctionSolver},
+                solver::{FunctionFacts, solve_with_writeback},
             },
             flow_analysis::FlowAnalysis,
             shared::{call_string::Context, fixpoint::call_graph_fixpoint},
@@ -65,15 +65,15 @@ const K: usize = 1;
 // DETERMINISM (PHASE 0)
 // ================================================================================================
 
-/// Per-function return-position determinism: `det[g][j] == true` iff return position `j` of `g` is a
-/// deterministic function of `g`'s arguments.
+/// Per-function return-position determinism: `det[g][j] == true` iff return position `j` of `g` is
+/// a deterministic function of `g`'s arguments.
 pub(crate) type DetSummaries = HashMap<FunctionId, Vec<bool>>;
 
 /// Solve every function's per-return determinism to a fixpoint over the call graph.
 pub(crate) fn compute_determinism(ssa: &HLSSA, flow: &FlowAnalysis) -> DetSummaries {
-    // Optimistic: every return position starts deterministic; the worklist only ever lowers a bit to
-    // false. A return is deterministic if its body's non-deterministic sources never reach it, which
-    // (for a recursive function) holds at the greatest fixpoint started from "all true".
+    // Optimistic: every return position starts deterministic; the worklist only ever lowers a bit
+    // to false. A return is deterministic if its body's non-deterministic sources never reach it,
+    // which (for a recursive function) holds at the greatest fixpoint started from "all true".
     let fids: Vec<FunctionId> = ssa.get_function_ids().collect();
     call_graph_fixpoint(
         ssa,
@@ -230,11 +230,10 @@ fn analyze_function(
         return FnSummary::default();
     }
 
-    let mut solver = FunctionSolver::new(func, consts)
-        .with_summaries(summaries)
-        .with_determinism(det);
-    solver.run();
-    let facts = solver.into_facts();
+    // The polymorphic solve applies the combined-fixpoint writeback (params `Bottom`): a return
+    // that is a comparison of congruent operands folds to a constant, so its summary becomes
+    // `Const`.
+    let facts = solve_with_writeback(func, consts, det, Some(summaries), &HashMap::default());
 
     let params: Vec<ValueId> = param_values(ssa, fid);
     let returns: Vec<&Vec<ValueId>> = func
@@ -362,13 +361,10 @@ pub(crate) fn specialize(
             .zip(seed_vec.into_iter().map(seed_or_bottom))
             .collect();
 
+        // The context-specialized solve applies the combined-fixpoint writeback over the seeded
+        // parameters, so a comparison of operands congruent in this context folds in its facts.
         let func = ssa.get_function(f);
-        let mut solver = FunctionSolver::new(func, consts)
-            .with_summaries(summaries)
-            .with_determinism(det)
-            .with_param_seeds(seed_map);
-        solver.run();
-        let mut facts = solver.into_facts();
+        let mut facts = solve_with_writeback(func, consts, det, Some(summaries), &seed_map);
 
         // Build the dominance-aware congruence leaders so `leader_in` yields a legal redirect
         // target.

--- a/compiler/src/compiler/analysis/instrumenter.rs
+++ b/compiler/src/compiler/analysis/instrumenter.rs
@@ -9,7 +9,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use ark_ff::{AdditiveGroup, BigInt, BigInteger, PrimeField};
 use itertools::Itertools;
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 use crate::{
     collections::HashMap,
@@ -794,11 +794,28 @@ impl Value {
         }
     }
 
-    fn constrain(a: &Value, b: &Value, c: &Value, instrumenter: &mut dyn OpInstrumenter) {
+    fn constrain(
+        a: &Value,
+        b: &Value,
+        c: &Value,
+        instrumenter: &mut dyn OpInstrumenter,
+    ) -> Result<(), AssertionFailure> {
         match (a.as_field_const(), b.as_field_const(), c.as_field_const()) {
-            (Some(a), Some(b), Some(c)) => assert_eq!(a * b, c),
+            (Some(a), Some(b), Some(c)) => {
+                if a * b != c {
+                    // A constraint over compile-time constants that does not hold: the program is
+                    // unsatisfiable on every input (e.g. an `execution_failure` test). Surface it
+                    // via the assertion-failure channel instead of panicking as R1CS generation is
+                    // the canonical reporter and rejects the program.
+                    return Err(AssertionFailure::new(format!(
+                        "constraint {a:?} * {b:?} = {c:?} is statically false"
+                    )));
+                }
+                // A trivially-true constant constraint is elided by codegen, so it costs nothing.
+            }
             _ => instrumenter.record_constrain(),
         }
+        Ok(())
     }
 
     fn to_bits(&self, endianness: &crate::compiler::ssa::hlssa::Endianness, size: usize) -> Value {
@@ -813,7 +830,7 @@ impl Value {
                             .map(|b| Value::WitnessOf(Box::new(b)))
                             .collect(),
                     ),
-                    _ => unreachable!(),
+                    _ => unreachable!("to_bits of a WitnessOf expected an Array result"),
                 }
             }
             Value::U(_, v) => {
@@ -858,7 +875,7 @@ impl Value {
                             .map(|d| Value::WitnessOf(Box::new(d)))
                             .collect(),
                     ),
-                    _ => unreachable!(),
+                    _ => unreachable!("to_radix of a WitnessOf expected an Array result"),
                 }
             }
             Value::Unknown(_) => Value::array(vec![Value::Unknown(ScalarKind::U(8)); size]),
@@ -1202,13 +1219,13 @@ impl symbolic_executor::Value<CostAnalysis> for SpecSplitValue {
             &b.unspecialized,
             &c.unspecialized,
             instrumenter.get_unspecialized(),
-        );
+        )?;
         Value::constrain(
             &a.specialized,
             &b.specialized,
             &c.specialized,
             instrumenter.get_specialized(),
-        );
+        )?;
         Ok(())
     }
 
@@ -1290,7 +1307,15 @@ impl symbolic_executor::Value<CostAnalysis> for SpecSplitValue {
                 self.unspecialized
             ),
         };
-        assert_eq!(specialized, unspecialized);
+        // The unspecialized world is a blinding-refinement of the specialized one: both are seeded
+        // identically and every value op is symmetric, with the only asymmetry being
+        // `blind_unspecialized`, which coarsens a concrete leaf to `Unknown` — never to a *different*
+        // concrete. So a branch condition that is a concrete bool in both worlds must agree; a
+        // divergence here is a specializer/writeback miscompilation, not a benign dead path.
+        assert_eq!(
+            specialized, unspecialized,
+            "ICE: branch condition diverged between the specialized and unspecialized cost-analysis worlds"
+        );
         specialized
     }
 
@@ -1329,7 +1354,14 @@ impl symbolic_executor::Value<CostAnalysis> for SpecSplitValue {
     fn expect_blob(&self, _ctx: &mut CostAnalysis) -> Vec<Self> {
         match (&self.unspecialized, &self.specialized) {
             (Value::Blob(unspecialized), Value::Blob(specialized)) => {
-                assert_eq!(unspecialized.len(), specialized.len());
+                // The two worlds are structurally identical up to blinding (which only coarsens
+                // leaves to `Unknown`, never changes a blob's shape), so their lengths must match;
+                // a mismatch is a miscompilation, not a recoverable condition.
+                assert_eq!(
+                    unspecialized.len(),
+                    specialized.len(),
+                    "ICE: blob length diverged between the specialized and unspecialized cost-analysis worlds"
+                );
                 unspecialized
                     .iter()
                     .cloned()
@@ -2055,6 +2087,17 @@ impl CostAnalysis {
         sig
     }
 
+    /// Seal any frames left on the stack after a symbolic execution aborted via an
+    /// `AssertionFailure` (so `on_return` never ran). The partial costs are irrelevant — a program
+    /// that statically violates a constraint is rejected by R1CS generation — but the per-function
+    /// maps must stay consistent (the entry point in particular must be present) so
+    /// `summarize`/`walk_call_tree` do not panic on a missing function.
+    fn finalize_aborted(&mut self) {
+        while !self.stack.is_empty() {
+            self.exit_call();
+        }
+    }
+
     fn get_specialized(&mut self) -> &mut dyn OpInstrumenter {
         self.stack.last_mut().unwrap().1.as_mut().get_specialized()
     }
@@ -2183,11 +2226,19 @@ impl CostEstimator {
                 specialized: param.to_value(),
             })
             .collect();
-        // The cost estimator evaluates over fully-symbolic inputs, so assertions never fold to
-        // a failing constant; a static assertion failure here would be a bug in this pass.
-        SymbolicExecutor::new()
-            .run(ssa, type_info, sig.id, inputs, costs)
-            .expect("ICE: cost analysis hit a static assertion failure on symbolic inputs");
+        // Upstream constant folding can make a constraint's operands compile-time constants, so
+        // the cost estimator can reach a statically-violated assertion even on symbolic inputs
+        // (e.g. an `execution_failure` program with an unsatisfiable constraint). That is not a
+        // bug here: the cost accumulated in `costs` so far is kept, and R1CS generation is the
+        // canonical reporter that rejects the program. So we stop costing this function rather
+        // than crashing compilation.
+        if let Err(failure) = SymbolicExecutor::new().run(ssa, type_info, sig.id, inputs, costs) {
+            debug!(
+                message = %"cost analysis: statically-violated assertion; stopping cost estimation for this function",
+                failure = %failure
+            );
+            costs.finalize_aborted();
+        }
     }
 
     fn type_to_unknown_sig(&self, tp: &Type) -> ValueSignature {
@@ -2238,5 +2289,60 @@ impl Analysis for Summary {
         let cost_estimator = CostEstimator::new();
         let cost_analysis = cost_estimator.run(ssa, type_info);
         cost_analysis.summarize()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CostEstimator;
+    use crate::compiler::{
+        Field,
+        analysis::{flow_analysis::FlowAnalysis, types::Types},
+        ssa::{
+            Terminator,
+            hlssa::{Constant, HLSSA, OpCode},
+        },
+    };
+
+    /// Run the cost estimator over `ssa` with freshly-computed dependencies, then `summarize` it —
+    /// exactly the path `Summary::compute` drives. The estimator absorbs static assertion failures
+    /// internally, so the point of these tests is simply that the whole path does not panic (in
+    /// particular `summarize`/`walk_call_tree`, which would trip over a failed function missing
+    /// from the cost map).
+    fn run_cost_estimator(ssa: &HLSSA) {
+        let flow = FlowAnalysis::run(ssa);
+        let type_info = Types::new().run(ssa, &flow);
+        let _ = CostEstimator::new().run(ssa, &type_info).summarize();
+    }
+
+    /// `main` with a single `Constrain { a, b, c }` over compile-time field constants.
+    fn ssa_constraining_constants(a: u64, b: u64, c: u64) -> HLSSA {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let a = ssa.add_const(Constant::Field(Field::from(a)));
+        let b = ssa.add_const(Constant::Field(Field::from(b)));
+        let c = ssa.add_const(Constant::Field(Field::from(c)));
+        let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
+        entry.push_instruction(OpCode::Constrain { a, b, c });
+        entry.set_terminator(Terminator::Return(vec![]));
+        ssa
+    }
+
+    /// A `Constrain` over constants whose product does NOT equal the third operand is statically
+    /// unsatisfiable (an `execution_failure`-style program). The cost estimator must surface this
+    /// through the `AssertionFailure` channel and keep going, NOT crash compilation. Regression for
+    /// the `assert_eq!(a * b, c)` panic that the Click-Cooper writebacks exposed on
+    /// `execution_failure/regression_5202`.
+    #[test]
+    fn statically_false_constraint_does_not_crash_cost_estimation() {
+        // 2 * 3 = 6 ≠ 7.
+        run_cost_estimator(&ssa_constraining_constants(2, 3, 7));
+    }
+
+    /// The satisfiable control: a trivially-true constant constraint is elided (costs nothing) and
+    /// the estimator runs cleanly.
+    #[test]
+    fn statically_true_constant_constraint_does_not_crash_cost_estimation() {
+        // 2 * 3 = 6.
+        run_cost_estimator(&ssa_constraining_constants(2, 3, 6));
     }
 }

--- a/compiler/src/compiler/passes/sparse_conditional_constant_propagation.rs
+++ b/compiler/src/compiler/passes/sparse_conditional_constant_propagation.rs
@@ -7,18 +7,29 @@
 //!
 //! # Folding Semantics
 //!
-//! Only *pure scalar* values are folded, and only when every operand is a pure interned constant —
-//! a `WitnessOf`-typed value is never an interned constant, so witness arithmetic is never touched.
+//! Folding is driven by Click-Cooper's `new_const_values`, which reports every value proven
+//! unconditionally constant — including congruence-derived must-equal facts, i.e. a comparison of
+//! congruent operands (`x == x → true`, `x < x → false`) even when neither operand is itself
+//! constant. A pure scalar fold whose result is constant is dropped and its uses aliased to the
+//! bare interned constant.
+//!
+//! The **exception** is a `WitnessOf`-typed folded constant (a witnessed comparison of congruent
+//! operands): aliasing it to a bare constant would drop the wrapper and mistype the IR, so it is
+//! instead redefined in place as `cast <const> to WitnessOf`, keeping the value witness-typed.
 
 use crate::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     compiler::{
-        analysis::click_cooper::ClickCooper,
+        analysis::{
+            click_cooper::ClickCooper,
+            flow_analysis::FlowAnalysis,
+            types::{TypeInfo, Types},
+        },
         pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
         passes::fix_double_jumps::{ReplaceScope, ValueReplacements},
         ssa::{
             BlockId, FunctionId, Instruction, Terminator, ValueId,
-            hlssa::{HLFunction, HLSSA, OpCode},
+            hlssa::{CastTarget, HLFunction, HLSSA, OpCode},
         },
     },
 };
@@ -35,11 +46,11 @@ impl Pass for SCCP {
     }
 
     fn needs(&self) -> Vec<AnalysisId> {
-        vec![ClickCooper::id()]
+        vec![ClickCooper::id(), TypeInfo::id()]
     }
 
     fn run(&self, ssa: &mut HLSSA, store: &AnalysisStore) {
-        self.do_run(ssa, store.get::<ClickCooper>());
+        rewrite_all(ssa, store.get::<ClickCooper>(), store.get::<TypeInfo>());
     }
 }
 
@@ -48,20 +59,36 @@ impl SCCP {
         Self {}
     }
 
+    /// Standalone entry (tests / callers without an `AnalysisStore`): recomputes `TypeInfo` from
+    /// the current SSA, then rewrites. The pass-manager `run` path uses the cached `TypeInfo`
+    /// instead.
     pub fn do_run(&self, ssa: &mut HLSSA, cc: &ClickCooper) {
-        let fids: Vec<_> = ssa.get_function_ids().collect();
-        for fid in fids {
-            let mut function = ssa.take_function(fid);
-            rewrite(&mut function, ssa, cc, fid);
-            ssa.put_function(fid, function);
-        }
+        let flow = FlowAnalysis::run(ssa);
+        let type_info = Types::new().run(ssa, &flow);
+        rewrite_all(ssa, cc, &type_info);
+    }
+}
+
+fn rewrite_all(ssa: &mut HLSSA, cc: &ClickCooper, type_info: &TypeInfo) {
+    let fids: Vec<_> = ssa.get_function_ids().collect();
+    for fid in fids {
+        let mut function = ssa.take_function(fid);
+        rewrite(&mut function, ssa, cc, type_info, fid);
+        ssa.put_function(fid, function);
     }
 }
 
 // REWRITING FUNCTIONALITY
 // ================================================================================================
 
-fn rewrite(function: &mut HLFunction, ssa: &HLSSA, cc: &ClickCooper, fid: FunctionId) {
+fn rewrite(
+    function: &mut HLFunction,
+    ssa: &HLSSA,
+    cc: &ClickCooper,
+    type_info: &TypeInfo,
+    fid: FunctionId,
+) {
+    let fn_type_info = type_info.get_function(fid);
     // Drop blocks the analysis never reached. Every kept terminator only targets reachable blocks:
     // a JmpIf with a constant condition is rewritten to a Jmp to its (reachable) live successor
     // below, and all other terminators had all successor edges marked executable.
@@ -73,13 +100,28 @@ fn rewrite(function: &mut HLFunction, ssa: &HLSSA, cc: &ClickCooper, fid: Functi
     }
 
     // Alias every constant-valued value (instruction results and block parameters) to the interned
-    // constant. `const_values` is sorted by value id, so interning a missing constant (which
-    // allocates a fresh value id) is deterministic across runs.
+    // constant. `const_values` comes from a deterministic `FxHashMap` iteration (the hasher has no
+    // per-run seed), so interning a missing constant (which allocates a fresh value id) is
+    // deterministic across runs.
+    //
+    // A `WitnessOf`-typed constant is the exception: it cannot be aliased to a bare interned
+    // constant (that would drop the wrapper and mistype the IR — e.g. a witnessed comparison of
+    // congruent operands folds to a provably-true witness). Those are collected here and redefined
+    // in place as a `cast <const> to WitnessOf` in the instruction loop below, preserving the
+    // witness type.
     let mut replacements = ValueReplacements::new();
     let const_values = cc.new_const_values(fid);
     let const_set: HashSet<ValueId> = const_values.iter().map(|(v, _)| *v).collect();
+
+    // In practice `witness_consts` only ever holds `Cmp` instruction *results* — the sole witnessed
+    // constants the analysis produces (a vacuous witnessed comparison).
+    let mut witness_consts = HashMap::default();
     for (v, c) in &const_values {
-        replacements.insert(*v, ssa.add_const((**c).clone()));
+        if fn_type_info.get_value_type(*v).is_witness_of() {
+            witness_consts.insert(*v, c.clone());
+        } else {
+            replacements.insert(*v, ssa.add_const((**c).clone()));
+        }
     }
 
     let kept_blocks: Vec<BlockId> = function.get_blocks().map(|(id, _)| *id).collect();
@@ -92,6 +134,10 @@ fn rewrite(function: &mut HLFunction, ssa: &HLSSA, cc: &ClickCooper, fid: Functi
         for instr in instructions {
             // Purity gate: a single-result instruction whose result the analysis proved constant is
             // dropped only when it is a pure scalar fold; its uses are aliased above either way.
+            //
+            // A `WitnessOf`-typed constant keeps its value id, redefined as a cast of the interned
+            // constant to `WitnessOf`, so the value's witness type is preserved for its (possibly
+            // witnessed) uses and return slots, rather than being aliased to a bare constant.
             {
                 let mut results = instr.get_results();
                 if let (Some(r), None) = (results.next(), results.next()) {
@@ -104,6 +150,14 @@ fn rewrite(function: &mut HLFunction, ssa: &HLSSA, cc: &ClickCooper, fid: Functi
                     );
 
                     if is_const && instr.is_pure_scalar_fold() {
+                        if let Some(c) = witness_consts.get(r) {
+                            let bare = ssa.add_const((**c).clone());
+                            kept.push(OpCode::Cast {
+                                result: *r,
+                                value: bare,
+                                target: CastTarget::WitnessOf,
+                            });
+                        }
                         continue;
                     }
                 }
@@ -613,6 +667,111 @@ mod tests {
         assert!(matches!(
             f.get_block(merge).get_terminator(),
             Some(Terminator::Return(vals)) if *vals == vec![c_true]
+        ));
+    }
+
+    /// A branch decided by *congruence* — `CmpEq(a, b)` with `a` and `b` structurally equal but not
+    /// constant — folds away through the combined-fixpoint writeback: the comparison is dropped,
+    /// the `JmpIf` becomes a `Jmp` to the then-block, and the dead else-block is deleted. The two
+    /// (non-constant) adds survive, and the purity assert does not trip on the folded `Cmp`.
+    #[test]
+    fn folds_congruence_decided_branch() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c1 = ssa.add_const(Constant::U(32, 1));
+        let (x, a, b, eq) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let then_b = f.add_block();
+        let else_b = f.add_block();
+        f.get_entry_mut().push_parameter(x, Type::u(32));
+        let entry = f.get_entry_mut();
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: a,
+            rhs: b,
+        });
+        entry.set_terminator(Terminator::JmpIf(eq, then_b, else_b));
+        f.get_block_mut(then_b)
+            .set_terminator(Terminator::Return(vec![a]));
+        f.get_block_mut(else_b)
+            .set_terminator(Terminator::Return(vec![b]));
+
+        let cc = run_in_test(&ssa);
+        SCCP::new().do_run(&mut ssa, &cc);
+
+        let f = ssa.get_unique_entrypoint();
+        // The two adds survive (not constant); only the `Cmp` folded away.
+        assert_eq!(f.get_entry().get_instructions().count(), 2);
+        // The branch is decided and the dead else-block is gone.
+        assert!(matches!(
+            f.get_entry().get_terminator(),
+            Some(Terminator::Jmp(t, args)) if *t == then_b && args.is_empty()
+        ));
+        assert_eq!(f.get_blocks().count(), 2);
+    }
+
+    /// A *witnessed* comparison of congruent operands folds to a constant, but — unlike a plain
+    /// scalar fold, which is dropped and aliased to the bare interned constant — the value keeps
+    /// its `WitnessOf` type: it is redefined in place as a `cast <const> to WitnessOf`, so the
+    /// (witnessed) return slot stays correctly typed.
+    #[test]
+    fn witnessed_constant_is_cast_to_witness_of() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let (w, ww) = (ssa.fresh_value(), ssa.fresh_value());
+
+        let f = ssa.get_unique_entrypoint_mut();
+        let entry = f.get_entry_mut();
+        // An operand is `WitnessOf`, so the comparison result is `WitnessOf(u1)`.
+        entry.push_parameter(w, Type::witness_of(Type::u(32)));
+        entry.push_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: ww,
+            lhs: w,
+            rhs: w,
+        });
+        entry.set_terminator(Terminator::Return(vec![ww]));
+
+        let cc = run_in_test(&ssa);
+        SCCP::new().do_run(&mut ssa, &cc);
+
+        let f = ssa.get_unique_entrypoint();
+        // The witnessed comparison is gone, replaced by a cast of the folded constant to `WitnessOf`
+        // (keeping `ww` witness-typed) rather than aliased to a bare constant.
+        assert!(
+            !f.get_entry()
+                .get_instructions()
+                .any(|i| matches!(i, OpCode::Cmp { .. })),
+            "the witnessed comparison should have folded away"
+        );
+        assert!(
+            f.get_entry().get_instructions().any(|i| matches!(
+                i,
+                OpCode::Cast { result, target: CastTarget::WitnessOf, .. } if *result == ww
+            )),
+            "ww should be redefined as a cast to WitnessOf"
+        );
+        // The return still references `ww`, now witness-typed, matching its WitnessOf return slot.
+        assert!(matches!(
+            f.get_entry().get_terminator(),
+            Some(Terminator::Return(vals)) if vals.as_slice() == [ww]
         ));
     }
 }

--- a/noir_tests/congruent_witness_comparison/Nargo.toml
+++ b/noir_tests/congruent_witness_comparison/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "congruent_witness_comparison"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/noir_tests/congruent_witness_comparison/src/main.nr
+++ b/noir_tests/congruent_witness_comparison/src/main.nr
@@ -1,0 +1,39 @@
+// Exercises the witnessed-comparison fold: `pre == post` compares two structurally-identical
+// (congruent) booleans derived from a witnessed unconstrained `Option`, so its result is
+// `WitnessOf(u1)`. The Click-Cooper writeback proves the operands congruent and folds the comparison
+// to `true`, and SCCP keeps the folded constant witness-typed via `cast <const> to WitnessOf`.
+//
+// This mirrors the structure of `execution_failure/regression_5202` (whose witnessed comparison
+// first surfaced this case) but is satisfiable, so it guards witgen/AD correctness of the fold
+// end-to-end as an execution_success test.
+
+unconstrained fn get_unconstrained_option() -> Option<u32> {
+    Option::some(13)
+}
+
+unconstrained fn should_i_assert() -> bool {
+    false
+}
+
+fn get_magical_boolean() -> bool {
+    // Safety: testing context
+    let option = unsafe { get_unconstrained_option() };
+
+    let pre = option.is_some() as Field;
+
+    // Safety: testing context. `should_i_assert` is unconstrained and false here, so the assert is
+    // not executed; its presence forces `option` through witness spilling so the comparison below is
+    // a *witnessed* one.
+    if unsafe { should_i_assert() } {
+        assert_eq(option, Option::some(42));
+    }
+
+    let post = option.is_some() as Field;
+
+    // `pre` and `post` are the same (congruent) witnessed computation, so this is provably true.
+    pre == post
+}
+
+fn main() {
+    assert(get_magical_boolean());
+}


### PR DESCRIPTION
This commit adds combined-fixpoint writebacks, allowing more in-depth fact propagation through Click-Cooper. The primary payoff is going to come with future work, though it does yield some small benefits in SCCP already.

There have been some minor changes to the soon-to-be-superseded SCCP pass to keep it working properly with the changes to the analysis that it relies on. This yields some small corpus improvements simply due to the added precision.

Partial work for #260.