### PR TITLE
Handle aggregates in click-cooper

### DIFF
--- a/compiler/src/compiler/analysis/click_cooper/lattice.rs
+++ b/compiler/src/compiler/analysis/click_cooper/lattice.rs
@@ -6,7 +6,10 @@ use ark_ff::{PrimeField, Zero};
 
 use crate::compiler::{
     Field,
-    ssa::hlssa::{BinaryArithOpKind, CastTarget, CmpKind, Constant, MAX_SUPPORTED_SIGNED_BITS},
+    ssa::hlssa::{
+        BinaryArithOpKind, Blob, CastTarget, CmpKind, Constant, MAX_SUPPORTED_SIGNED_BITS,
+        SliceOpDir, Type,
+    },
     util::{bit_mask, decode_signed, encode_signed, fits_signed},
 };
 
@@ -315,4 +318,108 @@ pub(crate) fn eval_not(v: &Constant) -> Option<Constant> {
         Constant::I(s, x) => Some(Constant::I(*s, !x & bit_mask(*s))),
         Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => None,
     }
+}
+
+// AGGREGATE CONSTANT EVALUATION
+// ================================================================================================
+
+/// The maximum element count of an aggregate the analysis will materialise as a constant.
+///
+/// Aggregate folding keeps the whole `Vec<Constant>` in the lattice, so an unbounded `MkRepeated`
+/// count (or a very long `MkSeq` / `SlicePush`) could blow up memory for no analysis benefit.
+/// Constant lookup tables of interest are far smaller than this, so the cap only rejects
+/// pathological sizes — which stay `Bottom`, hence sound.
+const AGGREGATE_FOLD_CAP: usize = 1 << 12;
+
+/// Reads a constant integer index as a `usize`, or `None` if it is non-integer or too large.
+fn const_index(index: &Constant) -> Option<usize> {
+    match index {
+        Constant::U(_, x) | Constant::I(_, x) => usize::try_from(*x).ok(),
+        Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => None,
+    }
+}
+
+/// Folds an `ArrayGet`: projects element `index` out of a constant aggregate.
+///
+/// `None` (→ `Bottom`) when the array is not an aggregate constant or the index is out of bounds —
+/// an out-of-bounds constant index is an erroneous program, so refusing the fold is sound.
+pub(crate) fn eval_array_get(array: &Constant, index: &Constant) -> Option<Constant> {
+    let Constant::Blob(blob) = array else {
+        return None;
+    };
+    blob.elements.get(const_index(index)?).cloned()
+}
+
+/// Folds an `ArraySet`: a constant aggregate with element `index` replaced by `value`.
+pub(crate) fn eval_array_set(
+    array: Constant,
+    index: &Constant,
+    value: Constant,
+) -> Option<Constant> {
+    let Constant::Blob(mut blob) = array else {
+        return None;
+    };
+
+    let idx = const_index(index)?;
+    if idx >= blob.elements.len() {
+        return None;
+    }
+
+    blob.elements[idx] = value;
+    Some(Constant::Blob(blob))
+}
+
+/// Folds a `SliceLen`: the element count of a constant aggregate.
+pub(crate) fn eval_slice_len(slice: &Constant) -> Option<Constant> {
+    let Constant::Blob(blob) = slice else {
+        return None;
+    };
+
+    // The result is always a u32 according to the type system.
+    Some(Constant::U(32, blob.len() as u128))
+}
+
+/// Folds a `SlicePush`: a constant aggregate extended by `values` at the front or back.
+///
+/// `Front` prepends the pushed values (in order) before the original elements; `Back` appends them
+/// after — matching the backends' slice-push semantics.
+pub(crate) fn eval_slice_push(
+    dir: SliceOpDir,
+    slice: Constant,
+    values: Vec<Constant>,
+) -> Option<Constant> {
+    let Constant::Blob(blob) = slice else {
+        return None;
+    };
+    if blob.len() + values.len() > AGGREGATE_FOLD_CAP {
+        return None;
+    }
+    let elements: Vec<Constant> = match dir {
+        SliceOpDir::Front => values.into_iter().chain(blob.elements).collect(),
+        SliceOpDir::Back => blob.elements.into_iter().chain(values).collect(),
+    };
+    Some(Constant::Blob(Blob::new(blob.elem_type, elements)))
+}
+
+/// Folds a `MkSeq`: an aggregate constant from constant elements.
+pub(crate) fn eval_mk_seq(elem_type: &Type, elems: Vec<Constant>) -> Option<Constant> {
+    if elems.len() > AGGREGATE_FOLD_CAP {
+        return None;
+    }
+    Some(Constant::Blob(Blob::new(elem_type.clone(), elems)))
+}
+
+/// Folds a `MkRepeated`: an aggregate constant of `count` copies of a constant element.
+pub(crate) fn eval_mk_repeated(
+    elem_type: &Type,
+    element: &Constant,
+    count: usize,
+) -> Option<Constant> {
+    if count > AGGREGATE_FOLD_CAP {
+        return None;
+    }
+    Some(Constant::Blob(Blob::new(
+        elem_type.clone(),
+        vec![element.clone(); count],
+    )))
 }

--- a/compiler/src/compiler/analysis/click_cooper/mod.rs
+++ b/compiler/src/compiler/analysis/click_cooper/mod.rs
@@ -47,6 +47,12 @@
 //!
 //! - **Constants:** The transfer functions fold a value only when the result is exact for the
 //!   operand widths so `value == c` holds under any advice.
+//! - **Aggregate Folding:** The pure, value-semantic sequence ops (`MkSeq`, `MkRepeated`,
+//!   `MkSeqOfBlob`, `ArrayGet`, `ArraySet`, `SlicePush`, `SliceLen`) are folded over the same
+//!   exact-constant lattice — a projection at an out-of-bounds constant index is refused rather
+//!   than guessed — so every folded element equals its runtime value. The aggregate (`Blob`)
+//!   constants are never surfaced (only the scalar projections flow out), so a consumer only ever
+//!   sees an ordinary scalar constant and inherits the **Constants** soundness above.
 //! - **Reachability:** An edge is executable only when a predecessor's terminator can take it. A
 //!   block proven unreachable is thus taken in no run.
 //! - **Congruence:** Two values are congruent iff computed by the same operator from operand-wise
@@ -113,12 +119,6 @@
 //!   pass per `(function, context)` — as `specialize` already does for the unconditional facts —
 //!   would let a context-specialized assert or branch expose more facts, and would warrant adding
 //!   the `_in` variants.
-//! - **Aggregate Constant Folding:** The pure, value-semantic sequence ops (`MkSeq`, `MkRepeated`,
-//!   `MkSeqOfBlob`, `ArrayGet`, `ArraySet`, `SlicePush`, `SliceLen`) are value-numbered (see
-//!   `congruence::op_signature`) but never constant-folded. The `Constness` lattice carries only a
-//!   scalar `Arc<Constant>` and the fold functions are scalar, so it cannot represent an aggregate
-//!   constant. Future work can widen the lattice to handle aggregate constants and transfer
-//!   functions.
 
 mod conditional;
 mod congruence;
@@ -270,8 +270,11 @@ impl ClickCooper {
             return Some(c.clone());
         }
         match facts?.lattice.get(&v) {
-            Some(Constness::Const(c)) => Some(c.clone()),
-            Some(Constness::Top) | Some(Constness::Bottom) | None => None,
+            // Aggregate (`Blob`) constants are folded only to drive `ArrayGet`/`SliceLen`
+            // projections *within* the analysis; they are never surfaced, so no consumer is asked
+            // to materialise an aggregate constant value (only the scalar projections flow out).
+            Some(Constness::Const(c)) if c.is_scalar() => Some(c.clone()),
+            Some(Constness::Const(_) | Constness::Top | Constness::Bottom) | None => None,
         }
     }
 }
@@ -312,8 +315,10 @@ impl ClickCooper {
             .lattice
             .iter()
             .filter_map(|(v, e)| match e {
-                Constness::Const(c) => Some((*v, c.clone())),
-                Constness::Top | Constness::Bottom => None,
+                // Surface scalars only; aggregate (`Blob`) constants stay internal to the analysis
+                // (see `const_in_facts`).
+                Constness::Const(c) if c.is_scalar() => Some((*v, c.clone())),
+                Constness::Const(_) | Constness::Top | Constness::Bottom => None,
             })
             .collect()
     }
@@ -571,7 +576,7 @@ pub(crate) mod tests {
         ssa::{
             Terminator,
             hlssa::{
-                BinaryArithOpKind, CallTarget, CastTarget, CmpKind, Constant, HLSSA, OpCode,
+                BinaryArithOpKind, Blob, CallTarget, CastTarget, CmpKind, Constant, HLSSA, OpCode,
                 ScalarFold, SequenceTargetType, SliceOpDir, Type,
             },
         },
@@ -2718,5 +2723,381 @@ pub(crate) mod tests {
 
         assert!(cc.known_equal(fid, i, j));
         assert_eq!(cc.const_of(fid, eq).as_deref(), Some(&Constant::U(1, 1)));
+    }
+
+    // AGGREGATE CONSTANT FOLDING
+    // ============================================================================================
+
+    /// `MkSeq` of constant elements folds to an *internal* aggregate; `ArrayGet` at a constant
+    /// index projects a scalar constant out of it. The aggregate itself is never surfaced to
+    /// consumers.
+    #[test]
+    fn const_array_get_folds_to_scalar() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c0 = ssa.add_const(Constant::U(32, 10));
+        let c1 = ssa.add_const(Constant::U(32, 20));
+        let c2 = ssa.add_const(Constant::U(32, 30));
+        let idx = ssa.add_const(Constant::U(32, 1));
+        let (seq, got) = (ssa.fresh_value(), ssa.fresh_value());
+
+        let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
+        entry.push_instruction(OpCode::MkSeq {
+            result: seq,
+            elems: vec![c0, c1, c2],
+            seq_type: SequenceTargetType::Array(3),
+            elem_type: Type::u(32),
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: got,
+            array: seq,
+            index: idx,
+        });
+        entry.set_terminator(Terminator::Return(vec![got]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        // The projection is a surfaced scalar constant.
+        assert_eq!(cc.const_of(fid, got).as_deref(), Some(&Constant::U(32, 20)));
+        assert!(
+            cc.new_const_values(fid)
+                .iter()
+                .any(|(v, c)| *v == got && **c == Constant::U(32, 20))
+        );
+        // The aggregate stays internal: never surfaced as a constant.
+        assert_eq!(cc.const_of(fid, seq), None);
+        assert!(cc.new_const_values(fid).iter().all(|(v, _)| *v != seq));
+    }
+
+    /// `MkRepeated` of a constant folds, and both `ArrayGet` and `SliceLen` project scalars out of
+    /// the resulting aggregate (the length is always `u32`).
+    #[test]
+    fn const_repeated_array_get_and_slice_len() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let elem = ssa.add_const(Constant::U(32, 7));
+        let idx = ssa.add_const(Constant::U(32, 2));
+        let (seq, got, len) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+
+        let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
+        entry.push_instruction(OpCode::MkRepeated {
+            result: seq,
+            element: elem,
+            seq_type: SequenceTargetType::Array(4),
+            count: 4,
+            elem_type: Type::u(32),
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: got,
+            array: seq,
+            index: idx,
+        });
+        entry.push_instruction(OpCode::SliceLen {
+            result: len,
+            slice: seq,
+        });
+        entry.set_terminator(Terminator::Return(vec![got, len]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        assert_eq!(cc.const_of(fid, got).as_deref(), Some(&Constant::U(32, 7)));
+        assert_eq!(cc.const_of(fid, len).as_deref(), Some(&Constant::U(32, 4)));
+    }
+
+    /// `ArraySet` of a constant aggregate is itself a constant aggregate: a later `ArrayGet` sees
+    /// the updated cell at the set index and the original value elsewhere.
+    #[test]
+    fn const_array_set_then_get() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c0 = ssa.add_const(Constant::U(32, 10));
+        let c1 = ssa.add_const(Constant::U(32, 20));
+        let c2 = ssa.add_const(Constant::U(32, 30));
+        let new_val = ssa.add_const(Constant::U(32, 99));
+        let idx0 = ssa.add_const(Constant::U(32, 0));
+        let idx1 = ssa.add_const(Constant::U(32, 1));
+        let (seq, seq2, at_set, at_orig) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
+        entry.push_instruction(OpCode::MkSeq {
+            result: seq,
+            elems: vec![c0, c1, c2],
+            seq_type: SequenceTargetType::Array(3),
+            elem_type: Type::u(32),
+        });
+        entry.push_instruction(OpCode::ArraySet {
+            result: seq2,
+            array: seq,
+            index: idx1,
+            value: new_val,
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: at_set,
+            array: seq2,
+            index: idx1,
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: at_orig,
+            array: seq2,
+            index: idx0,
+        });
+        entry.set_terminator(Terminator::Return(vec![at_set, at_orig]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        assert_eq!(
+            cc.const_of(fid, at_set).as_deref(),
+            Some(&Constant::U(32, 99))
+        );
+        assert_eq!(
+            cc.const_of(fid, at_orig).as_deref(),
+            Some(&Constant::U(32, 10))
+        );
+    }
+
+    /// `SlicePush` extends a constant aggregate at the front or back, preserving element order.
+    #[test]
+    fn const_slice_push_front_and_back() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let mid = ssa.add_const(Constant::U(32, 1));
+        let front = ssa.add_const(Constant::U(32, 0));
+        let back = ssa.add_const(Constant::U(32, 2));
+        let idx0 = ssa.add_const(Constant::U(32, 0));
+        let idx1 = ssa.add_const(Constant::U(32, 1));
+        let (base, pushed_front, pushed_back, head, tail) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
+        entry.push_instruction(OpCode::MkSeq {
+            result: base,
+            elems: vec![mid],
+            seq_type: SequenceTargetType::Slice,
+            elem_type: Type::u(32),
+        });
+        // Front: [front, mid]; element 0 is the pushed value.
+        entry.push_instruction(OpCode::SlicePush {
+            dir: SliceOpDir::Front,
+            result: pushed_front,
+            slice: base,
+            values: vec![front],
+        });
+        // Back: [mid, back]; element 1 is the pushed value.
+        entry.push_instruction(OpCode::SlicePush {
+            dir: SliceOpDir::Back,
+            result: pushed_back,
+            slice: base,
+            values: vec![back],
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: head,
+            array: pushed_front,
+            index: idx0,
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: tail,
+            array: pushed_back,
+            index: idx1,
+        });
+        entry.set_terminator(Terminator::Return(vec![head, tail]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        assert_eq!(cc.const_of(fid, head).as_deref(), Some(&Constant::U(32, 0)));
+        assert_eq!(cc.const_of(fid, tail).as_deref(), Some(&Constant::U(32, 2)));
+    }
+
+    /// `MkSeqOfBlob` re-views a constant blob as a sequence; projecting a constant index folds.
+    #[test]
+    fn const_mk_seq_of_blob_folds() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let blob = ssa.add_const(Constant::Blob(Blob::new(
+            Type::u(32),
+            vec![Constant::U(32, 100), Constant::U(32, 200)],
+        )));
+        let idx = ssa.add_const(Constant::U(32, 1));
+        let (seq, got) = (ssa.fresh_value(), ssa.fresh_value());
+
+        let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
+        entry.push_instruction(OpCode::MkSeqOfBlob {
+            result: seq,
+            element_type: Type::u(32),
+            blob,
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: got,
+            array: seq,
+            index: idx,
+        });
+        entry.set_terminator(Terminator::Return(vec![got]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        assert_eq!(
+            cc.const_of(fid, got).as_deref(),
+            Some(&Constant::U(32, 200))
+        );
+        // The aggregate stays internal.
+        assert_eq!(cc.const_of(fid, seq), None);
+    }
+
+    /// Aggregate folding refuses (stays `Bottom`, i.e. `const_of == None`) on an out-of-bounds
+    /// constant index, a non-constant element, and an over-cap `MkRepeated`.
+    #[test]
+    fn aggregate_folding_negative_cases() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c0 = ssa.add_const(Constant::U(32, 10));
+        let c1 = ssa.add_const(Constant::U(32, 20));
+        let idx0 = ssa.add_const(Constant::U(32, 0));
+        let idx_oob = ssa.add_const(Constant::U(32, 5));
+        let p = ssa.fresh_value();
+        let (seq, g_oob, seq_nc, g_nc, big, g_big) = (
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+            ssa.fresh_value(),
+        );
+
+        let f = ssa.get_unique_entrypoint_mut();
+        f.get_entry_mut().push_parameter(p, Type::u(32));
+        let entry = f.get_entry_mut();
+        // Out of bounds: index 5 into a length-2 array.
+        entry.push_instruction(OpCode::MkSeq {
+            result: seq,
+            elems: vec![c0, c1],
+            seq_type: SequenceTargetType::Array(2),
+            elem_type: Type::u(32),
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: g_oob,
+            array: seq,
+            index: idx_oob,
+        });
+        // Non-constant element keeps the whole aggregate non-constant.
+        entry.push_instruction(OpCode::MkSeq {
+            result: seq_nc,
+            elems: vec![c0, p],
+            seq_type: SequenceTargetType::Array(2),
+            elem_type: Type::u(32),
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: g_nc,
+            array: seq_nc,
+            index: idx0,
+        });
+        // Over-cap repeat is refused before materialising the aggregate.
+        entry.push_instruction(OpCode::MkRepeated {
+            result: big,
+            element: c0,
+            seq_type: SequenceTargetType::Array((1 << 16) + 1),
+            count: (1 << 16) + 1,
+            elem_type: Type::u(32),
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: g_big,
+            array: big,
+            index: idx0,
+        });
+        entry.set_terminator(Terminator::Return(vec![g_oob, g_nc, g_big]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        assert_eq!(cc.const_of(fid, g_oob), None);
+        assert_eq!(cc.const_of(fid, g_nc), None);
+        assert_eq!(cc.const_of(fid, g_big), None);
+    }
+
+    /// The remaining refusal paths, complementing `aggregate_folding_negative_cases`: an
+    /// out-of-bounds `ArraySet`, an over-cap `SlicePush`, and an over-cap `MkSeq` all stay
+    /// `Bottom`. Each is observed through a later `ArrayGet`, which bottoms out over the refused
+    /// (non-constant) aggregate.
+    #[test]
+    fn aggregate_folding_refuses_oob_set_and_over_cap_constructors() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c0 = ssa.add_const(Constant::U(32, 10));
+        let c1 = ssa.add_const(Constant::U(32, 20));
+        let idx0 = ssa.add_const(Constant::U(32, 0));
+        let idx_oob = ssa.add_const(Constant::U(32, 5));
+        let over_cap = (1usize << 12) + 1; // AGGREGATE_FOLD_CAP + 1
+
+        let (base, set_oob, at_set_oob) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+        let (one, pushed, at_pushed) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+        let (big_seq, at_big) = (ssa.fresh_value(), ssa.fresh_value());
+
+        let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
+
+        // Out-of-bounds `ArraySet` (index 5 into a length-2 array): refused, so the get sees Bottom.
+        entry.push_instruction(OpCode::MkSeq {
+            result: base,
+            elems: vec![c0, c1],
+            seq_type: SequenceTargetType::Array(2),
+            elem_type: Type::u(32),
+        });
+        entry.push_instruction(OpCode::ArraySet {
+            result: set_oob,
+            array: base,
+            index: idx_oob,
+            value: c0,
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: at_set_oob,
+            array: set_oob,
+            index: idx0,
+        });
+
+        // `SlicePush` whose result would exceed the cap (1 + CAP values): refused.
+        entry.push_instruction(OpCode::MkSeq {
+            result: one,
+            elems: vec![c0],
+            seq_type: SequenceTargetType::Slice,
+            elem_type: Type::u(32),
+        });
+        entry.push_instruction(OpCode::SlicePush {
+            dir: SliceOpDir::Back,
+            result: pushed,
+            slice: one,
+            values: vec![c0; 1 << 12],
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: at_pushed,
+            array: pushed,
+            index: idx0,
+        });
+
+        // Over-cap `MkSeq`: refused before materialising the aggregate.
+        entry.push_instruction(OpCode::MkSeq {
+            result: big_seq,
+            elems: vec![c0; over_cap],
+            seq_type: SequenceTargetType::Array(over_cap),
+            elem_type: Type::u(32),
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: at_big,
+            array: big_seq,
+            index: idx0,
+        });
+
+        entry.set_terminator(Terminator::Return(vec![at_set_oob, at_pushed, at_big]));
+
+        let fid = ssa.get_unique_entrypoint_id();
+        let cc = run_in_test(&ssa);
+
+        assert_eq!(cc.const_of(fid, at_set_oob), None);
+        assert_eq!(cc.const_of(fid, at_pushed), None);
+        assert_eq!(cc.const_of(fid, at_big), None);
     }
 }

--- a/compiler/src/compiler/analysis/click_cooper/solver.rs
+++ b/compiler/src/compiler/analysis/click_cooper/solver.rs
@@ -13,8 +13,9 @@ use crate::{
         analysis::click_cooper::{
             congruence::Congruence,
             lattice::{
-                Constness, bool_constant, bool_constness, const_bool, const_join, eval_binary,
-                eval_bit_range, eval_cast, eval_cmp, eval_not, eval_sext,
+                Constness, bool_constant, bool_constness, const_bool, const_join, eval_array_get,
+                eval_array_set, eval_binary, eval_bit_range, eval_cast, eval_cmp, eval_mk_repeated,
+                eval_mk_seq, eval_not, eval_sext, eval_slice_len, eval_slice_push,
             },
             summary::{DetSummaries, FnSummary, ReturnJump},
         },
@@ -566,9 +567,9 @@ impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
 
     /// The transfer function: new lattice values for the instruction's results.
     fn transfer(&self, bid: BlockId, instr: &OpCode) -> Vec<(ValueId, Constness)> {
-        // A constrained static `Call` folds its results via the callee's interprocedural
-        // jump-function summary (when summaries are supplied). Without summaries every result is
-        // `Bottom`. It is not a scalar fold, so it is handled before the `scalar_fold` projection.
+        // A constrained static `Call` folds its results via the callee's interprocedural jump
+        // summary (when summaries are supplied). Without summaries every result is `Bottom`. It is
+        // not a scalar fold, so it is handled before the `scalar_fold` projection.
         if let OpCode::Call {
             results,
             function,
@@ -577,6 +578,14 @@ impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
         } = instr
         {
             return self.eval_call(bid, function, args, results, *unconstrained);
+        }
+
+        // The pure, value-semantic sequence ops are not scalar folds but *are* constant-folded over
+        // the aggregate (`Blob`) constants kept in the lattice — e.g. indexing a constant lookup
+        // table with a constant index yields a scalar constant. Like `Call`, they are handled
+        // before the `scalar_fold` projection (which would otherwise bottom them out).
+        if let Some(value) = self.eval_aggregate(bid, instr) {
+            return instr.get_results().map(|r| (*r, value.clone())).collect();
         }
 
         // Foldable scalar ops are evaluated; everything else (memory, witness ops, asserts,
@@ -693,6 +702,92 @@ impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
                 .unwrap_or(Constness::Bottom),
             (Constness::Bottom, _) | (_, Constness::Bottom) => Constness::Bottom,
         }
+    }
+
+    /// Evaluate a variadic aggregate op `f` over `operands` in the context of `bid`.
+    ///
+    /// `f` receives the operands' constants by value (already collected), so a constructor can move
+    /// them into the result blob rather than cloning them a second time. Any number of operands is
+    /// accepted, so this also serves the fixed-arity ops (e.g. `ArraySet`'s three).
+    fn eval_n(
+        &self,
+        bid: BlockId,
+        operands: &[ValueId],
+        f: impl FnOnce(Vec<Constant>) -> Option<Constant>,
+    ) -> Constness {
+        let mut consts = Vec::with_capacity(operands.len());
+        let mut saw_bottom = false;
+        for v in operands {
+            match self.lattice_in_block(bid, *v) {
+                Constness::Top => return Constness::Top,
+                Constness::Bottom => saw_bottom = true,
+                Constness::Const(c) => consts.push((*c).clone()),
+            }
+        }
+        if saw_bottom {
+            return Constness::Bottom;
+        }
+        f(consts)
+            .map(|c| Constness::Const(Arc::new(c)))
+            .unwrap_or(Constness::Bottom)
+    }
+
+    /// The transfer for the pure, value-semantic sequence ops, folded over aggregate (`Blob`)
+    /// constants in the lattice, or `None` if `instr` is not one of those ops.
+    ///
+    /// The result is a single value. An aggregate constructor folds to a `Const(Blob)` only when
+    /// every element is constant; a projection (`ArrayGet`/`SliceLen`) folds to a scalar. Operands
+    /// that are not yet constant propagate `Top`/`Bottom` exactly as the scalar folds do.
+    fn eval_aggregate(&self, bid: BlockId, instr: &OpCode) -> Option<Constness> {
+        let value = match instr {
+            OpCode::MkSeq {
+                elems, elem_type, ..
+            } => self.eval_n(bid, elems, |cs| eval_mk_seq(elem_type, cs)),
+            OpCode::MkRepeated {
+                element,
+                count,
+                elem_type,
+                ..
+            } => self.eval1(bid, *element, |e| eval_mk_repeated(elem_type, e, *count)),
+
+            // `MkSeqOfBlob` views its blob operand as a sequence; the operand already *is* the
+            // aggregate constant so we can share the Arc cheaply.
+            OpCode::MkSeqOfBlob { blob, .. } => match self.lattice_in_block(bid, *blob) {
+                Constness::Const(c) if matches!(&*c, Constant::Blob(_)) => Constness::Const(c),
+                Constness::Const(_) => Constness::Bottom,
+                other => other,
+            },
+            OpCode::ArrayGet { array, index, .. } => {
+                self.eval2(bid, *array, *index, eval_array_get)
+            }
+            OpCode::ArraySet {
+                array,
+                index,
+                value,
+                ..
+            } => self.eval_n(bid, &[*array, *index, *value], |cs| {
+                let [array, index, value]: [Constant; 3] = cs
+                    .try_into()
+                    .expect("ArraySet folds exactly three constant operands");
+                eval_array_set(array, &index, value)
+            }),
+            OpCode::SlicePush {
+                dir, slice, values, ..
+            } => {
+                let operands: Vec<ValueId> = std::iter::once(*slice)
+                    .chain(values.iter().copied())
+                    .collect();
+
+                self.eval_n(bid, &operands, |mut cs| {
+                    let values = cs.split_off(1);
+                    let slice = cs.pop().expect("SlicePush has a slice operand");
+                    eval_slice_push(*dir, slice, values)
+                })
+            }
+            OpCode::SliceLen { slice, .. } => self.eval1(bid, *slice, eval_slice_len),
+            _ => return None,
+        };
+        Some(value)
     }
 
     fn eval_select(&self, bid: BlockId, cond: ValueId, if_t: ValueId, if_f: ValueId) -> Constness {

--- a/compiler/src/compiler/passes/sparse_conditional_constant_propagation.rs
+++ b/compiler/src/compiler/passes/sparse_conditional_constant_propagation.rs
@@ -13,6 +13,10 @@
 //! constant. A pure scalar fold whose result is constant is dropped and its uses aliased to the
 //! bare interned constant.
 //!
+//! The same applies to a pure sequence *projection* (`ArrayGet` / `SliceLen`) that Click-Cooper
+//! folded over a constant aggregate at a constant in-bounds index: its scalar result is the only
+//! thing surfaced, so it is dropped and aliased identically.
+//!
 //! The **exception** is a `WitnessOf`-typed folded constant (a witnessed comparison of congruent
 //! operands): aliasing it to a bare constant would drop the wrapper and mistype the IR, so it is
 //! instead redefined in place as `cast <const> to WitnessOf`, keeping the value witness-typed.
@@ -142,14 +146,22 @@ fn rewrite(
                 let mut results = instr.get_results();
                 if let (Some(r), None) = (results.next(), results.next()) {
                     let is_const = const_set.contains(r);
+
+                    // A surfaced scalar constant is produced either by a pure scalar fold or by a
+                    // pure sequence *projection* — an `ArrayGet`/`SliceLen` that ClickCooper folded
+                    // over a constant aggregate at a proven in-bounds constant index. Both are pure
+                    // single-result reads, so the definition is dropped and its uses are aliased to
+                    // the interned constant; any other constant-producing op is an analysis bug.
+                    let foldable = instr.is_pure_scalar_fold()
+                        || matches!(instr, OpCode::ArrayGet { .. } | OpCode::SliceLen { .. });
                     assert!(
-                        !is_const || instr.is_pure_scalar_fold(),
-                        "ICE::SCCP: result {r:?} of non-pure-scalar instruction {instr:?} is in the \
-                         constant set; the intraprocedural ClickCooper facts must never fold a \
-                         non-pure-scalar op to a constant"
+                        !is_const || foldable,
+                        "ICE: Result {r:?} of non-foldable instruction {instr:?} is in the \
+                         constant set; ClickCooper must only fold pure scalar ops and pure sequence \
+                         projections to a constant"
                     );
 
-                    if is_const && instr.is_pure_scalar_fold() {
+                    if is_const && foldable {
                         if let Some(c) = witness_consts.get(r) {
                             let bare = ssa.add_const((**c).clone());
                             kept.push(OpCode::Cast {
@@ -223,7 +235,7 @@ mod tests {
     use crate::compiler::{
         Field,
         analysis::click_cooper::tests::run_in_test,
-        ssa::hlssa::{BinaryArithOpKind, CastTarget, CmpKind, Constant, Type},
+        ssa::hlssa::{BinaryArithOpKind, CastTarget, CmpKind, Constant, SequenceTargetType, Type},
     };
 
     /// `2 + 3 == 5` decides the branch: the comparison chain folds away, the `JmpIf` becomes a
@@ -772,6 +784,57 @@ mod tests {
         assert!(matches!(
             f.get_entry().get_terminator(),
             Some(Terminator::Return(vals)) if vals.as_slice() == [ww]
+        ));
+    }
+
+    /// A constant lookup-table projection folds at the SCCP level: `ArrayGet`/`SliceLen` over a
+    /// constant `MkSeq` are dropped and their uses aliased to the interned scalar constant, while
+    /// the aggregate `MkSeq` itself (never surfaced) is left in place. Exercises the widened
+    /// `foldable` gate — the purity assert must accept these pure sequence projections.
+    #[test]
+    fn folds_constant_aggregate_projections() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let c10 = ssa.add_const(Constant::U(32, 10));
+        let c20 = ssa.add_const(Constant::U(32, 20));
+        let c30 = ssa.add_const(Constant::U(32, 30));
+        let idx = ssa.add_const(Constant::U(32, 1));
+        let c_len = ssa.add_const(Constant::U(32, 3));
+        let (seq, got, len) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+
+        let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
+        entry.push_instruction(OpCode::MkSeq {
+            result: seq,
+            elems: vec![c10, c20, c30],
+            seq_type: SequenceTargetType::Array(3),
+            elem_type: Type::u(32),
+        });
+        entry.push_instruction(OpCode::ArrayGet {
+            result: got,
+            array: seq,
+            index: idx,
+        });
+        entry.push_instruction(OpCode::SliceLen {
+            result: len,
+            slice: seq,
+        });
+        entry.set_terminator(Terminator::Return(vec![got, len]));
+
+        let cc = run_in_test(&ssa);
+        SCCP::new().do_run(&mut ssa, &cc);
+
+        let f = ssa.get_unique_entrypoint();
+        // Both projections folded away; only the (internal, now-dead) aggregate constructor remains.
+        assert!(
+            !f.get_entry()
+                .get_instructions()
+                .any(|i| matches!(i, OpCode::ArrayGet { .. } | OpCode::SliceLen { .. })),
+            "the constant projections should have folded away"
+        );
+        assert_eq!(f.get_entry().get_instructions().count(), 1); // the surviving MkSeq
+        // Their uses are aliased to the interned scalars: element 1 == 20, length == 3.
+        assert!(matches!(
+            f.get_entry().get_terminator(),
+            Some(Terminator::Return(vals)) if vals.as_slice() == [c20, c_len]
         ));
     }
 }

--- a/compiler/src/compiler/ssa/hlssa/mod.rs
+++ b/compiler/src/compiler/ssa/hlssa/mod.rs
@@ -1980,6 +1980,16 @@ pub enum Constant {
     Blob(Blob),
 }
 
+impl Constant {
+    /// `true` if this is a scalar constant (not an aggregate `Blob`).
+    pub fn is_scalar(&self) -> bool {
+        match self {
+            Self::U(_, _) | Self::I(_, _) | Self::Field(_) | Self::FnPtr(_) => true,
+            Self::Blob(_) => false,
+        }
+    }
+}
+
 // REFERENCE COUNTING OPS
 // ================================================================================================
 


### PR DESCRIPTION
This commit adds basic support for aggregates in the click-cooper analysis, handling projections from and changes to aggregates. The aggregate constants themselves remain internal as exposing them for use leads to bytecode growth with no benefit. The handling of aggregates as is will yield benefits in future transforms based on Click-Cooper.

Partial work for #260.