### PR TITLE
Precise queries for conditional facts

### DIFF
--- a/compiler/src/compiler/analysis/click_cooper/conditional.rs
+++ b/compiler/src/compiler/analysis/click_cooper/conditional.rs
@@ -7,36 +7,40 @@
 //! post-convergence using a single pass over the already solved function facts structure, plus the
 //! dominance.
 //!
-//! # Dominance and Post-Dominance, not Dataflow
+//! # Dominance, not Dataflow
 //!
 //! An assert is a *global* constraint, not a runtime check: on an accepting run it holds at every
-//! program point, whether the assert lies in that point's past or future. So an assert in reachable
-//! block `B` contributes its fact to the entry of every reachable block `C` for which the assert is
-//! guaranteed to be on the accepting run that flows through `C` — and there are two static ways to
-//! prove that:
+//! program point. So an assert in reachable block `B` contributes its fact to the entry of every
+//! reachable block `C` that `B` strictly dominates — the assert has *already run* before `C`, so
+//! the constraint is established there. Static dominance is sound because every statically-dominating
+//! block also dominates on the executable subgraph (pruning paths only adds dominators), a
+//! conservative under-approximation of executable-path dominance, and thus subsumes the
+//! intersect-at-join dataflow used by branch facts. Because `def(v) dom B dom C`, the asserted value
+//! `v` is transitively live at `C`, so the dominance direction needs no separate in-scope check.
 //!
-//! - **`B` strictly dominates `C`** — the assert has *already run* before `C`. Static dominance is
-//!   sound because every statically-dominating block also dominates on the executable subgraph
-//!   (pruning paths only adds dominators), a conservative under-approximation of executable-path
-//!   dominance, and thus subsumes the intersect-at-join dataflow used by branch facts.
-//! - **`B` strictly post-dominates `C`** — the assert is *bound to run* on every continuation out of
-//!   `C`, so on an accepting (terminating) run the constraint is satisfied and the fact holds at `C`
-//!   too. (A non-terminating run never reaches the assert, but never reaches `exit` either, so it is
-//!   non-accepting and excluded; `post_dominates` is `false` for a block that cannot reach `exit`,
-//!   which is the safe answer.)
+//! # Index Granularity Within the Asserting Block
 //!
-//! The post-dominance direction needs one guard the dominance direction supplies for free: under
-//! dominance `def(v) dom B dom C`, so the asserted value `v` is transitively live at `C`; under
-//! post-dominance that chain breaks, so `v` (both sides, for an equality) must be independently
-//! checked to be in scope at `C` (defined in a block that dominates `C`). This also keeps a
-//! loop-carried value — defined inside a loop and asserted below it — from being mis-attributed to a
-//! pre-loop block.
+//! The dominance fan-out above is *strict* (`B != C`), so it never attributes an assert to its own
+//! block `B`. A use in `B` *after* the assert is instead recovered at index granularity: each
+//! assert is recorded against `B` together with its instruction index (the `local_*` maps), and a
+//! query at a program point in `B` sees the fact only when its use-index is strictly greater than
+//! the assert's.
 //!
-//! Only asserts get the post-dominance direction. A disequality is an *edge* fact (the false edge of
-//! an equality branch): it is path-conditional — true only on the taken edge — so it holds at the
-//! entry of its target block `else_b` only when that edge is the block's sole executable in-edge, and
-//! from there propagates to every block `else_b` *dominates* (reflexively). A post-dominated block
-//! need not have taken that edge, so disequalities stay dominance-only.
+//! Strict `>` is the index-granular form of the "already ran" (dominance) direction, and it
+//! self-protects the constraint: an assert never informs its *own* operands (same index), so it
+//! cannot be folded into a vacuous tautology — not even by a later, contradictory assert in `B`
+//! (the earliest establisher wins — first-writer-wins). The asserted operands are the assert's own
+//! inputs, hence defined before it, hence in scope at every later index — so the `local_*` path
+//! needs no `in_scope` check.
+//!
+//! A use textually *before* a same-block assert is deliberately left at entry granularity: it still
+//! sees any cross-block fact for the same value, and recovering the before-the-assert case would
+//! reintroduce the contradiction hazard for no real gain.
+//!
+//! A disequality is an *edge* fact (the false edge of an equality branch): it is path-conditional —
+//! true only on the taken edge — so it holds at the entry of its target block `else_b` only when
+//! that edge is the block's sole executable in-edge, and from there propagates to every block
+//! `else_b` *dominates* (reflexively).
 
 use std::sync::Arc;
 
@@ -50,10 +54,9 @@ use crate::{
             },
             flow_analysis::CFG,
             types::FunctionTypeInfo,
-            value_definitions::{FunctionValueDefinitions, ValueDefinition},
         },
         ssa::{
-            BlockId, Terminator, ValueId,
+            BlockId, ProgramPoint, Terminator, ValueId,
             hlssa::{CastTarget, CmpKind, Constant, HLFunction, HLSSAConstantsSnapshot, OpCode},
         },
     },
@@ -64,17 +67,41 @@ use crate::{
 
 /// The conditional facts of one function.
 ///
-/// All maps are keyed by the block at whose **entry** the fact holds.
+/// The cross-block maps ([`Self::assert_const`], [`Self::assert_eq`], [`Self::diseq`]) are keyed by
+/// the block at whose **entry** the fact holds. The two `local_*` maps are keyed by the *asserting*
+/// block and additionally carry the establishing assert's instruction index, so their facts hold
+/// only at use-indices after it (see their field docs and the module "Index Granularity" section).
 #[derive(Debug, Default)]
 pub(crate) struct ConditionalFacts {
-    /// Values forced to a constant by a dominating or post-dominating assert: `Assert{v}` ⇒
-    /// `v = true`, `AssertCmp{Eq, x, c}` (with one side unconditional-constant `c`) ⇒ the other
-    /// side `= c`.
+    /// Values forced to a constant by a dominating assert: `Assert{v}` ⇒ `v = true`,
+    /// `AssertCmp{Eq, x, c}` (with one side unconditional-constant `c`) ⇒ the other side `= c`.
     assert_const: HashMap<BlockId, HashMap<ValueId, Arc<Constant>>>,
 
-    /// Equalities established by a dominating or post-dominating `AssertCmp{Eq, a, b}` where neither
-    /// side is a (unconditional) constant — a *conditional* analog of congruence's `known_equal`.
+    /// Equalities established by a dominating `AssertCmp{Eq, a, b}` where neither side is a
+    /// (unconditional) constant — a *conditional* analog of congruence's `known_equal`.
+    ///
+    /// Each pair is stored canonically as `(min, max)` by value id, so `(a, b)` and `(b, a)` dedup
+    /// as one.
     assert_eq: HashMap<BlockId, Vec<(ValueId, ValueId)>>,
+
+    /// Values pinned to a constant by an assert *within* the keyed block, each paired with the
+    /// instruction index of the establishing assert.
+    ///
+    /// The within-block analog of [`Self::assert_const`]: rather than holding at the whole block,
+    /// each entry holds only at use-indices strictly greater than its stored index, recovering uses
+    /// in the asserting block after the assert. The `Vec` is in instruction order (so the earliest
+    /// establisher wins); it must not be sorted or deduplicated, as that order *is* the
+    /// deterministic first-writer rule.
+    local_assert_const: HashMap<BlockId, Vec<(usize, ValueId, Arc<Constant>)>>,
+
+    /// Equalities established by an `AssertCmp{Eq, a, b}` *within* the keyed block (neither side a
+    /// constant), each paired with the assert's instruction index.
+    ///
+    /// The within-block analog of [`Self::assert_eq`], holding only at use-indices strictly greater
+    /// than the stored index; likewise kept in instruction order. Each pair is stored canonically
+    /// as `(min, max)` by value id (the *entries* stay in instruction order — only each pair's two
+    /// sides are ordered).
+    local_assert_eq: HashMap<BlockId, Vec<(usize, ValueId, ValueId)>>,
 
     /// Disequalities `(a, b)` from the false edge of an equality `JmpIf` dominating the block.
     diseq: HashMap<BlockId, HashSet<(ValueId, ValueId)>>,
@@ -89,17 +116,37 @@ pub(crate) struct ConditionalFacts {
 }
 
 impl ConditionalFacts {
-    /// The constant `v` is forced to on entry to `bid` by a dominating assert, or `None`.
-    pub(crate) fn asserted_const(&self, bid: BlockId, v: ValueId) -> Option<Arc<Constant>> {
-        self.assert_const.get(&bid)?.get(&v).cloned()
+    /// The constant `v` is forced to at `point` by a dominating assert (valid at every index of the
+    /// block) or by a same-block assert strictly before `point.index`, or `None`.
+    pub(crate) fn asserted_const(&self, point: ProgramPoint, v: ValueId) -> Option<Arc<Constant>> {
+        // A cross-block assert holds at every index of the block.
+        if let Some(c) = self.assert_const.get(&point.block).and_then(|m| m.get(&v)) {
+            return Some(c.clone());
+        }
+
+        // Otherwise a same-block assert strictly *before* the use supplies the fact. The `Vec` is
+        // in instruction order, so `find` returns the earliest establisher (first-writer-wins).
+        self.local_assert_const
+            .get(&point.block)?
+            .iter()
+            .find(|(i, vv, _)| *i < point.index && *vv == v)
+            .map(|(_, _, c)| c.clone())
     }
 
-    /// `true` if a dominating assert proves `a == b` on entry to `bid` (reflexive + symmetric).
-    pub(crate) fn asserted_equal(&self, bid: BlockId, a: ValueId, b: ValueId) -> bool {
+    /// `true` if `a == b` is proven at `point` by a dominating assert or by a same-block assert
+    /// strictly before `point.index` (reflexive + symmetric).
+    pub(crate) fn asserted_equal(&self, point: ProgramPoint, a: ValueId, b: ValueId) -> bool {
+        // Pairs are stored canonically as `(min, max)` by value id, so canonicalize the query pair
+        // once and compare directly.
+        let (lo, hi) = if a.0 <= b.0 { (a, b) } else { (b, a) };
         a == b
-            || self.assert_eq.get(&bid).is_some_and(|eqs| {
+            || self
+                .assert_eq
+                .get(&point.block)
+                .is_some_and(|eqs| eqs.iter().any(|p| *p == (lo, hi)))
+            || self.local_assert_eq.get(&point.block).is_some_and(|eqs| {
                 eqs.iter()
-                    .any(|(x, y)| (*x == a && *y == b) || (*x == b && *y == a))
+                    .any(|(i, x, y)| *i < point.index && (*x, *y) == (lo, hi))
             })
     }
 
@@ -147,36 +194,25 @@ pub(crate) fn build(
         }
     };
 
-    // A value→defining-block lookup, used to gate the post-dominance fan-out (Step 3) on the
-    // asserted value being live at the target block. `v` is in scope on entry to `c` iff it is
-    // defined in a block that dominates `c`. A value with no structural definition (an interned
-    // constant / global) is in scope everywhere. Dominance fan-out needs no such check: `def(v)`
-    // dominates the asserting block, which dominates the target, so `v` is transitively live there.
-    let defs = FunctionValueDefinitions::from_function(function);
-    let in_scope = |v: ValueId, c: BlockId| match defs.get_definition(v) {
-        Some(ValueDefinition::Param(b, ..) | ValueDefinition::Instruction(b, ..)) => {
-            cfg.dominates(*b, c)
-        }
-        None => true,
-    };
-
-    // Step 1: Gather facts at their establishing block, plus the (global) witness forwards and the
-    // `Cmp{Eq}` results needed to interpret equality branches.
-    let mut raw_const: HashMap<BlockId, Vec<(ValueId, Arc<Constant>)>> = HashMap::default();
-    let mut raw_eq: HashMap<BlockId, Vec<(ValueId, ValueId)>> = HashMap::default();
+    // Step 1: Gather facts at their establishing block — tagged with the instruction index of the
+    // establishing assert, so the asserting block's own post-assert uses can be recovered at index
+    // granularity (the cross-block fan-out in Step 3 ignores the index) — plus the (global) witness
+    // forwards and the `Cmp{Eq}` results needed to interpret equality branches.
+    let mut raw_const: HashMap<BlockId, Vec<(usize, ValueId, Arc<Constant>)>> = HashMap::default();
+    let mut raw_eq: HashMap<BlockId, Vec<(usize, ValueId, ValueId)>> = HashMap::default();
     let mut eq_cmp_of: HashMap<ValueId, (ValueId, ValueId)> = HashMap::default();
 
     for (bid, block) in function.get_blocks() {
         if !facts.reachable.contains(bid) {
             continue;
         }
-        for instr in block.get_instructions() {
+        for (idx, instr) in block.get_instructions().enumerate() {
             match instr {
                 OpCode::Assert { value } => {
                     raw_const
                         .entry(*bid)
                         .or_default()
-                        .push((*value, bool_constant(true)));
+                        .push((idx, *value, bool_constant(true)));
                 }
                 OpCode::AssertCmp {
                     kind: CmpKind::Eq,
@@ -184,11 +220,18 @@ pub(crate) fn build(
                     rhs,
                 } => {
                     if let Some(c) = const_of(*lhs) {
-                        raw_const.entry(*bid).or_default().push((*rhs, c));
+                        raw_const.entry(*bid).or_default().push((idx, *rhs, c));
                     } else if let Some(c) = const_of(*rhs) {
-                        raw_const.entry(*bid).or_default().push((*lhs, c));
+                        raw_const.entry(*bid).or_default().push((idx, *lhs, c));
                     } else {
-                        raw_eq.entry(*bid).or_default().push((*lhs, *rhs));
+                        // Store the pair canonically (min, max) by value id so `(x, y)` and
+                        // `(y, x)` dedup as one in the cross-block fan-out below.
+                        let (lo, hi) = if lhs.0 <= rhs.0 {
+                            (*lhs, *rhs)
+                        } else {
+                            (*rhs, *lhs)
+                        };
+                        raw_eq.entry(*bid).or_default().push((idx, lo, hi));
                     }
                 }
                 OpCode::Cmp {
@@ -238,6 +281,13 @@ pub(crate) fn build(
     // whose entry they hold. The fact holds there only when that edge is the target's *sole*
     // executable in-edge (otherwise a join could merge in a path that never established it).
     let mut raw_diseq: HashMap<BlockId, HashSet<(ValueId, ValueId)>> = HashMap::default();
+
+    // Executable in-edges per block (the reverse of `exec_edges`), built once for efficiency.
+    let mut exec_preds_of: HashMap<BlockId, Vec<BlockId>> = HashMap::default();
+    for (p, t) in &facts.exec_edges {
+        exec_preds_of.entry(*t).or_default().push(*p);
+    }
+
     for (bid, block) in function.get_blocks() {
         if !facts.reachable.contains(bid) {
             continue;
@@ -257,22 +307,20 @@ pub(crate) fn build(
             continue;
         }
 
-        let preds: Vec<BlockId> = facts
-            .exec_edges
-            .iter()
-            .filter(|(_, t)| t == else_b)
-            .map(|(p, _)| *p)
-            .collect();
+        let preds = exec_preds_of
+            .get(else_b)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
         if preds.len() == 1 && preds[0] == *bid {
             raw_diseq.entry(*else_b).or_default().insert((*lhs, *rhs));
         }
     }
 
-    // Step 3: Fan out to dominated (and, for asserts, post-dominated) blocks. The inner loop only
-    // needs the blocks that actually established a fact (the keys of the raw maps), not every
-    // reachable block. Iterating sorted targets `C` (outer) and sorted fact-source blocks `B`
-    // (inner) keeps the result deterministic and first-writer-wins on any contradictory pair of
-    // asserts (which can only co-dominate/co-post-dominate a block that no honest run reaches).
+    // Step 3: Fan out to dominated blocks. The inner loop only needs the blocks that actually
+    // established a fact (the keys of the raw maps), not every reachable block. Iterating sorted
+    // targets `C` (outer) and sorted fact-source blocks `B` (inner) keeps the result deterministic
+    // and first-writer-wins on any contradictory pair of asserts (which can only co-dominate a block
+    // that no honest run reaches).
     let mut reachable_blocks: Vec<BlockId> = facts.reachable.iter().copied().collect();
     reachable_blocks.sort_by_key(|b| b.0);
     let mut fact_sources: Vec<BlockId> = raw_const
@@ -286,43 +334,33 @@ pub(crate) fn build(
 
     for &c in &reachable_blocks {
         for &b in &fact_sources {
-            // Assert facts hold at `C` when the assert is guaranteed on every run flowing through
-            // `C`: either it has already run (`B` strictly dominates `C`) or it is bound to run on
-            // every continuation (`B` strictly post-dominates `C`). `B != C` excludes the asserting
-            // block's own entry.
-            let dominates = b != c && cfg.dominates(b, c);
-            let post_dominates = b != c && cfg.post_dominates(b, c);
-
-            if dominates || post_dominates {
+            // Assert facts hold at `C` when the assert has already run before `C`, i.e. `B` strictly
+            // dominates `C`. `B != C` excludes the asserting block's own entry; its own post-assert
+            // uses are recovered separately at index granularity from the `local_*` maps (see the
+            // module "Index Granularity" section). Dominance makes the asserted value transitively
+            // live at `C`, so no in-scope check is needed. The post-dominance direction is
+            // deliberately omitted as unsound for loop-carried values — see `mod.rs`'s "Deferred
+            // Improvements".
+            if b != c && cfg.dominates(b, c) {
                 if let Some(consts_at_b) = raw_const.get(&b) {
                     let entry = out.assert_const.entry(c).or_default();
-                    for (v, k) in consts_at_b {
-                        // Dominance makes `v` transitively live at `C`; under post-dominance only,
-                        // `v` must be independently in scope (see the module soundness note).
-                        if dominates || in_scope(*v, c) {
-                            entry.entry(*v).or_insert_with(|| k.clone());
-                        }
+                    for (_i, v, k) in consts_at_b {
+                        entry.entry(*v).or_insert_with(|| k.clone());
                     }
                 }
                 if let Some(eqs_at_b) = raw_eq.get(&b) {
                     let entry = out.assert_eq.entry(c).or_default();
-                    for pair in eqs_at_b {
-                        let (x, y) = pair;
-
-                        // Post-dominance requires *both* sides of the equality to be in scope at
-                        // `C`.
-                        if (dominates || (in_scope(*x, c) && in_scope(*y, c)))
-                            && !entry.contains(pair)
-                        {
-                            entry.push(*pair);
+                    for (_i, x, y) in eqs_at_b {
+                        let pair = (*x, *y);
+                        if !entry.contains(&pair) {
+                            entry.push(pair);
                         }
                     }
                 }
             }
 
             // Disequalities are path-conditional edge facts already attached to their target's
-            // entry, so they propagate reflexively (`B == C` keeps the fact at the target itself)
-            // and stay dominance-only — a post-dominated block need not have taken that edge.
+            // entry, so they propagate reflexively (`B == C` keeps the fact at the target itself).
             if cfg.dominates(b, c) {
                 if let Some(diseqs_at_b) = raw_diseq.get(&b) {
                     let entry = out.diseq.entry(c).or_default();
@@ -333,6 +371,11 @@ pub(crate) fn build(
             }
         }
     }
+
+    // The raw per-block asserts (now unborrowed by Step 3) *are* the asserting block's own facts,
+    // already in instruction order: move them in to drive the index-granular `local_*` queries.
+    out.local_assert_const = raw_const;
+    out.local_assert_eq = raw_eq;
 
     out
 }

--- a/compiler/src/compiler/analysis/click_cooper/mod.rs
+++ b/compiler/src/compiler/analysis/click_cooper/mod.rs
@@ -75,8 +75,10 @@
 //!   accepting runs that preserve their establishing constraint, so they are exposed only through
 //!   dedicated queries. An assert, being a global constraint that holds at every point of an
 //!   accepting run, is *also* attributed to in-scope blocks it post-dominates (the assert is then
-//!   guaranteed on every continuation). Control-flow derived equality and disequality facts, being
-//!   path-conditional, stay dominance-only.
+//!   guaranteed on every continuation), and — at index granularity — to uses *after* it in its own
+//!   block (the index-precise "already ran" direction; a use textually before a same-block assert
+//!   still sees only the cross-block facts). Control-flow derived equality and disequality facts,
+//!   being path-conditional, stay dominance-only.
 //! - **Witness Forwarding:** Both readings of the one witness↔value correspondence — the
 //!   `WriteWitness` hint (`r = witness_of(v)`) and the `ValueOf` projection (`v = value_of(r)`) —
 //!   only _add_ constraints and hence never reject an honest run, while two free witnesses are
@@ -103,10 +105,6 @@
 //!
 //! The following are improvements planned for the future of this analysis.
 //!
-//! - **Assert Facts at Index Granularity:** Assert-derived facts are attributed at block-entry
-//!   granularity via *strict* dominance/post-dominance, so a use in the asserting block itself
-//!   (after the assert) is not yet claimed. Index-precise program points would recover it; soundness
-//!   is unaffected.
 //! - **Symbolic Interprocedural Congruence:** Cross-call congruence currently requires that *all*
 //!   arguments are congruent and is gated on a whole-return determinism bit; it does not graft a
 //!   callee's return expression into the caller, so it cannot relate `f(x)` to an open expression
@@ -119,6 +117,12 @@
 //!   pass per `(function, context)` — as `specialize` already does for the unconditional facts —
 //!   would let a context-specialized assert or branch expose more facts, and would warrant adding
 //!   the `_in` variants.
+//! - **Sound Post-Dominance for Assert Facts:** Assert facts (`asserted_const`/`asserted_equal`)
+//!   currently fan out by dominance only. The post-dominance direction — an assert in `B` is *bound
+//!   to run* at every block `C` it strictly post-dominates, so its fact would also hold at a use
+//!   *before* a requires an additional notion of value stability to be added to the analysis. A
+//!   future post-dominance direction would require gating all of the asserted values on being
+//!   value-stable using a cyclic-SCC membership primitive.
 
 mod conditional;
 mod congruence;
@@ -147,7 +151,7 @@ use crate::{
         },
         pass_manager::{Analysis, AnalysisId, AnalysisStore},
         ssa::{
-            BlockId, FunctionId, ValueId,
+            BlockId, FunctionId, ProgramPoint, ValueId,
             hlssa::{Constant, HLSSA, HLSSAConstantsSnapshot},
         },
     },
@@ -448,23 +452,42 @@ impl ClickCooper {
         out
     }
 
-    /// The constant `v` is pinned to on entry to `bid` in `f` by a *dominating assert*
-    /// (`Assert{v}`⇒`true`, or `AssertCmp{Eq, v, c}`).
+    /// The constant `v` is pinned to at `point` in `f` (`Assert{v}`⇒`true`, or
+    /// `AssertCmp{Eq, v, c}`) by a *dominating assert* (which holds at every index of `point.block`)
+    /// or by an assert *earlier in `point.block`* than `point.index`.
     ///
-    /// A conditional fact, deliberately disjoint from [`Self::const_of`] as a
-    /// consumer must keep the establishing assert.
-    pub fn asserted_const(&self, f: FunctionId, bid: BlockId, v: ValueId) -> Option<Arc<Constant>> {
-        self.conditional.get(&f)?.asserted_const(bid, v)
+    /// `point.index` is the position of the *using* instruction itself within
+    /// `point.block.get_instructions()` — a consumer walking `get_instructions().enumerate()` has
+    /// it for free, and a use in the terminator takes `index == get_instructions().count()`. A
+    /// same-block assert is reported only for use-indices *strictly greater* than its own, so the
+    /// assert never folds its own operand and vacuums the constraint.
+    ///
+    /// A conditional fact, deliberately disjoint from [`Self::const_of`] as a consumer must keep
+    /// the establishing assert.
+    pub fn asserted_const(
+        &self,
+        f: FunctionId,
+        point: ProgramPoint,
+        v: ValueId,
+    ) -> Option<Arc<Constant>> {
+        self.conditional.get(&f)?.asserted_const(point, v)
     }
 
-    /// `true` if a dominating `AssertCmp{Eq}` proves `a == b` on entry to `bid` in `f`.
+    /// `true` if `a == b` is proven at `point` in `f` by a dominating `AssertCmp{Eq}` or one
+    /// earlier in `point.block` than `point.index`.
     ///
     /// The conditional analog of [`Self::known_equal`] (structural congruence): sound only for
     /// constraint-preserving use, so kept out of the unconditional partition.
-    pub fn asserted_equal(&self, f: FunctionId, bid: BlockId, a: ValueId, b: ValueId) -> bool {
+    pub fn asserted_equal(
+        &self,
+        f: FunctionId,
+        point: ProgramPoint,
+        a: ValueId,
+        b: ValueId,
+    ) -> bool {
         self.conditional
             .get(&f)
-            .is_some_and(|c| c.asserted_equal(bid, a, b))
+            .is_some_and(|c| c.asserted_equal(point, a, b))
     }
 
     /// `true` if `a` and `b` are proven unequal on entry to `bid` in `f` (the false edge of an

--- a/compiler/src/compiler/analysis/click_cooper/solver.rs
+++ b/compiler/src/compiler/analysis/click_cooper/solver.rs
@@ -838,6 +838,7 @@ pub(crate) fn solve_with_writeback(
     // to `None`, `set_lattice`'s guard is `false`, and `into_facts` materialises nothing).
     let mut promotions: HashMap<ValueId, Arc<Constant>> = HashMap::default();
     let mut facts = None;
+    let mut converged = false;
     for _ in 0..MAX_WRITEBACK_ROUNDS {
         let mut solver = FunctionSolver::new(function, consts)
             .with_determinism(det)
@@ -855,12 +856,19 @@ pub(crate) fn solve_with_writeback(
         for (v, c) in derive_promotions(function, &solved) {
             promotions.entry(v).or_insert(c);
         }
-        let converged = promotions.len() == before;
+        converged = promotions.len() == before;
         facts = Some(solved);
         if converged {
             break;
         }
     }
+
+    debug_assert!(
+        converged,
+        "ClickCooper combined-fixpoint writeback did not converge within {MAX_WRITEBACK_ROUNDS} \
+         rounds for `{}` (expected 1–2)",
+        function.get_name(),
+    );
     facts.expect("the writeback loop always runs at least one round")
 }
 

--- a/compiler/src/compiler/analysis/click_cooper/test.rs
+++ b/compiler/src/compiler/analysis/click_cooper/test.rs
@@ -3,7 +3,7 @@ use crate::compiler::{
     Field,
     analysis::types::Types,
     ssa::{
-        Terminator,
+        ProgramPoint, Terminator,
         hlssa::{
             BinaryArithOpKind, Blob, CallTarget, CastTarget, CmpKind, Constant, HLSSA, OpCode,
             ScalarFold, SequenceTargetType, SliceOpDir, Type,
@@ -693,11 +693,22 @@ fn assert_eq_const_is_conditional_not_unconditional() {
     assert!(cc.new_const_values(fid).iter().all(|(v, _)| *v != x));
     // Conditionally `x == 5` at every block the assert *strictly* dominates ...
     assert_eq!(
-        cc.asserted_const(fid, after, x).as_deref(),
+        cc.asserted_const(fid, ProgramPoint::new(after, 0), x)
+            .as_deref(),
         Some(&Constant::U(32, 5))
     );
-    // ... but not in the asserting block itself (block-entry granularity).
-    assert_eq!(cc.asserted_const(fid, entry_id, x), None);
+    // ... and, at index granularity, in the asserting block itself *after* the assert (the assert is
+    // instruction 0, so the terminator at index 1 sees the pin) ...
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 1), x)
+            .as_deref(),
+        Some(&Constant::U(32, 5))
+    );
+    // ... but never at the assert's own index, where folding `x` would vacuum the constraint.
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 0), x),
+        None
+    );
 }
 
 /// `assert(b)` proves `b == true` conditionally in dominated blocks, never unconditionally.
@@ -707,6 +718,7 @@ fn assert_bool_is_conditional() {
     let b = ssa.fresh_value();
 
     let f = ssa.get_unique_entrypoint_mut();
+    let entry_id = f.get_entry_id();
     let after = f.add_block();
     f.get_entry_mut().push_parameter(b, Type::u(1));
     f.get_entry_mut()
@@ -720,8 +732,20 @@ fn assert_bool_is_conditional() {
     let cc = run_in_test(&ssa);
     assert_eq!(cc.const_of(fid, b), None);
     assert_eq!(
-        cc.asserted_const(fid, after, b).as_deref(),
+        cc.asserted_const(fid, ProgramPoint::new(after, 0), b)
+            .as_deref(),
         Some(&Constant::U(1, 1))
+    );
+    // Index granularity: the bool pin also holds after the `Assert` (instruction 0) in its own
+    // block, but not at the assert's own index.
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 1), b)
+            .as_deref(),
+        Some(&Constant::U(1, 1))
+    );
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 0), b),
+        None
     );
 }
 
@@ -749,9 +773,13 @@ fn assert_eq_pure_equality_is_conditional() {
 
     let fid = ssa.get_unique_entrypoint_id();
     let cc = run_in_test(&ssa);
-    assert!(cc.asserted_equal(fid, after, x, y));
-    assert!(cc.asserted_equal(fid, after, y, x)); // symmetric
-    assert!(!cc.asserted_equal(fid, entry_id, x, y)); // not in the asserting block
+    assert!(cc.asserted_equal(fid, ProgramPoint::new(after, 0), x, y));
+    assert!(cc.asserted_equal(fid, ProgramPoint::new(after, 0), y, x)); // symmetric
+    // Index granularity: also holds after the assert (index 0) in its own block, symmetrically ...
+    assert!(cc.asserted_equal(fid, ProgramPoint::new(entry_id, 1), x, y));
+    assert!(cc.asserted_equal(fid, ProgramPoint::new(entry_id, 1), y, x));
+    // ... but not at the assert's own index.
+    assert!(!cc.asserted_equal(fid, ProgramPoint::new(entry_id, 0), x, y));
     // Structural congruence (unconditional) does not see the assert.
     assert!(!cc.known_equal(fid, x, y));
 }
@@ -886,11 +914,14 @@ fn witness_forward_unions_hint_and_value_of_reads() {
     assert!(!cc.known_equal(fid, r, r2));
 }
 
-/// An assert placed in the *last* block proves nothing by dominance (nothing follows it), but it
-/// post-dominates everything upstream — so on accepting runs its fact holds at those earlier
-/// blocks. The asserted value (`x`, a parameter) is in scope throughout.
+/// An assert placed in the *last* block proves nothing by dominance (nothing follows it). The
+/// post-dominance direction — which would carry its fact up to the earlier blocks it post-dominates
+/// — was removed because it is unsound for loop-carried values (see `mod.rs`'s "Deferred
+/// Improvements" and `post_dominating_assert_unsound_for_loop_carried_value`), so the
+/// fact is *not* propagated to `entry`/`mid`. Index granularity still recovers it within the
+/// asserting block.
 #[test]
-fn assert_below_use_holds_via_post_dominance() {
+fn post_dominance_not_propagated_at_block_granularity() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let c5 = ssa.add_const(Constant::U(32, 5));
     let x = ssa.fresh_value();
@@ -914,65 +945,84 @@ fn assert_below_use_holds_via_post_dominance() {
 
     let fid = ssa.get_unique_entrypoint_id();
     let cc = run_in_test(&ssa);
-    // `tail` post-dominates `mid` and `entry`, so `x == 5` holds at both — a fact pure dominance
-    // (the assert is last) would miss entirely.
+    // `tail` only post-dominates `mid`/`entry` (it does not dominate them), so its assert's fact is
+    // withheld there now that the post-dominance direction is gone.
+    assert_eq!(cc.asserted_const(fid, ProgramPoint::new(mid, 0), x), None);
     assert_eq!(
-        cc.asserted_const(fid, mid, x).as_deref(),
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 0), x),
+        None
+    );
+    // In the asserting block, index granularity still recovers it *after* the assert (index 0), but
+    // not at the assert's own index.
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(tail, 1), x)
+            .as_deref(),
         Some(&Constant::U(32, 5))
     );
-    assert_eq!(
-        cc.asserted_const(fid, entry_id, x).as_deref(),
-        Some(&Constant::U(32, 5))
-    );
-    // Still never recorded at the asserting block's own entry (block-entry granularity).
-    assert_eq!(cc.asserted_const(fid, tail, x), None);
+    assert_eq!(cc.asserted_const(fid, ProgramPoint::new(tail, 0), x), None);
 }
 
-/// Post-dominance fan-out is gated on the asserted value being in scope: a value defined *below*
-/// the target block must not have the fact attributed to that target (the guard dominance
-/// otherwise supplies for free).
+/// Regression for the soundness bug that motivated removing the post-dominance direction: a
+/// loop-carried value asserted *after* the loop. `after` post-dominates `header`/`body` and
+/// `def(v) = header` dominates them, yet `v` is `0..9` at the header on every iteration but the
+/// last — so pinning `v = 10` there is false, and a constraint-preserving consumer could fold the
+/// loop away and turn an accepting run rejecting. With post-dominance gone the fact is withheld at
+/// `header` and `body` (the old code wrongly produced `Some(10)`).
 #[test]
-fn post_dominance_respects_value_scope() {
+fn post_dominating_assert_unsound_for_loop_carried_value() {
     let mut ssa = HLSSA::with_main("main".to_string());
+    let c0 = ssa.add_const(Constant::U(32, 0));
+    let c1 = ssa.add_const(Constant::U(32, 1));
     let c10 = ssa.add_const(Constant::U(32, 10));
-    let p = ssa.fresh_value();
-    let x = ssa.fresh_value();
+    let (v, lt, v1) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
-    let entry_id = f.get_entry_id();
-    let mid = f.add_block();
-    let tail = f.add_block();
-    f.get_entry_mut().push_parameter(p, Type::u(32));
+    let header = f.add_block();
+    let body = f.add_block();
+    let after = f.add_block();
+
     f.get_entry_mut()
-        .set_terminator(Terminator::Jmp(mid, vec![]));
-    // `x` is defined in `mid`, *below* `entry`.
-    f.get_block_mut(mid)
-        .push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: x,
-            lhs: p,
-            rhs: p,
-        });
-    f.get_block_mut(mid)
-        .set_terminator(Terminator::Jmp(tail, vec![]));
-    f.get_block_mut(tail).push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: x,
+        .set_terminator(Terminator::Jmp(header, vec![c0]));
+    let header_block = f.get_block_mut(header);
+    header_block.push_parameter(v, Type::u(32));
+    header_block.push_instruction(OpCode::Cmp {
+        kind: CmpKind::Lt,
+        result: lt,
+        lhs: v,
         rhs: c10,
     });
-    f.get_block_mut(tail)
-        .set_terminator(Terminator::Return(vec![]));
+    header_block.set_terminator(Terminator::JmpIf(lt, body, after));
+    let body_block = f.get_block_mut(body);
+    body_block.push_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: v1,
+        lhs: v,
+        rhs: c1,
+    });
+    body_block.set_terminator(Terminator::Jmp(header, vec![v1]));
+    let after_block = f.get_block_mut(after);
+    after_block.push_instruction(OpCode::AssertCmp {
+        kind: CmpKind::Eq,
+        lhs: v,
+        rhs: c10,
+    });
+    after_block.set_terminator(Terminator::Return(vec![]));
 
     let fid = ssa.get_unique_entrypoint_id();
     let cc = run_in_test(&ssa);
-    // At `mid`, `x` is in scope and `tail` post-dominates it ⇒ the fact holds.
+    // The (removed) post-dominance attribution would pin `v = 10` at the loop header/body; it must
+    // not, regardless of `def(v)` being in scope there.
     assert_eq!(
-        cc.asserted_const(fid, mid, x).as_deref(),
+        cc.asserted_const(fid, ProgramPoint::new(header, 0), v),
+        None
+    );
+    assert_eq!(cc.asserted_const(fid, ProgramPoint::new(body, 0), v), None);
+    // Sanity: within `after`, after the assert (index 0), index granularity still recovers it.
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(after, 1), v)
+            .as_deref(),
         Some(&Constant::U(32, 10))
     );
-    // At `entry`, `x` is not yet defined — the in-scope guard withholds the fact even though
-    // `tail` post-dominates `entry`.
-    assert_eq!(cc.asserted_const(fid, entry_id, x), None);
 }
 
 /// An assert on only one arm of a branch neither dominates nor post-dominates the blocks around
@@ -1010,54 +1060,338 @@ fn assert_on_one_branch_does_not_post_dominate() {
     let cc = run_in_test(&ssa);
     // `x` is in scope everywhere, so only the missing dominance/post-dominance keeps the fact
     // out of `entry` and `merge` (the `else` path skips the assert).
-    assert_eq!(cc.asserted_const(fid, entry_id, x), None);
-    assert_eq!(cc.asserted_const(fid, merge, x), None);
-    // And never at the asserting block's own entry.
-    assert_eq!(cc.asserted_const(fid, then_b, x), None);
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 0), x),
+        None
+    );
+    assert_eq!(cc.asserted_const(fid, ProgramPoint::new(merge, 0), x), None);
+    // In the asserting block itself the fact is still recovered after the assert (index
+    // granularity), but never at the assert's own index.
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(then_b, 1), x)
+            .as_deref(),
+        Some(&Constant::U(32, 5))
+    );
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(then_b, 0), x),
+        None
+    );
 }
 
-/// A post-dominating *pure* equality (`assert(x == y)`, neither side constant) requires *both*
-/// sides in scope at the target.
+/// A use in the terminator sits at `index == instruction count`, so the asserting block's own pin
+/// reaches a value the terminator forwards (here a return), proving the index convention.
 #[test]
-fn post_dominating_assert_eq_needs_both_sides_in_scope() {
+fn local_assert_reaches_terminator_use() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let x = ssa.fresh_value();
-    let y = ssa.fresh_value();
-    let p = ssa.fresh_value();
+    let c5 = ssa.add_const(Constant::U(32, 5));
+    let (x, doubled) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
     let entry_id = f.get_entry_id();
-    let mid = f.add_block();
-    let tail = f.add_block();
     f.get_entry_mut().push_parameter(x, Type::u(32));
-    f.get_entry_mut().push_parameter(p, Type::u(32));
-    f.get_entry_mut()
-        .set_terminator(Terminator::Jmp(mid, vec![]));
-    // `y` is defined in `mid`, below `entry`.
-    f.get_block_mut(mid)
-        .push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: y,
-            lhs: p,
-            rhs: p,
-        });
-    f.get_block_mut(mid)
-        .set_terminator(Terminator::Jmp(tail, vec![]));
-    f.get_block_mut(tail).push_instruction(OpCode::AssertCmp {
+    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+        // index 0
         kind: CmpKind::Eq,
         lhs: x,
-        rhs: y,
+        rhs: c5,
     });
-    f.get_block_mut(tail)
+    f.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+        // index 1
+        kind: BinaryArithOpKind::Add,
+        result: doubled,
+        lhs: x,
+        rhs: x,
+    });
+    f.get_entry_mut()
+        .set_terminator(Terminator::Return(vec![doubled])); // terminator: index 2
+
+    let fid = ssa.get_unique_entrypoint_id();
+    let term_index = ssa
+        .get_unique_entrypoint()
+        .get_entry()
+        .get_instructions()
+        .count();
+    assert_eq!(term_index, 2);
+    let cc = run_in_test(&ssa);
+    // The pin holds at the terminator's index (== instruction count) and at the add after it ...
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, term_index), x)
+            .as_deref(),
+        Some(&Constant::U(32, 5))
+    );
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 1), x)
+            .as_deref(),
+        Some(&Constant::U(32, 5))
+    );
+    // ... but not at the assert's own index.
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 0), x),
+        None
+    );
+}
+
+/// Two asserts on different values in one block are each recovered only after their own index.
+#[test]
+fn multiple_local_asserts_each_recovered_after_its_index() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let c5 = ssa.add_const(Constant::U(32, 5));
+    let c6 = ssa.add_const(Constant::U(32, 6));
+    let (x, y) = (ssa.fresh_value(), ssa.fresh_value());
+
+    let f = ssa.get_unique_entrypoint_mut();
+    let entry_id = f.get_entry_id();
+    f.get_entry_mut().push_parameter(x, Type::u(32));
+    f.get_entry_mut().push_parameter(y, Type::u(32));
+    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+        // index 0: x == 5
+        kind: CmpKind::Eq,
+        lhs: x,
+        rhs: c5,
+    });
+    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+        // index 1: y == 6
+        kind: CmpKind::Eq,
+        lhs: y,
+        rhs: c6,
+    });
+    f.get_entry_mut().set_terminator(Terminator::Return(vec![]));
+
+    let fid = ssa.get_unique_entrypoint_id();
+    let cc = run_in_test(&ssa);
+    // At index 1 only `x == 5` is in effect (the `y` assert has not been passed yet).
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 1), x)
+            .as_deref(),
+        Some(&Constant::U(32, 5))
+    );
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 1), y),
+        None
+    );
+    // At index 2 both hold.
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 2), x)
+            .as_deref(),
+        Some(&Constant::U(32, 5))
+    );
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 2), y)
+            .as_deref(),
+        Some(&Constant::U(32, 6))
+    );
+}
+
+/// Two contradictory asserts in one block: a use after both sees the *earliest* (first-writer-wins,
+/// the instruction order is the deterministic tie-break), and the first assert's own operand is
+/// never informed by the later one.
+#[test]
+fn contradictory_local_asserts_first_writer_wins() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let c5 = ssa.add_const(Constant::U(32, 5));
+    let c7 = ssa.add_const(Constant::U(32, 7));
+    let x = ssa.fresh_value();
+
+    let f = ssa.get_unique_entrypoint_mut();
+    let entry_id = f.get_entry_id();
+    f.get_entry_mut().push_parameter(x, Type::u(32));
+    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+        // index 0: x == 5
+        kind: CmpKind::Eq,
+        lhs: x,
+        rhs: c5,
+    });
+    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+        // index 1: x == 7
+        kind: CmpKind::Eq,
+        lhs: x,
+        rhs: c7,
+    });
+    f.get_entry_mut().set_terminator(Terminator::Return(vec![]));
+
+    let fid = ssa.get_unique_entrypoint_id();
+    let cc = run_in_test(&ssa);
+    // The first assert's own operand (index 0) is never informed.
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 0), x),
+        None
+    );
+    // Between the two asserts (index 1) only the first is in effect.
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 1), x)
+            .as_deref(),
+        Some(&Constant::U(32, 5))
+    );
+    // After both, first-writer-wins keeps the earliest establisher.
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 2), x)
+            .as_deref(),
+        Some(&Constant::U(32, 5))
+    );
+}
+
+/// A block that is both dominated by an outer assert *and* makes its own asserts: the cross-block
+/// fact holds at *every* index (including before the local re-assert — the documented
+/// before-the-assert behavior), while a local fact holds only after its own index; a cross-block
+/// fact also takes precedence over a contradictory local one.
+#[test]
+fn entry_and_local_assert_facts_layer() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let c5 = ssa.add_const(Constant::U(32, 5));
+    let c6 = ssa.add_const(Constant::U(32, 6));
+    let c7 = ssa.add_const(Constant::U(32, 7));
+    let (a, b) = (ssa.fresh_value(), ssa.fresh_value());
+
+    let f = ssa.get_unique_entrypoint_mut();
+    let inner = f.add_block();
+    f.get_entry_mut().push_parameter(a, Type::u(32));
+    f.get_entry_mut().push_parameter(b, Type::u(32));
+    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+        // outer: a == 5
+        kind: CmpKind::Eq,
+        lhs: a,
+        rhs: c5,
+    });
+    f.get_entry_mut()
+        .set_terminator(Terminator::Jmp(inner, vec![]));
+    let inner_block = f.get_block_mut(inner);
+    inner_block.push_instruction(OpCode::AssertCmp {
+        // index 0: b == 6
+        kind: CmpKind::Eq,
+        lhs: b,
+        rhs: c6,
+    });
+    inner_block.push_instruction(OpCode::AssertCmp {
+        // index 1: a == 7 (contradicts the dominating outer assert)
+        kind: CmpKind::Eq,
+        lhs: a,
+        rhs: c7,
+    });
+    inner_block.set_terminator(Terminator::Return(vec![]));
+
+    let fid = ssa.get_unique_entrypoint_id();
+    let cc = run_in_test(&ssa);
+    // The outer (cross-block) pin on `a` holds at every index of `inner` — before the local
+    // re-assert and after it — and wins over the contradictory local `a == 7`.
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(inner, 0), a)
+            .as_deref(),
+        Some(&Constant::U(32, 5))
+    );
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(inner, 2), a)
+            .as_deref(),
+        Some(&Constant::U(32, 5))
+    );
+    // The local pin on `b` is the before-the-assert gap: absent at index 0, present after index 0.
+    assert_eq!(cc.asserted_const(fid, ProgramPoint::new(inner, 0), b), None);
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(inner, 1), b)
+            .as_deref(),
+        Some(&Constant::U(32, 6))
+    );
+}
+
+/// The asserted operand is defined earlier in the same block: local facts need no `in_scope` check
+/// (the operand is necessarily defined before the assert), and the pin is recovered after it.
+#[test]
+fn local_assert_on_value_defined_earlier_in_block() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let c10 = ssa.add_const(Constant::U(32, 10));
+    let (p, y) = (ssa.fresh_value(), ssa.fresh_value());
+
+    let f = ssa.get_unique_entrypoint_mut();
+    let entry_id = f.get_entry_id();
+    f.get_entry_mut().push_parameter(p, Type::u(32));
+    f.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+        // index 0: y = p + p
+        kind: BinaryArithOpKind::Add,
+        result: y,
+        lhs: p,
+        rhs: p,
+    });
+    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+        // index 1: y == 10
+        kind: CmpKind::Eq,
+        lhs: y,
+        rhs: c10,
+    });
+    f.get_entry_mut()
+        .set_terminator(Terminator::Return(vec![y])); // index 2
+
+    let fid = ssa.get_unique_entrypoint_id();
+    let cc = run_in_test(&ssa);
+    // At/before the assert (index 1): no fact. After it (the return at index 2 forwards `y`): 10.
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 1), y),
+        None
+    );
+    assert_eq!(
+        cc.asserted_const(fid, ProgramPoint::new(entry_id, 2), y)
+            .as_deref(),
+        Some(&Constant::U(32, 10))
+    );
+}
+
+/// An assert inside a loop body is recovered after it within the body, and is not mis-attributed to
+/// the loop header (which the body neither dominates nor post-dominates).
+#[test]
+fn local_assert_in_loop_body() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let c0 = ssa.add_const(Constant::U(32, 0));
+    let c1 = ssa.add_const(Constant::U(32, 1));
+    let (n, i, lt, next) = (
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+    );
+
+    let f = ssa.get_unique_entrypoint_mut();
+    let header = f.add_block();
+    let body = f.add_block();
+    let exit = f.add_block();
+    f.get_entry_mut().push_parameter(n, Type::u(32));
+    f.get_entry_mut()
+        .set_terminator(Terminator::Jmp(header, vec![c0]));
+    let header_block = f.get_block_mut(header);
+    header_block.push_parameter(i, Type::u(32));
+    header_block.push_instruction(OpCode::Cmp {
+        kind: CmpKind::Lt,
+        result: lt,
+        lhs: i,
+        rhs: n,
+    });
+    header_block.set_terminator(Terminator::JmpIf(lt, body, exit));
+    let body_block = f.get_block_mut(body);
+    // `next = i + 1` keeps `i` loop-variant (else it would fold to the constant 0 and the assert
+    // would degrade to a constant pin rather than the pure equality this test exercises).
+    body_block.push_instruction(OpCode::BinaryArithOp {
+        // index 0
+        kind: BinaryArithOpKind::Add,
+        result: next,
+        lhs: i,
+        rhs: c1,
+    });
+    body_block.push_instruction(OpCode::AssertCmp {
+        // index 1: i == n
+        kind: CmpKind::Eq,
+        lhs: i,
+        rhs: n,
+    });
+    body_block.set_terminator(Terminator::Jmp(header, vec![next]));
+    f.get_block_mut(exit)
         .set_terminator(Terminator::Return(vec![]));
 
     let fid = ssa.get_unique_entrypoint_id();
     let cc = run_in_test(&ssa);
-    // Both sides live at `mid` ⇒ the post-dominating equality holds, symmetrically.
-    assert!(cc.asserted_equal(fid, mid, x, y));
-    assert!(cc.asserted_equal(fid, mid, y, x));
-    // `y` is undefined at `entry`, so the equality is withheld there.
-    assert!(!cc.asserted_equal(fid, entry_id, x, y));
+    // Recovered after the assert (index 1) in the body, not at or before its own index.
+    assert!(cc.asserted_equal(fid, ProgramPoint::new(body, 2), i, n));
+    assert!(!cc.asserted_equal(fid, ProgramPoint::new(body, 1), i, n));
+    assert!(!cc.asserted_equal(fid, ProgramPoint::new(body, 0), i, n));
+    // Not mis-attributed to the header (body neither dominates nor post-dominates it).
+    assert!(!cc.asserted_equal(fid, ProgramPoint::new(header, 0), i, n));
+    assert!(!cc.asserted_equal(fid, ProgramPoint::new(header, 2), i, n));
 }
 
 /// A callee that returns a constant: the call result folds interprocedurally in the caller's

--- a/compiler/src/compiler/analysis/liveness.rs
+++ b/compiler/src/compiler/analysis/liveness.rs
@@ -16,16 +16,6 @@ use crate::{
     },
 };
 
-pub enum InstructionPosition {
-    Offset(usize),
-    Terminator,
-}
-
-pub struct InstructionPointer {
-    pub position: InstructionPosition,
-    pub block: BlockId,
-}
-
 pub struct BlockLiveness {
     pub live_in: HashSet<ValueId>,
     pub live_out: HashSet<ValueId>,

--- a/compiler/src/compiler/analysis/witness_taint_inference/phases.rs
+++ b/compiler/src/compiler/analysis/witness_taint_inference/phases.rs
@@ -20,7 +20,7 @@ use crate::compiler::{
         },
     },
     ssa::{
-        BlockId, FunctionId, ValueId,
+        BlockId, FunctionId, ProgramPoint, ValueId,
         hlssa::{CallTarget, HLFunction, HLSSA, OpCode, Type, TypeExpr},
         traits::Instruction,
     },
@@ -451,11 +451,12 @@ struct ContextSolution {
     /// The witness shape of each return value, positionally.
     return_shapes: Vec<WitnessShape>,
 
-    /// Each constrained static call site, keyed by `(block, instruction index)`, paired with the
-    /// concrete callee context it resolves to. Cloning preserves block ids and instruction order,
-    /// so rewiring looks each call up by its site (`BTreeMap` keeps clone-discovery order
-    /// deterministic).
-    calls: BTreeMap<(BlockId, usize), Ctx>,
+    /// Each constrained static call site, keyed by its [`ProgramPoint`], paired with the concrete
+    /// callee context it resolves to.
+    ///
+    /// Cloning preserves block ids and instruction order, so rewiring looks each call up by its
+    /// site (`BTreeMap` keeps clone-discovery order deterministic).
+    calls: BTreeMap<ProgramPoint, Ctx>,
 }
 
 /// Walk the reachable `(function, concrete arg shapes, concrete return-deref shapes, concrete
@@ -529,7 +530,8 @@ fn specialize_contexts(
         ctx_result.insert(ctx, result);
     }
 
-    // Materialize: re-key shapes onto each clone, register FunctionWitnessType, rewire call targets.
+    // Materialize: re-key shapes onto each clone, register FunctionWitnessType, rewire call
+    // targets.
     let mut functions: HashMap<FunctionId, FunctionWitnessType> = HashMap::default();
     for (ctx, result) in &ctx_result {
         let (clone_id, remap) = &ctx_clone[ctx];
@@ -570,7 +572,7 @@ fn specialize_contexts(
                 {
                     let cc = result
                         .calls
-                        .get(&(bid, idx))
+                        .get(&ProgramPoint::new(bid, idx))
                         .expect("ICE: constrained call site without a solved context");
                     *t = ctx_clone[cc].0;
                     rewired += 1;
@@ -683,7 +685,7 @@ fn solve_context(
     }
 
     // Constrained static call sites, keyed by site, with their concrete callee contexts.
-    let mut calls: BTreeMap<(BlockId, usize), Ctx> = BTreeMap::new();
+    let mut calls: BTreeMap<ProgramPoint, Ctx> = BTreeMap::new();
     for (bid, block) in func.get_blocks() {
         let block_cw = *block_cfg_witness.get(bid).unwrap();
         for (idx, instr) in block.get_instructions().enumerate() {
@@ -718,7 +720,7 @@ fn solve_context(
                     })
                     .collect();
                 calls.insert(
-                    (*bid, idx),
+                    ProgramPoint::new(*bid, idx),
                     Ctx {
                         fid: *callee,
                         arg_shapes,

--- a/compiler/src/compiler/passes/common_subexpression_elimination.rs
+++ b/compiler/src/compiler/passes/common_subexpression_elimination.rs
@@ -10,7 +10,7 @@ use crate::{
         pass_manager::{AnalysisId, AnalysisStore, Pass},
         passes::fix_double_jumps::ValueReplacements,
         ssa::{
-            BlockId, SSAConstantsSnapshot, ValueId,
+            BlockId, ProgramPoint, SSAConstantsSnapshot, ValueId,
             hlssa::{
                 BinaryArithOpKind, CastTarget, CmpKind, Constant, Endianness, HLFunction, HLSSA,
                 LookupTarget, OpCode, Radix,
@@ -335,42 +335,29 @@ impl CSE {
                 if occurrences.len() <= 1 {
                     continue;
                 }
-                let mut replacement_groups: Vec<((BlockId, usize, ValueId), Vec<ValueId>)> = vec![];
-                for (block_id, instruction_idx, value_id) in occurrences {
+                let mut replacement_groups: Vec<((ProgramPoint, ValueId), Vec<ValueId>)> = vec![];
+                for (point, value_id) in occurrences {
                     let mut found = false;
-                    for ((candidate_block, candidate_instruction, candidate_value_id), others) in
+                    for ((candidate_point, candidate_value_id), others) in
                         replacement_groups.iter_mut()
                     {
-                        if self.can_replace(
-                            cfg,
-                            *candidate_block,
-                            *candidate_instruction,
-                            block_id,
-                            instruction_idx,
-                        ) {
+                        if self.can_replace(cfg, *candidate_point, point) {
                             found = true;
                             others.push(value_id);
                             break;
-                        } else if self.can_replace(
-                            cfg,
-                            block_id,
-                            instruction_idx,
-                            *candidate_block,
-                            *candidate_instruction,
-                        ) {
+                        } else if self.can_replace(cfg, point, *candidate_point) {
                             found = true;
                             others.push(*candidate_value_id);
-                            *candidate_block = block_id;
-                            *candidate_instruction = instruction_idx;
+                            *candidate_point = point;
                             *candidate_value_id = value_id;
                             break;
                         }
                     }
                     if !found {
-                        replacement_groups.push(((block_id, instruction_idx, value_id), vec![]));
+                        replacement_groups.push(((point, value_id), vec![]));
                     }
                 }
-                for ((_, _, value_id), others) in replacement_groups {
+                for ((_, value_id), others) in replacement_groups {
                     for other in others {
                         value_replacements.insert(other, value_id);
                     }
@@ -379,44 +366,31 @@ impl CSE {
 
             // Side-effect dedup: same dominance grouping as the value loop,
             // but duplicates are dropped rather than redirected.
-            let mut to_remove: HashSet<(BlockId, usize)> = HashSet::default();
+            let mut to_remove: HashSet<ProgramPoint> = HashSet::default();
             for (_, occurrences) in assertions {
                 if occurrences.len() <= 1 {
                     continue;
                 }
-                let mut groups: Vec<(BlockId, usize, Vec<(BlockId, usize)>)> = vec![];
-                for (block_id, instruction_idx) in occurrences {
+                let mut groups: Vec<(ProgramPoint, Vec<ProgramPoint>)> = vec![];
+                for point in occurrences {
                     let mut found = false;
-                    for (candidate_block, candidate_instruction, others) in groups.iter_mut() {
-                        if self.can_replace(
-                            cfg,
-                            *candidate_block,
-                            *candidate_instruction,
-                            block_id,
-                            instruction_idx,
-                        ) {
+                    for (candidate_point, others) in groups.iter_mut() {
+                        if self.can_replace(cfg, *candidate_point, point) {
                             found = true;
-                            others.push((block_id, instruction_idx));
+                            others.push(point);
                             break;
-                        } else if self.can_replace(
-                            cfg,
-                            block_id,
-                            instruction_idx,
-                            *candidate_block,
-                            *candidate_instruction,
-                        ) {
+                        } else if self.can_replace(cfg, point, *candidate_point) {
                             found = true;
-                            others.push((*candidate_block, *candidate_instruction));
-                            *candidate_block = block_id;
-                            *candidate_instruction = instruction_idx;
+                            others.push(*candidate_point);
+                            *candidate_point = point;
                             break;
                         }
                     }
                     if !found {
-                        groups.push((block_id, instruction_idx, vec![]));
+                        groups.push((point, vec![]));
                     }
                 }
-                for (_, _, others) in groups {
+                for (_, others) in groups {
                     for pos in others {
                         to_remove.insert(pos);
                     }
@@ -428,7 +402,7 @@ impl CSE {
                 let old_instructions = block.take_instructions();
                 let mut new_instructions = Vec::with_capacity(old_instructions.len());
                 for (idx, mut instruction) in old_instructions.into_iter().enumerate() {
-                    if to_remove.contains(&(bid, idx)) {
+                    if to_remove.contains(&ProgramPoint::new(bid, idx)) {
                         continue;
                     }
                     value_replacements.replace_inputs(&mut instruction);
@@ -440,18 +414,13 @@ impl CSE {
         }
     }
 
-    fn can_replace(
-        &self,
-        cfg: &CFG,
-        block1: BlockId,
-        instruction1: usize,
-        block2: BlockId,
-        instruction2: usize,
-    ) -> bool {
-        if block1 == block2 && instruction1 < instruction2 {
+    /// Whether a definition/assertion at `p1` is available at `p2`: either earlier in the same block,
+    /// or in a block that dominates `p2`'s.
+    fn can_replace(&self, cfg: &CFG, p1: ProgramPoint, p2: ProgramPoint) -> bool {
+        if p1.block == p2.block && p1.index < p2.index {
             return true;
         }
-        if cfg.dominates(block1, block2) {
+        if cfg.dominates(p1.block, p2.block) {
             return true;
         }
         false
@@ -463,12 +432,12 @@ impl CSE {
         cfg: &CFG,
         constants: &SSAConstantsSnapshot<Constant>,
     ) -> (
-        HashMap<ExprId, Vec<(BlockId, usize, ValueId)>>,
-        HashMap<Assertion, Vec<(BlockId, usize)>>,
+        HashMap<ExprId, Vec<(ProgramPoint, ValueId)>>,
+        HashMap<Assertion, Vec<ProgramPoint>>,
     ) {
         let mut interner = ExprInterner::default();
-        let mut result: HashMap<ExprId, Vec<(BlockId, usize, ValueId)>> = HashMap::default();
-        let mut assertions: HashMap<Assertion, Vec<(BlockId, usize)>> = HashMap::default();
+        let mut result: HashMap<ExprId, Vec<(ProgramPoint, ValueId)>> = HashMap::default();
+        let mut assertions: HashMap<Assertion, Vec<ProgramPoint>> = HashMap::default();
 
         // Seed the value->expr map with the SSA's constants so they can be referenced as operands.
         // They are not recorded into `result`: the constant store already dedups them, so CSE must
@@ -497,7 +466,7 @@ impl CSE {
 
         fn record_expr(
             exprs: &mut HashMap<ValueId, ExprId>,
-            result: &mut HashMap<ExprId, Vec<(BlockId, usize, ValueId)>>,
+            result: &mut HashMap<ExprId, Vec<(ProgramPoint, ValueId)>>,
             block_id: BlockId,
             instruction_idx: usize,
             value_id: ValueId,
@@ -507,11 +476,11 @@ impl CSE {
             result
                 .entry(expr)
                 .or_default()
-                .push((block_id, instruction_idx, value_id));
+                .push((ProgramPoint::new(block_id, instruction_idx), value_id));
         }
 
         fn record_assertion(
-            assertions: &mut HashMap<Assertion, Vec<(BlockId, usize)>>,
+            assertions: &mut HashMap<Assertion, Vec<ProgramPoint>>,
             block_id: BlockId,
             instruction_idx: usize,
             assertion: Assertion,
@@ -519,7 +488,7 @@ impl CSE {
             assertions
                 .entry(assertion)
                 .or_default()
-                .push((block_id, instruction_idx));
+                .push(ProgramPoint::new(block_id, instruction_idx));
         }
 
         fn lookup_target_expr(

--- a/compiler/src/compiler/passes/sparse_conditional_constant_propagation.rs
+++ b/compiler/src/compiler/passes/sparse_conditional_constant_propagation.rs
@@ -118,7 +118,10 @@ fn rewrite(
     let const_set: HashSet<ValueId> = const_values.iter().map(|(v, _)| *v).collect();
 
     // In practice `witness_consts` only ever holds `Cmp` instruction *results* — the sole witnessed
-    // constants the analysis produces (a vacuous witnessed comparison).
+    // constants the analysis produces (a vacuous witnessed comparison). A witness-typed *block
+    // parameter* proven constant would also land here, but is intentionally left as-is (neither
+    // aliased nor redefined — the cast-redefine below runs only for instruction results): sound,
+    // just unfolded.
     let mut witness_consts = HashMap::default();
     for (v, c) in &const_values {
         if fn_type_info.get_value_type(*v).is_witness_of() {

--- a/compiler/src/compiler/ssa/mod.rs
+++ b/compiler/src/compiler/ssa/mod.rs
@@ -865,6 +865,33 @@ impl<Op: Instruction, Ty: SSAType> Function<Op, Ty> {
     }
 }
 
+// PROGRAM POINT
+// ================================================================================================
+
+/// A pointer to a specific instruction in a program.
+///
+/// It describes the `block` in the SSA in which the instruction is found, and the 0-based `index`
+/// of the instruction within that block. The terminating instruction of the block is found at
+/// `index == block.get_instructions().count()`.
+///
+/// Ordering is lexicographic on `(block, index)` so comparing two points is only meaningful where
+/// `p1.block == p2.block`. Across blocks it yields an arbitrary-but-stable total order.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ProgramPoint {
+    /// The block the point lies in.
+    pub block: BlockId,
+
+    /// The instruction position within `block` (the terminator is at the instruction count).
+    pub index: usize,
+}
+
+impl ProgramPoint {
+    /// A point at instruction `index` within `block`.
+    pub fn new(block: BlockId, index: usize) -> Self {
+        Self { block, index }
+    }
+}
+
 // BLOCK
 // ================================================================================================
 


### PR DESCRIPTION
Conditional facts are now able to be queried at a resolution within individual blocks. This allows for far more comprehensive use of those facts for optimization.

Locations within blocks are denoted by the `ProgramPoint` construction, which is also used in WTI and CSE to make the codebase more uniform.

This commit introduces no changes in the test corpus as the new queries are not yet used, and the other pass changes are purely refactorings.