### PR TITLE
Implement symbolic congruence in Click-Cooper

### DIFF
--- a/compiler/src/compiler/analysis/click_cooper/conditional.rs
+++ b/compiler/src/compiler/analysis/click_cooper/conditional.rs
@@ -219,6 +219,7 @@ pub(crate) fn build(
     cfg: &CFG,
     consts: &HLSSAConstantsSnapshot,
     type_info: &FunctionTypeInfo,
+    order: &DefOrder,
 ) -> ConditionalFacts {
     let mut out = ConditionalFacts::default();
 
@@ -421,10 +422,9 @@ pub(crate) fn build(
     // `ConditionalFacts::asserted_leader`. Only values appearing in an equality pair can be class
     // members, and every such value appears in `local_assert_eq` (the cross-block `assert_eq` is
     // fanned out from the same pairs), so a non-empty `local_assert_eq` is the authoritative "any
-    // equalities exist" gate — the (O(n)) definition order and per-block tables are built only
-    // then.
+    // equalities exist" gate — the per-block leader tables are built only then (the definition
+    // `order` is shared from the caller, built once for the congruence leaders too).
     if out.local_assert_eq.values().any(|eqs| !eqs.is_empty()) {
-        let order = DefOrder::new(function, cfg);
         for &b in &reachable_blocks {
             let cross = out.assert_eq.get(&b).map(Vec::as_slice).unwrap_or(&[]);
             let local = out

--- a/compiler/src/compiler/analysis/click_cooper/congruence.rs
+++ b/compiler/src/compiler/analysis/click_cooper/congruence.rs
@@ -16,12 +16,11 @@
 //! - **Reachability** scopes φ-operands — a block parameter's operands are the incoming jump-args
 //!   on each *executable* predecessor edge only, so a dead in-edge never forces two φ's apart.
 
-use std::sync::Arc;
-
+use super::summary::{Sym, SymSummaries};
 use crate::{
     collections::{HashMap, HashSet},
     compiler::{
-        analysis::{click_cooper::def_order::DefOrder, flow_analysis::CFG},
+        analysis::click_cooper::def_order::DefOrder,
         ssa::{
             BlockId, FunctionId, Instruction, Terminator, ValueId,
             hlssa::{
@@ -31,6 +30,7 @@ use crate::{
         },
     },
 };
+use std::sync::Arc;
 
 // TYPES
 // ================================================================================================
@@ -93,15 +93,13 @@ impl Congruence {
         }
     }
 
-    /// Build the dominance-aware [`Self::leader`] of every member using `cfg`.
+    /// Build the dominance-aware [`Self::leader`] of every member using the shared definition
+    /// `order`: `order.key(v)` is a total order that is a linear extension of definition dominance
+    /// (if `def(w)` dominates `def(v)` then `key(w) < key(v)`), and `order.dominates_def(w, v)` is
+    /// the dominance test itself.
     ///
     /// Must be called before [`Self::leader`] is queried.
-    pub(crate) fn compute_leaders(&mut self, function: &HLFunction, cfg: &CFG) {
-        // The shared definition order: `order.key(v)` is a total order that is a linear extension
-        // of definition dominance (if `def(w)` dominates `def(v)` then `key(w) < key(v)`), and
-        // `order.dominates_def(w, v)` is the dominance test itself.
-        let order = DefOrder::new(function, cfg);
-
+    pub(crate) fn compute_leaders(&mut self, order: &DefOrder) {
         // For each member, the root-most class member dominating its definition. Every member that
         // dominates `def(v)` lies on `v`'s dominator chain, so all such members are mutually
         // comparable and the root-most is well-defined and order-independent.
@@ -140,6 +138,7 @@ impl Congruence {
         exec_edges: &HashSet<(BlockId, BlockId)>,
         const_of: impl Fn(ValueId) -> Option<Arc<Constant>>,
         call_det: impl Fn(FunctionId, usize) -> bool,
+        sym_summaries: Option<&SymSummaries>,
     ) -> Congruence {
         let entry = function.get_entry_id();
 
@@ -147,6 +146,20 @@ impl Congruence {
         //    (definitions plus every referenced operand).
         let mut nodes: HashMap<ValueId, Node> = HashMap::default();
         let mut universe: HashSet<ValueId> = HashSet::default();
+
+        // Synthetic-graft state for symbolic call returns, shared across every call site so
+        // identical grafted subexpressions collapse to one synthetic id. A constrained static call
+        // whose callee has a symbolic return has its result node grafted inline (below) from that
+        // return expression over the call's actual arguments.
+        //
+        // Synthetic ids stand in for internal graft nodes that have no value in this function. They
+        // must be disjoint from every real id `const_of` can resolve — not merely this function's
+        // `universe`, but every program-interned constant id, since `const_of` queries the
+        // whole-program snapshot and the single global monotonic id counter can place a constant
+        // used only by another function *above* this function's local max.
+        let mut synthetic: HashSet<ValueId> = HashSet::default();
+        let mut hashcons: HashMap<(OpKey, Vec<ValueId>), ValueId> = HashMap::default();
+        let mut next_synth = u64::MAX;
 
         for (bid, block) in function.get_blocks() {
             if !reachable.contains(bid) {
@@ -193,12 +206,32 @@ impl Congruence {
                 {
                     for (j, r) in results.iter().enumerate() {
                         universe.insert(*r);
-                        let node = if call_det(*g, j) {
-                            Node::Op {
-                                key: OpKey::CallDet(*g, j),
-                                operands: args.clone(),
-                                commutative: false,
+
+                        // A symbolic jump grafts the callee's return *expression* over the actual
+                        // arguments; it strictly refines the whole-argument `CallDet` numbering (it
+                        // can ignore an unused argument and relate the result to an open
+                        // expression), so prefer it. Grafting is inline: synthetic ids for internal
+                        // tree nodes are minted disjoint from all real ids (see above), so no
+                        // post-pass over a finalized universe is needed.
+                        let sym = sym_summaries
+                            .and_then(|s| s.get(g))
+                            .and_then(|rets| rets.get(j))
+                            .and_then(|jump| jump.as_ref());
+                        if let Some(sym) = sym {
+                            let node = Graft {
+                                nodes: &mut nodes,
+                                universe: &mut universe,
+                                synthetic: &mut synthetic,
+                                hashcons: &mut hashcons,
+                                next_synth: &mut next_synth,
                             }
+                            .instantiate_root(sym, args);
+                            nodes.insert(*r, node);
+                            continue;
+                        }
+
+                        let node = if call_det(*g, j) {
+                            Node::op(OpKey::CallDet(*g, j), args.clone(), false)
                         } else {
                             Node::Opaque
                         };
@@ -212,14 +245,7 @@ impl Congruence {
                         let mut results = instr.get_results();
                         if let Some(r) = results.next() {
                             universe.insert(*r);
-                            nodes.insert(
-                                *r,
-                                Node::Op {
-                                    key,
-                                    operands,
-                                    commutative,
-                                },
-                            );
+                            nodes.insert(*r, Node::op(key, operands, commutative));
                         }
 
                         // Pure folds are single-result; any extra results are opaque (defensive).
@@ -338,12 +364,99 @@ impl Congruence {
             }
         }
 
+        // Strip the synthetic graft scaffolding. Refinement has finalized every *real* value's
+        // class (two real call results unified only through shared synthetic subnodes keep the same
+        // class id), so dropping the synthetics preserves all real-value congruences while keeping
+        // a def-less id out of `compute_leaders` (where `DefOrder` would treat it as defined at
+        // entry and could emit it as an illegal leader) and out of every consumer query.
+        if !synthetic.is_empty() {
+            for v in &synthetic {
+                class_of.remove(v);
+            }
+            for class in &mut members {
+                class.retain(|v| !synthetic.contains(v));
+            }
+        }
+
         // Leaders are finalized separately by `compute_leaders` once a CFG is available; the
         // transient summary-phase partition that never exposes `leader` skips it.
         Congruence {
             class_of,
             members,
             leader_of: HashMap::default(),
+        }
+    }
+}
+
+// GRAFT
+// ================================================================================================
+
+/// Mutable state for grafting callees' symbolic return expressions into this function's value
+/// numbering: the growing `nodes`/`universe` maps plus the synthetic-id bookkeeping shared across
+/// every grafted call site (so identical subexpressions collapse to one synthetic id).
+struct Graft<'a> {
+    nodes: &'a mut HashMap<ValueId, Node>,
+    universe: &'a mut HashSet<ValueId>,
+    synthetic: &'a mut HashSet<ValueId>,
+    hashcons: &'a mut HashMap<(OpKey, Vec<ValueId>), ValueId>,
+    next_synth: &'a mut u64,
+}
+
+impl Graft<'_> {
+    /// Instantiate an `Op`-rooted return `sym` as the node for a call result.
+    ///
+    /// The root becomes a real [`Node::Op`] over `sym`'s grafted operands — no synthetic for the
+    /// root, which *is* the call result value. A non-`Op` root (already covered by the constant /
+    /// pass-through [`ReturnJump`](super::summary::ReturnJump)) or any unresolvable leaf yields
+    /// [`Node::Opaque`].
+    fn instantiate_root(&mut self, sym: &Sym, args: &[ValueId]) -> Node {
+        let Sym::Op(key, commutative, children) = sym else {
+            return Node::Opaque;
+        };
+        let mut operands = Vec::with_capacity(children.len());
+        for child in children {
+            match self.instantiate(child, args) {
+                Some(id) => operands.push(id),
+                None => return Node::Opaque,
+            }
+        }
+        Node::op(key.clone(), operands, *commutative)
+    }
+
+    /// Instantiate a symbolic sub-expression `sym` over a call's actual `args`, returning the value
+    /// id that represents it for value numbering, or `None` if a leaf is unresolvable.
+    ///
+    /// `Param`/`Const` leaves resolve to real ids (the argument, or the program-interned constant
+    /// id, which is added to `universe` so the labelling pass numbers it). An internal `Op` mints
+    /// (or, via `hashcons`, reuses) a synthetic id whose node is registered in `nodes` and recorded
+    /// in `synthetic` for stripping after refinement.
+    fn instantiate(&mut self, sym: &Sym, args: &[ValueId]) -> Option<ValueId> {
+        match sym {
+            Sym::Param(i) => args.get(*i).copied(),
+            Sym::Const(id) => {
+                self.universe.insert(*id);
+                Some(*id)
+            }
+            Sym::Op(key, commutative, children) => {
+                let mut operands = Vec::with_capacity(children.len());
+                for child in children {
+                    operands.push(self.instantiate(child, args)?);
+                }
+
+                let cache_key = (key.clone(), operands.clone());
+                if let Some(&existing) = self.hashcons.get(&cache_key) {
+                    return Some(existing);
+                }
+
+                let s = ValueId(*self.next_synth);
+                *self.next_synth -= 1;
+                self.nodes
+                    .insert(s, Node::op(key.clone(), operands, *commutative));
+                self.universe.insert(s);
+                self.synthetic.insert(s);
+                self.hashcons.insert(cache_key, s);
+                Some(s)
+            }
         }
     }
 }
@@ -366,10 +479,22 @@ enum Node {
     Opaque,
 }
 
+impl Node {
+    /// A pure-operator node (the common [`Node::Op`] constructor, shared by the direct build and the
+    /// symbolic graft).
+    fn op(key: OpKey, operands: Vec<ValueId>, commutative: bool) -> Node {
+        Node::Op {
+            key,
+            operands,
+            commutative,
+        }
+    }
+}
+
 /// The operand-free operator key seeding the optimistic partition: two values can be congruent only
 /// if they share this key (same operator and the same immediate, non-value attributes).
-#[derive(Clone, PartialEq, Eq, Hash)]
-enum OpKey {
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum OpKey {
     Add,
     Sub,
     Mul,
@@ -451,7 +576,7 @@ pub(crate) fn pure_op_operands(instr: &OpCode) -> Option<Vec<ValueId>> {
 /// (their aggregate results never enter the constant lattice). So it may disagree with
 /// `is_pure_scalar_fold` / `solver::transfer` on the sequence ops by design, but never on a scalar
 /// op.
-fn op_signature(instr: &OpCode) -> Option<(OpKey, Vec<ValueId>, bool)> {
+pub(crate) fn op_signature(instr: &OpCode) -> Option<(OpKey, Vec<ValueId>, bool)> {
     // Sequence ops are pure and deterministic but not scalar-foldable, so they are matched directly
     // rather than via `scalar_fold`. Sequence order is significant, so none are commutative.
     match instr {

--- a/compiler/src/compiler/analysis/click_cooper/mod.rs
+++ b/compiler/src/compiler/analysis/click_cooper/mod.rs
@@ -14,8 +14,11 @@
 //! - **Interprocedural facts** refine the intraprocedural view across calls: polymorphic
 //!   jump-function summaries (a `return_const` holding for any arguments, a `return Param(i)`
 //!   pass-through) and 1-CFA per-`(function, context)` specialization seeding callee parameters
-//!   with the caller's argument constants, plus determinism-gated *cross-call congruence* (two
-//!   constrained static calls to one callee with congruent arguments yield congruent results).
+//!   with the caller's argument constants, plus *cross-call congruence*: a constrained static call's
+//!   result is numbered by grafting the callee's symbolic return expression over the actual
+//!   arguments (relating it to an open expression, and ignoring arguments the return does not use),
+//!   or — failing that — by a determinism-gated whole-call key (two calls with congruent arguments
+//!   yield congruent results).
 //! - **Conditional facts** are ones derived from asserts, equalities, disequalities, and unpinned
 //!   witness forwarding. They are computed post-convergence over the same reachability state plus
 //!   CFG dominance, and are intentionally disjoint from the unconditional view.
@@ -67,10 +70,15 @@
 //!   `return Param(i)` pass-through equals argument `i` exactly. Per-context parameter seeds are
 //!   the meet of the argument constants over *every* static call path mapped to that context, so a
 //!   per-context constant holds on every concrete invocation in that context.
-//! - **Cross-Call Congruence:** A constrained static call's result is value-numbered by
-//!   `(callee, return-index)` over its argument classes only when the callee's return is a
-//!   deterministic function of its arguments; equal arguments then force an equal result. A
-//!   non-deterministic return (e.g. one carrying a fresh witness) stays opaque.
+//! - **Cross-Call Congruence:** A constrained static call's result is value-numbered either by
+//!   grafting the callee's symbolic return — a bounded-depth expression whose leaves are the
+//!   callee's formals (instantiated to the actual arguments) and program constants and whose nodes
+//!   are pure, deterministic ops — or, when no such expression exists, by a `(callee, return-index)`
+//!   key over its argument classes, gated on the return being a deterministic function of its
+//!   arguments. Both are sound because the constrained call pins the result to that deterministic
+//!   function of its arguments, so equal (congruent) arguments force an equal result; a
+//!   non-deterministic return (e.g. one carrying a fresh witness) is expressible by neither and
+//!   stays opaque, and an unconstrained (advice) result is never numbered.
 //! - **Conditional Facts:** Assert-derived constants, equalities, and disequalities hold only on
 //!   accepting runs that preserve their establishing constraint, so they are exposed only through
 //!   dedicated queries. An assert, being a global constraint that holds at every point of an
@@ -105,11 +113,6 @@
 //!
 //! The following are improvements planned for the future of this analysis.
 //!
-//! - **Symbolic Interprocedural Congruence:** Cross-call congruence currently requires that *all*
-//!   arguments are congruent and is gated on a whole-return determinism bit; it does not graft a
-//!   callee's return expression into the caller, so it cannot relate `f(x)` to an open expression
-//!   over `x`, nor see that a return ignores some argument. A symbolic return jump function would
-//!   recover both.
 //! - **Per-context Conditional Facts:** The assert/disequality/witness-forwarding conditional facts
 //!   are computed once per function and not refined per 1-CFA context, so they have no `_in(f, ctx,
 //!   …)` query: a caller reads them through the intraprocedural methods, whose (sound,
@@ -120,9 +123,19 @@
 //! - **Sound Post-Dominance for Assert Facts:** Assert facts (`asserted_const`/`asserted_equal`)
 //!   currently fan out by dominance only. The post-dominance direction — an assert in `B` is *bound
 //!   to run* at every block `C` it strictly post-dominates, so its fact would also hold at a use
-//!   *before* a requires an additional notion of value stability to be added to the analysis. A
-//!   future post-dominance direction would require gating all of the asserted values on being
-//!   value-stable using a cyclic-SCC membership primitive.
+//!   *before* the assert on any path guaranteed to reach it — requires an additional notion of value
+//!   stability to be added to the analysis. A future post-dominance direction would require gating
+//!   all of the asserted values on being value-stable using a cyclic-SCC membership primitive.
+//! - **Deeper Symbolic Interprocedural Congruence:** The implemented symbolic cross-call congruence
+//!   (a callee's return grafted into the caller as a bounded-depth expression over its formals) is
+//!   intentionally restricted to a *single* interprocedural level and a shallow depth cap. A nested
+//!   call in a callee's return is an opaque leaf, so a composed gadget `g(x) = h(x) + 1` is not
+//!   expressed. Transitively inlining a callee's own symbolic return, or raising the depth cap,
+//!   would widen coverage — but multi-level inlining reintroduces a feedback edge into the summary
+//!   fixpoint (the projection is currently a structurally output-only post-pass), so it must
+//!   restore termination with a depth bound. A further extension would consume the symbolic return
+//!   in the constant channel (`eval_call`) to fold a call whose arguments are constant (that
+//!   channel is untouched today).
 
 mod conditional;
 mod congruence;
@@ -142,9 +155,12 @@ use crate::{
         analysis::{
             click_cooper::{
                 conditional::ConditionalFacts,
+                def_order::DefOrder,
                 lattice::Constness,
                 solver::{FunctionFacts, solve_with_writeback},
-                summary::{compute_determinism, compute_summaries, specialize},
+                summary::{
+                    compute_determinism, compute_summaries, compute_sym_summaries, specialize,
+                },
             },
             flow_analysis::FlowAnalysis,
             shared::call_string::Context,
@@ -157,6 +173,9 @@ use crate::{
         },
     },
 };
+
+// RE-EXPORTS
+// ================================================================================================
 
 /// The canonical 1-bit constant for a folded boolean, re-exported for the consumers of this
 /// analysis (e.g. the sparse conditional simplification pass).
@@ -203,52 +222,69 @@ impl ClickCooper {
         let consts = ssa.const_snapshot();
 
         // Phase 0: per-`(callee, return)` determinism, used below to value-number deterministic
-        // static-call results cross-call. It only refines congruence (never the constant lattice or
-        // reachability), so it leaves the SCS-visible facts byte-identical.
+        // static-call results cross-call. It refines only congruence, not reachability and not the
+        // constant lattice *directly* — though a refined congruence can still reach the lattice
+        // indirectly through the writeback's `derive_promotions` (a `Cmp{Eq}`/`Cmp{Lt}` over
+        // newly-congruent operands folding to a constant). In practice this is corpus-neutral for
+        // SCS, but that is an empirically verified result, not a structural guarantee.
         let det = compute_determinism(ssa, flow);
 
-        // Per-function intraprocedural facts: parameters and call results `Bottom` (no summaries
-        // here). The conditional side facts are computed from the same converged state plus CFG
-        // dominance, kept in a disjoint map so the unconditional view is untouched.
+        // Interprocedural summaries first: the polymorphic jump functions, then the symbolic
+        // congruence projection as a post-fixpoint pass over the converged summaries). Both are
+        // computed before the intraprocedural solve so it can graft symbolic call-return
+        // expressions into its congruence partition.
+        let (summaries, sym_cache) = compute_summaries(ssa, flow, &consts, &det);
+        let sym = compute_sym_summaries(ssa, &consts, &sym_cache);
+        drop(sym_cache);
+
+        // Per-function intraprocedural facts: parameters and call results `Bottom`. The conditional
+        // facts are computed from the same converged state plus CFG dominance, kept in a disjoint
+        // map so the unconditional view is untouched.
         //
-        // This solve MUST stay summary-free: SCS reads `functions` and relies on `Call` staying
-        // `Bottom`, so that every constant-valued result it aliases or deletes is a pure scalar
-        // fold. Wiring summaries in here would let a constrained `Call` result become `Const` and
-        // break that contract.
+        // The eval-call summary channel MUST stay off here as downstream passes rely on `Call`
+        // staying `Bottom`. The _symbolic_ channel is enabled: like the `det` channel above, it
+        // refines congruence — not reachability, and not the constant lattice *directly*.
         let mut functions = HashMap::default();
         let mut conditional = HashMap::default();
         for fid in ssa.get_function_ids() {
             let function = ssa.get_function(fid);
 
-            // Combined-fixpoint writeback (intraprocedural, summary-free): solve constants +
-            // reachability, then fold a comparison of congruent operands to a constant and re-solve
-            // until no new fact appears (see `solve_with_writeback`). `summaries = None` keeps
-            // every `Call` result `Bottom` — the contract SCS reads `functions` under — and round 0
-            // has empty promotions, so a function with no such comparison is solved once and
-            // unchanged.
-            let mut facts =
-                solve_with_writeback(function, &consts, &det, None, &HashMap::default());
+            // Combined-fixpoint writeback (intraprocedural): solve constants + reachability, then
+            // fold a comparison of congruent operands to a constant and re-solve until no new fact
+            // appears (see `solve_with_writeback`). The eval-call `summaries = None` keeps every
+            // `Call` result `Bottom` — the contract SCS reads `functions` under — while
+            // `Some(&sym)` grafts symbolic call-return expressions into the congruence partition.
+            let mut facts = solve_with_writeback(
+                function,
+                &consts,
+                &det,
+                None,
+                Some(&sym),
+                &HashMap::default(),
+            );
 
-            // Finalize dominance-aware congruence leaders against the function's CFG, so `leader`
-            // returns a legal redirect target.
-            facts
-                .congruence
-                .compute_leaders(function, flow.get_function_cfg(fid));
+            // The shared dominance-consistent definition order, built once and reused for both the
+            // congruence leaders and the conditional-fact leaders below.
+            let order = DefOrder::new(function, flow.get_function_cfg(fid));
+
+            // Finalize dominance-aware congruence leaders, so `leader` returns a legal redirect
+            // target.
+            facts.congruence.compute_leaders(&order);
             let cond = conditional::build(
                 function,
                 &facts,
                 flow.get_function_cfg(fid),
                 &consts,
                 types.get_function(fid),
+                &order,
             );
             conditional.insert(fid, cond);
             functions.insert(fid, facts);
         }
 
-        // Handle the interprocedural layer using polymorphic jump-function summaries then
-        // contextual facts on the 1-CFA.
-        let summaries = compute_summaries(ssa, flow, &consts, &det);
-        let contexts = specialize(ssa, flow, &consts, &summaries, &det);
+        // The 1-CFA contextual facts, built from the polymorphic summaries (computed above) plus
+        // the symbolic congruence projection.
+        let contexts = specialize(ssa, flow, &consts, &summaries, &sym, &det);
 
         ClickCooper {
             consts,
@@ -504,7 +540,7 @@ impl ClickCooper {
     /// differs from `v`).
     ///
     /// The conditional analog of the congruence [`Self::leader`]: sound only under
-    /// constraint-preserving use.  
+    /// constraint-preserving use.
     pub fn asserted_leader(
         &self,
         f: FunctionId,

--- a/compiler/src/compiler/analysis/click_cooper/solver.rs
+++ b/compiler/src/compiler/analysis/click_cooper/solver.rs
@@ -17,7 +17,7 @@ use crate::{
                 eval_array_set, eval_binary, eval_bit_range, eval_cast, eval_cmp, eval_mk_repeated,
                 eval_mk_seq, eval_not, eval_sext, eval_slice_len, eval_slice_push,
             },
-            summary::{DetSummaries, FnSummary, ReturnJump},
+            summary::{DetSummaries, FnSummary, ReturnJump, SymSummaries},
         },
         ssa::{
             BlockId, FunctionId, Instruction, Terminator, ValueId,
@@ -125,6 +125,15 @@ pub(crate) struct FunctionSolver<'f, 'c, 's> {
     /// `None` (the default) leaves every call result opaque, identical to the prior behavior.
     det: Option<&'s DetSummaries>,
 
+    /// Per-`(callee, return-index)` symbolic congruence jump functions, used when building the
+    /// congruence partition to graft a callee's return expression into a constrained static call.
+    ///
+    /// A *separate* channel from `summaries`: this refines only congruence, never the constant
+    /// lattice (`eval_call`), so it can be enabled in the summary-free intraprocedural solve
+    /// without breaking the contract that keeps `Call` results `Bottom`. `None` (the default) falls
+    /// back to the `det`-gated `CallDet` numbering.
+    sym_summaries: Option<&'s SymSummaries>,
+
     /// Entry-parameter seeds for a context-sensitive solve: an entry parameter maps to the constant
     /// the calling context proved for the matching argument. Absent params default to `Bottom`.
     param_seeds: HashMap<ValueId, Constness>,
@@ -173,6 +182,7 @@ impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
             uses,
             summaries: None,
             det: None,
+            sym_summaries: None,
             param_seeds: HashMap::default(),
             promotions: None,
         }
@@ -187,6 +197,13 @@ impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
     /// Number deterministic static-call results cross-call using these determinism bits.
     pub(crate) fn with_determinism(mut self, det: &'s DetSummaries) -> Self {
         self.det = Some(det);
+        self
+    }
+
+    /// Graft callees' symbolic return expressions into constrained static-call results when
+    /// building the congruence partition (a refinement of the `det`-gated `CallDet` numbering).
+    pub(crate) fn with_sym_summaries(mut self, sym_summaries: &'s SymSummaries) -> Self {
+        self.sym_summaries = Some(sym_summaries);
         self
     }
 
@@ -258,6 +275,7 @@ impl<'f, 'c, 's> FunctionSolver<'f, 'c, 's> {
             |g, j| {
                 det.is_some_and(|d| d.get(&g).and_then(|rets| rets.get(j)).copied() == Some(true))
             },
+            self.sym_summaries,
         );
 
         // Materialise the promotions into the returned lattice: they live in the borrowed
@@ -830,6 +848,7 @@ pub(crate) fn solve_with_writeback(
     consts: &HLSSAConstantsSnapshot,
     det: &DetSummaries,
     summaries: Option<&HashMap<FunctionId, FnSummary>>,
+    sym_summaries: Option<&SymSummaries>,
     param_seeds: &HashMap<ValueId, Constness>,
 ) -> FunctionFacts {
     // The accumulator starts empty, so the first iteration is a plain base solve:
@@ -843,14 +862,20 @@ pub(crate) fn solve_with_writeback(
             .with_determinism(det)
             .with_param_seeds(param_seeds.clone())
             .with_promotions(&promotions);
+
         if let Some(summaries) = summaries {
             solver = solver.with_summaries(summaries);
         }
+
+        if let Some(sym_summaries) = sym_summaries {
+            solver = solver.with_sym_summaries(sym_summaries);
+        }
+
         solver.run();
         let solved = solver.into_facts();
 
-        // Fold every newly-foldable comparison of congruent operands; re-solve only if the set grew,
-        // otherwise the combined fixpoint is reached.
+        // Fold every newly-foldable comparison of congruent operands; re-solve only if the set
+        // grew, otherwise the combined fixpoint is reached.
         let before = promotions.len();
         for (v, c) in derive_promotions(function, &solved) {
             promotions.entry(v).or_insert(c);

--- a/compiler/src/compiler/analysis/click_cooper/summary.rs
+++ b/compiler/src/compiler/analysis/click_cooper/summary.rs
@@ -1,6 +1,6 @@
 //! The interprocedural layer: a return-determinism pass (Phase 0), polymorphic jump-function
-//! summaries (Phase 1) and 1-CFA per-context specialization (Phase 2), mirroring the two-phase
-//! structure of `analysis/points_to`.
+//! summaries (Phase 1), a symbolic-congruence projection over the converged summaries, and 1-CFA
+//! per-context specialization (Phase 2).
 //!
 //! # Phase 0: Return Determinism
 //!
@@ -42,16 +42,18 @@ use crate::{
     compiler::{
         analysis::{
             click_cooper::{
-                congruence::pure_op_operands,
+                congruence::{Congruence, OpKey, op_signature, pure_op_operands},
+                def_order::DefOrder,
                 lattice::{Constness, const_join},
                 solver::{FunctionFacts, solve_with_writeback},
             },
             flow_analysis::FlowAnalysis,
             shared::{call_string::Context, fixpoint::call_graph_fixpoint},
+            value_definitions::{FunctionValueDefinitions, ValueDefinition},
         },
         ssa::{
-            FunctionId, Instruction, Terminator, ValueId,
-            hlssa::{CallTarget, Constant, HLSSA, HLSSAConstantsSnapshot, OpCode},
+            BlockId, FunctionId, Instruction, Terminator, ValueId,
+            hlssa::{CallTarget, Constant, HLFunction, HLSSA, HLSSAConstantsSnapshot, OpCode},
         },
     },
 };
@@ -203,47 +205,62 @@ pub(crate) fn compute_summaries(
     flow: &FlowAnalysis,
     consts: &HLSSAConstantsSnapshot,
     det: &DetSummaries,
-) -> HashMap<FunctionId, FnSummary> {
+) -> (HashMap<FunctionId, FnSummary>, SymSolveCache) {
     // Polymorphic over call sites: callees folded via their current summaries, parameters `Bottom`.
     let fids: Vec<FunctionId> = ssa.get_function_ids().collect();
-    call_graph_fixpoint(
+
+    // The worklist discards each round's `FunctionFacts`, but a function's *last* analysis runs
+    // against converged callee summaries (any callee change re-queues it), so those facts are
+    // exactly what the symbolic post-pass would recompute. Retain the sym-relevant slice as we go —
+    // the `FnMut` closure captures the cache, mirroring `witness_taint_inference`'s graph capture.
+    let mut sym_cache = SymSolveCache::default();
+    let summaries = call_graph_fixpoint(
         ssa,
         flow,
         &fids,
         |_| FnSummary::default(),
-        |f, summaries| analyze_function(ssa, consts, det, f, summaries),
-    )
+        |f, summaries| {
+            let func = ssa.get_function(f);
+            if func.get_returns().is_empty() {
+                // Arity 0: nothing flows out and the symbolic pass skips it — no solve, no cache.
+                return FnSummary::default();
+            }
+            let facts = solve_polymorphic(func, consts, det, summaries);
+            let summary = summarize_returns(ssa, consts, f, &facts);
+
+            // Keep only what `compute_sym_summaries` reads; drop `lattice`/`exec_edges`/`block_facts`.
+            let FunctionFacts {
+                reachable,
+                congruence,
+                ..
+            } = facts;
+            sym_cache.insert(
+                f,
+                SymSolveFacts {
+                    reachable,
+                    congruence,
+                },
+            );
+            summary
+        },
+    );
+    (summaries, sym_cache)
 }
 
-/// Solve `fid` polymorphically (parameters `Bottom`, callees folded via `summaries`) and project
-/// its return jump functions.
-fn analyze_function(
+/// Project `fid`'s return jump functions from its already-solved polymorphic `facts`.
+///
+/// The polymorphic solve applies the combined-fixpoint writeback (params `Bottom`): a return that is
+/// a comparison of congruent operands folds to a constant, so its summary becomes `Const`.
+fn summarize_returns(
     ssa: &HLSSA,
     consts: &HLSSAConstantsSnapshot,
-    det: &DetSummaries,
     fid: FunctionId,
-    summaries: &HashMap<FunctionId, FnSummary>,
+    facts: &FunctionFacts,
 ) -> FnSummary {
     let func = ssa.get_function(fid);
     let arity = func.get_returns().len();
-    if arity == 0 {
-        return FnSummary::default();
-    }
-
-    // The polymorphic solve applies the combined-fixpoint writeback (params `Bottom`): a return
-    // that is a comparison of congruent operands folds to a constant, so its summary becomes
-    // `Const`.
-    let facts = solve_with_writeback(func, consts, det, Some(summaries), &HashMap::default());
-
     let params: Vec<ValueId> = param_values(ssa, fid);
-    let returns: Vec<&Vec<ValueId>> = func
-        .get_blocks()
-        .filter(|(bid, _)| facts.reachable.contains(*bid))
-        .filter_map(|(_, block)| match block.get_terminator() {
-            Some(Terminator::Return(vals)) => Some(vals),
-            _ => None,
-        })
-        .collect();
+    let returns = reachable_returns(func, &facts.reachable);
 
     // No reachable return (the function always traps): nothing flows out.
     if returns.is_empty() {
@@ -253,7 +270,7 @@ fn analyze_function(
     }
 
     let jumps = (0..arity)
-        .map(|j| return_jump(consts, &facts, &params, &returns, j))
+        .map(|j| return_jump(consts, facts, &params, &returns, j))
         .collect();
     FnSummary { returns: jumps }
 }
@@ -310,6 +327,173 @@ fn return_jump(
     }
 }
 
+// SYMBOLIC SUMMARIES
+// ================================================================================================
+
+/// Maximum depth of a symbolic return expression.
+///
+/// Set low deliberately: past shallow arithmetic the binding constraint on expressibility is
+/// opacity (witnesses, φ, memory, nested calls), not depth, so a deeper cap only grows the
+/// grafted-node count for tree shapes that rarely occur. A `Param` or `Const` leaf is admitted at
+/// any depth (it terminates recursion); only descending *into* an op consumes budget.
+const MAX_DEPTH: usize = 2;
+
+/// A bounded-depth symbolic expression over a function's formals — the congruence half of an
+/// interprocedural return jump function.
+///
+/// A return value expressed as such a tree can be *grafted* into a caller's value numbering at a
+/// call site (substituting the actual arguments for `Param` leaves and the interned constants for
+/// `Const` leaves), so the constrained call's result is numbered by the expression rather than left
+/// an opaque `CallDet` node. This both ignores arguments the return does not use and relates the
+/// result to an open expression over the used ones.
+// No `PartialEq`/`Hash`: agreement across a function's returns is decided by the congruence
+// partition (`known_equal`), never by structural comparison of `Sym` trees.
+#[derive(Clone, Debug)]
+pub(crate) enum Sym {
+    /// Formal parameter `i`.
+    Param(usize),
+
+    /// A program-interned scalar constant, named by its (program-wide) value id.
+    Const(ValueId),
+
+    /// A pure value-numbering op (its commutativity flag carried verbatim from [`op_signature`],
+    /// the single source of truth) applied to operand sub-expressions.
+    Op(OpKey, bool, Vec<Sym>),
+}
+
+/// Per-function, per-return-position symbolic congruence jump functions.
+///
+/// A position holds `Some(sym)` only when `sym` is `Op`-rooted: a bare `Param`/`Const` root is
+/// already covered by the constant/pass-through [`ReturnJump`] and has no representation in the
+/// split-only congruence partition (there is no "alias `r` to a leaf" primitive).
+pub(crate) type SymSummaries = HashMap<FunctionId, Vec<Option<Sym>>>;
+
+/// Project each function's per-return symbolic congruence jump functions over the converged
+/// polymorphic summaries.
+///
+/// This is a **post-fixpoint** pass: it runs after [`compute_summaries`] has converged and does not
+/// feed back into it (the symbolic data lives in a separate map, never on [`FnSummary`]), so it is
+/// structurally output-only and leaves the summary fixpoint's termination argument untouched.
+///
+/// It reuses the polymorphic facts [`compute_summaries`] captured in `cache` (the final-round solve
+/// per function) rather than re-solving — see [`SymSolveCache`].
+pub(crate) fn compute_sym_summaries(
+    ssa: &HLSSA,
+    consts: &HLSSAConstantsSnapshot,
+    cache: &SymSolveCache,
+) -> SymSummaries {
+    let mut out = SymSummaries::default();
+    for fid in ssa.get_function_ids() {
+        let func = ssa.get_function(fid);
+        let arity = func.get_returns().len();
+        if arity == 0 {
+            continue;
+        }
+
+        // The polymorphic facts (params `Bottom`, callees folded via their summaries, sym channel
+        // OFF) captured during `compute_summaries`. Absent only for arity-0 functions, skipped above.
+        let Some(facts) = cache.get(&fid) else {
+            continue;
+        };
+
+        let params = param_values(ssa, fid);
+        let defs = FunctionValueDefinitions::from_function(func);
+        let returns = reachable_returns(func, &facts.reachable);
+        if returns.is_empty() {
+            continue;
+        }
+
+        let syms: Vec<Option<Sym>> = (0..arity)
+            .map(|j| return_sym(&params, &defs, &facts.congruence, consts, &returns, j))
+            .collect();
+
+        // Drop the all-`None` case to keep the map (and the grafting fast path) sparse.
+        if syms.iter().any(Option::is_some) {
+            out.insert(fid, syms);
+        }
+    }
+    out
+}
+
+/// The symbolic congruence jump for return position `j`.
+///
+/// When every reachable return at `j` is present and mutually congruent, this is the first return's
+/// expression — valid for all of them, since congruent values are structurally equal in every run.
+/// `None` if the returns disagree, some return lacks position `j`, or the first return is not a
+/// bounded-depth pure `Op`-rooted function of the formals + interned constants.
+fn return_sym(
+    params: &[ValueId],
+    defs: &FunctionValueDefinitions,
+    congruence: &Congruence,
+    consts: &HLSSAConstantsSnapshot,
+    returns: &[&Vec<ValueId>],
+    j: usize,
+) -> Option<Sym> {
+    // All reachable returns must yield a value at `j` and all must be congruent: they then compute
+    // the same value in every run, so the first return's expression is a sound graft for all. The
+    // congruence partition already subsumes structural (incl. commutative) equality.
+    let first = *returns.first()?.get(j)?;
+    for vals in &returns[1..] {
+        let rv = *vals.get(j)?;
+        if rv != first && !congruence.known_equal(rv, first) {
+            return None;
+        }
+    }
+
+    // Build the common expression once, from the first return. Only an `Op`-rooted root is stored
+    // (a bare `Param`/`Const` root is already covered by the constant/pass-through `ReturnJump`).
+    let sym = build_sym(first, 0, params, defs, congruence, consts)?;
+    matches!(sym, Sym::Op(..)).then_some(sym)
+}
+
+/// Build the symbolic expression for value `v` over the formals `params`, or `None` if `v` is not a
+/// bounded-depth pure function of the formals and program-interned scalar constants.
+///
+/// A `Param`/`Const` leaf is admitted at any depth; an op consumes one unit of depth budget to
+/// descend, so the deepest *expanded op* sits at `MAX_DEPTH - 1`. A nested call, witness, memory
+/// op, or non-entry φ (none congruent to a formal) classifies as `None` (opaque), as does an op
+/// past the depth budget.
+fn build_sym(
+    v: ValueId,
+    depth: usize,
+    params: &[ValueId],
+    defs: &FunctionValueDefinitions,
+    congruence: &Congruence,
+    consts: &HLSSAConstantsSnapshot,
+) -> Option<Sym> {
+    // Formal pass-through first (a formal is an entry block parameter, never an instruction). A
+    // value congruent to a formal is equal to it in every run, so substituting `Param(i)` is sound.
+    for (i, p) in params.iter().enumerate() {
+        if v == *p || congruence.known_equal(v, *p) {
+            return Some(Sym::Param(i));
+        }
+    }
+
+    // A program-interned *scalar* constant leaf. Aggregate constants are never surfaced, so an
+    // interned aggregate is opaque for symbolic purposes.
+    if let Some(c) = consts.get(&v) {
+        return c.is_scalar().then_some(Sym::Const(v));
+    }
+
+    // Otherwise `v` must be a pure op all of whose operands are themselves expressible.
+    match defs.get_definition(v) {
+        Some(ValueDefinition::Instruction(_, _, op)) => {
+            let (key, operands, commutative) = op_signature(op)?;
+            if depth >= MAX_DEPTH {
+                return None;
+            }
+            let children: Option<Vec<Sym>> = operands
+                .iter()
+                .map(|o| build_sym(*o, depth + 1, params, defs, congruence, consts))
+                .collect();
+            Some(Sym::Op(key, commutative, children?))
+        }
+
+        // A non-entry φ not congruent to a formal, or no structural definition: opaque.
+        Some(ValueDefinition::Param(..)) | None => None,
+    }
+}
+
 // SPECIALIZATION (PHASE 2)
 // ================================================================================================
 
@@ -320,6 +504,7 @@ pub(crate) fn specialize(
     flow: &FlowAnalysis,
     consts: &HLSSAConstantsSnapshot,
     summaries: &HashMap<FunctionId, FnSummary>,
+    sym: &SymSummaries,
     det: &DetSummaries,
 ) -> HashMap<(FunctionId, Context), FunctionFacts> {
     let main = ssa.get_unique_entrypoint_id();
@@ -362,15 +547,17 @@ pub(crate) fn specialize(
             .collect();
 
         // The context-specialized solve applies the combined-fixpoint writeback over the seeded
-        // parameters, so a comparison of operands congruent in this context folds in its facts.
+        // parameters, so a comparison of operands congruent in this context folds in its facts. The
+        // symbolic channel is on here, so a call's grafted return expression can refine per-context
+        // congruence too.
         let func = ssa.get_function(f);
-        let mut facts = solve_with_writeback(func, consts, det, Some(summaries), &seed_map);
+        let mut facts =
+            solve_with_writeback(func, consts, det, Some(summaries), Some(sym), &seed_map);
 
         // Build the dominance-aware congruence leaders so `leader_in` yields a legal redirect
         // target.
-        facts
-            .congruence
-            .compute_leaders(func, flow.get_function_cfg(f));
+        let order = DefOrder::new(func, flow.get_function_cfg(f));
+        facts.congruence.compute_leaders(&order);
 
         // Propagate argument constants from each reachable static call into the callee's context.
         for (bid, block) in func.get_blocks() {
@@ -430,8 +617,60 @@ pub(crate) fn specialize(
     results
 }
 
+// FACTS AND FACT CACHE
+// ================================================================================================
+
+/// The slice of a function's polymorphic [`FunctionFacts`] that the symbolic post-pass reads,
+/// retained from the summary fixpoint's final round so [`compute_sym_summaries`] need not re-solve.
+///
+/// Only the two fields [`return_sym`]/[`reachable_returns`] consume are kept;
+/// `lattice`/`exec_edges`/`block_facts` are dropped so the retained footprint stays minimal.
+pub(crate) struct SymSolveFacts {
+    pub reachable: HashSet<BlockId>,
+    pub congruence: Congruence,
+}
+
+/// The per-function [`SymSolveFacts`] captured by [`compute_summaries`] for
+/// [`compute_sym_summaries`].
+pub(crate) type SymSolveCache = HashMap<FunctionId, SymSolveFacts>;
+
 // HELPERS
 // ================================================================================================
+
+/// The polymorphic solve driving the summary fixpoint (the `analyze` closure in
+/// [`compute_summaries`]); its final-round facts are cached for [`compute_sym_summaries`].
+///
+/// Parameters left `Bottom`, callees folded via their current `summaries`, and the symbolic
+/// congruence channel off (this is where `Sym` is *produced*, so it must never be consumed here).
+fn solve_polymorphic(
+    func: &HLFunction,
+    consts: &HLSSAConstantsSnapshot,
+    det: &DetSummaries,
+    summaries: &HashMap<FunctionId, FnSummary>,
+) -> FunctionFacts {
+    solve_with_writeback(
+        func,
+        consts,
+        det,
+        Some(summaries),
+        None,
+        &HashMap::default(),
+    )
+}
+
+/// The value lists of every reachable `Return` in `func`, in block order.
+fn reachable_returns<'a>(
+    func: &'a HLFunction,
+    reachable: &HashSet<BlockId>,
+) -> Vec<&'a Vec<ValueId>> {
+    func.get_blocks()
+        .filter(|(bid, _)| reachable.contains(*bid))
+        .filter_map(|(_, block)| match block.get_terminator() {
+            Some(Terminator::Return(vals)) => Some(vals),
+            _ => None,
+        })
+        .collect()
+}
 
 /// The entry-parameter values of `f`, in order.
 fn param_values(ssa: &HLSSA, f: FunctionId) -> Vec<ValueId> {

--- a/compiler/src/compiler/analysis/click_cooper/test.rs
+++ b/compiler/src/compiler/analysis/click_cooper/test.rs
@@ -3248,3 +3248,644 @@ fn aggregate_folding_refuses_oob_set_and_over_cap_constructors() {
     assert_eq!(cc.const_of(fid, at_pushed), None);
     assert_eq!(cc.const_of(fid, at_big), None);
 }
+
+// SYMBOLIC INTERPROCEDURAL CONGRUENCE
+// ================================================================================================
+
+/// A symbolic return jump ignores an argument the return does not use: `f(x, y) = x + 1` makes
+/// `f(a, c)` and `f(a, d)` congruent even when `c ≢ d` (which the whole-argument `CallDet`
+/// numbering cannot see), while a call differing in the *used* argument stays distinct.
+#[test]
+fn symbolic_jump_ignores_dead_argument() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let f = ssa.add_function("f".to_string());
+    let c1 = ssa.add_const(Constant::Field(Field::from(1u64)));
+    let (x, y, fa) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+
+    // f(x, y) = x + 1  (y is dead).
+    {
+        let hf = ssa.get_function_mut(f);
+        hf.add_return_type(Type::field());
+        hf.get_entry_mut().push_parameter(x, Type::field());
+        hf.get_entry_mut().push_parameter(y, Type::field());
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: fa,
+            lhs: x,
+            rhs: c1,
+        });
+        hf.get_entry_mut()
+            .set_terminator(Terminator::Return(vec![fa]));
+    }
+
+    let (a, b, c, d) = (
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+    );
+    let (r1, r2, r3) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+    {
+        let mf = ssa.get_function_mut(main_id);
+        mf.add_return_type(Type::field());
+        mf.add_return_type(Type::field());
+        mf.add_return_type(Type::field());
+        mf.get_entry_mut().push_parameter(a, Type::field());
+        mf.get_entry_mut().push_parameter(b, Type::field());
+        mf.get_entry_mut().push_parameter(c, Type::field());
+        mf.get_entry_mut().push_parameter(d, Type::field());
+        let entry = mf.get_entry_mut();
+        for (res, args) in [(r1, vec![a, c]), (r2, vec![a, d]), (r3, vec![b, c])] {
+            entry.push_instruction(OpCode::Call {
+                results: vec![res],
+                function: CallTarget::Static(f),
+                args,
+                unconstrained: false,
+            });
+        }
+        entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
+    }
+
+    let cc = run_in_test(&ssa);
+    assert!(cc.known_equal(main_id, r1, r2)); // dead 2nd arg ⇒ congruent
+    assert!(!cc.known_equal(main_id, r1, r3)); // distinct 1st arg ⇒ distinct
+}
+
+/// A symbolic return jump relates a call result to an *open expression* over the caller's values:
+/// `f(x) = x + 5` makes `f(a)` congruent to a caller-local `a + 5` (which the opaque per-callee
+/// `CallDet` node cannot), and not to `a + 6`. The call result still stays `Bottom` in the lattice,
+/// so the SCS contract (the `eval_call` constant channel untouched) holds.
+#[test]
+fn symbolic_jump_relates_call_to_open_expression() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let f = ssa.add_function("f".to_string());
+    let c5 = ssa.add_const(Constant::Field(Field::from(5u64)));
+    let c6 = ssa.add_const(Constant::Field(Field::from(6u64)));
+    let (x, fa) = (ssa.fresh_value(), ssa.fresh_value());
+
+    // f(x) = x + 5
+    {
+        let hf = ssa.get_function_mut(f);
+        hf.add_return_type(Type::field());
+        hf.get_entry_mut().push_parameter(x, Type::field());
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: fa,
+            lhs: x,
+            rhs: c5,
+        });
+        hf.get_entry_mut()
+            .set_terminator(Terminator::Return(vec![fa]));
+    }
+
+    let a = ssa.fresh_value();
+    let (r, w, w2) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+    {
+        let mf = ssa.get_function_mut(main_id);
+        mf.add_return_type(Type::field());
+        mf.get_entry_mut().push_parameter(a, Type::field());
+        let entry = mf.get_entry_mut();
+        entry.push_instruction(OpCode::Call {
+            results: vec![r],
+            function: CallTarget::Static(f),
+            args: vec![a],
+            unconstrained: false,
+        });
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: w,
+            lhs: a,
+            rhs: c5,
+        });
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: w2,
+            lhs: a,
+            rhs: c6,
+        });
+        entry.set_terminator(Terminator::Return(vec![r]));
+    }
+
+    let cc = run_in_test(&ssa);
+    assert!(cc.known_equal(main_id, r, w)); // r ≡ a + 5
+    assert!(!cc.known_equal(main_id, r, w2)); // r ≢ a + 6
+    // The call result is never folded into the constant lattice (Bottom contract).
+    assert_eq!(cc.const_of(main_id, r), None);
+    assert!(cc.new_const_values(main_id).iter().all(|(v, _)| *v != r));
+}
+
+/// A two-level return expression grafts through a synthetic intermediate node: `f(x) = (x + 5) * 2`
+/// makes `f(a)` congruent to a caller-local `(a + 5) * 2`. The synthetic scaffolding is stripped,
+/// so it never reaches a congruence class or `compute_leaders` (which would otherwise treat a
+/// def-less id as an illegal leader).
+#[test]
+fn symbolic_jump_depth_two_grafts_via_synthetic() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let f = ssa.add_function("f".to_string());
+    let c5 = ssa.add_const(Constant::Field(Field::from(5u64)));
+    let c2 = ssa.add_const(Constant::Field(Field::from(2u64)));
+    let (x, ft, fa) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+
+    // f(x) = (x + 5) * 2
+    {
+        let hf = ssa.get_function_mut(f);
+        hf.add_return_type(Type::field());
+        hf.get_entry_mut().push_parameter(x, Type::field());
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: ft,
+            lhs: x,
+            rhs: c5,
+        });
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Mul,
+            result: fa,
+            lhs: ft,
+            rhs: c2,
+        });
+        hf.get_entry_mut()
+            .set_terminator(Terminator::Return(vec![fa]));
+    }
+
+    let a = ssa.fresh_value();
+    let (r, wt, w) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+    {
+        let mf = ssa.get_function_mut(main_id);
+        mf.add_return_type(Type::field());
+        mf.get_entry_mut().push_parameter(a, Type::field());
+        let entry = mf.get_entry_mut();
+        entry.push_instruction(OpCode::Call {
+            results: vec![r],
+            function: CallTarget::Static(f),
+            args: vec![a],
+            unconstrained: false,
+        });
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: wt,
+            lhs: a,
+            rhs: c5,
+        });
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Mul,
+            result: w,
+            lhs: wt,
+            rhs: c2,
+        });
+        entry.set_terminator(Terminator::Return(vec![r]));
+    }
+
+    let cc = run_in_test(&ssa);
+    assert!(cc.known_equal(main_id, r, w)); // r ≡ (a + 5) * 2
+
+    // `r`'s class is exactly `{r, w}` — no synthetic id leaked in.
+    let mut r_class = cc.congruence_class(main_id, r);
+    r_class.sort();
+    let mut expected = vec![r, w];
+    expected.sort();
+    assert_eq!(r_class, expected);
+
+    // The grafted inner `Add(a, 5)` is congruent to the real `wt`, but the synthetic that carried
+    // it was stripped, so `wt`'s class is `{wt}` alone and its leader is a real, def-dominating
+    // value.
+    assert_eq!(cc.congruence_class(main_id, wt), vec![wt]);
+    assert_eq!(cc.leader(main_id, wt), Some(wt));
+    let leader = cc.leader(main_id, r).expect("r is in a class");
+    assert!(leader == r || leader == w);
+}
+
+/// The dead-argument win survives a two-level return: `f(x, y) = (x + 5) * 2` (y dead) makes
+/// `f(a, c) ≡ f(a, d)` — the case a depth-1-only graft would lose by falling back to
+/// `CallDet[x, y]`.
+#[test]
+fn symbolic_jump_dead_argument_behind_depth_two() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let f = ssa.add_function("f".to_string());
+    let c5 = ssa.add_const(Constant::Field(Field::from(5u64)));
+    let c2 = ssa.add_const(Constant::Field(Field::from(2u64)));
+    let (x, y, ft, fa) = (
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+    );
+
+    // f(x, y) = (x + 5) * 2  (y is dead).
+    {
+        let hf = ssa.get_function_mut(f);
+        hf.add_return_type(Type::field());
+        hf.get_entry_mut().push_parameter(x, Type::field());
+        hf.get_entry_mut().push_parameter(y, Type::field());
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: ft,
+            lhs: x,
+            rhs: c5,
+        });
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Mul,
+            result: fa,
+            lhs: ft,
+            rhs: c2,
+        });
+        hf.get_entry_mut()
+            .set_terminator(Terminator::Return(vec![fa]));
+    }
+
+    let (a, b, c, d) = (
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+    );
+    let (r1, r2, r3) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+    {
+        let mf = ssa.get_function_mut(main_id);
+        mf.add_return_type(Type::field());
+        mf.add_return_type(Type::field());
+        mf.add_return_type(Type::field());
+        mf.get_entry_mut().push_parameter(a, Type::field());
+        mf.get_entry_mut().push_parameter(b, Type::field());
+        mf.get_entry_mut().push_parameter(c, Type::field());
+        mf.get_entry_mut().push_parameter(d, Type::field());
+        let entry = mf.get_entry_mut();
+        for (res, args) in [(r1, vec![a, c]), (r2, vec![a, d]), (r3, vec![b, c])] {
+            entry.push_instruction(OpCode::Call {
+                results: vec![res],
+                function: CallTarget::Static(f),
+                args,
+                unconstrained: false,
+            });
+        }
+        entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
+    }
+
+    let cc = run_in_test(&ssa);
+    assert!(cc.known_equal(main_id, r1, r2)); // dead 2nd arg, two levels deep ⇒ still congruent
+    assert!(!cc.known_equal(main_id, r1, r3)); // distinct 1st arg ⇒ distinct
+}
+
+/// A return deeper than the depth cap is not symbolically expressed (`Sym = None`), so the call
+/// falls back to `CallDet`: two identical calls stay congruent and a distinct argument does not,
+/// but the result is *not* related to the caller-local full expression.
+#[test]
+fn symbolic_jump_depth_over_cap_falls_back_to_calldet() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let f = ssa.add_function("f".to_string());
+    let c1 = ssa.add_const(Constant::Field(Field::from(1u64)));
+    let c2 = ssa.add_const(Constant::Field(Field::from(2u64)));
+    let c3 = ssa.add_const(Constant::Field(Field::from(3u64)));
+    let (x, ft, fu, fa) = (
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+    );
+
+    // f(x) = ((x + 1) * 2) + 3  (depth 3, over the cap).
+    {
+        let hf = ssa.get_function_mut(f);
+        hf.add_return_type(Type::field());
+        hf.get_entry_mut().push_parameter(x, Type::field());
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: ft,
+            lhs: x,
+            rhs: c1,
+        });
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Mul,
+            result: fu,
+            lhs: ft,
+            rhs: c2,
+        });
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: fa,
+            lhs: fu,
+            rhs: c3,
+        });
+        hf.get_entry_mut()
+            .set_terminator(Terminator::Return(vec![fa]));
+    }
+
+    let (a, b) = (ssa.fresh_value(), ssa.fresh_value());
+    let (r1, r2, r3) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+    let (wt, wu, w) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+    {
+        let mf = ssa.get_function_mut(main_id);
+        mf.add_return_type(Type::field());
+        mf.add_return_type(Type::field());
+        mf.add_return_type(Type::field());
+        mf.get_entry_mut().push_parameter(a, Type::field());
+        mf.get_entry_mut().push_parameter(b, Type::field());
+        let entry = mf.get_entry_mut();
+        for (res, arg) in [(r1, a), (r2, a), (r3, b)] {
+            entry.push_instruction(OpCode::Call {
+                results: vec![res],
+                function: CallTarget::Static(f),
+                args: vec![arg],
+                unconstrained: false,
+            });
+        }
+        // The caller-local `((a + 1) * 2) + 3`.
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: wt,
+            lhs: a,
+            rhs: c1,
+        });
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Mul,
+            result: wu,
+            lhs: wt,
+            rhs: c2,
+        });
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: w,
+            lhs: wu,
+            rhs: c3,
+        });
+        entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
+    }
+
+    let cc = run_in_test(&ssa);
+    assert!(cc.known_equal(main_id, r1, r2)); // CallDet still fires for identical args
+    assert!(!cc.known_equal(main_id, r1, r3)); // distinct arg ⇒ distinct
+    assert!(!cc.known_equal(main_id, r1, w)); // no symbolic graft past the depth cap
+}
+
+/// A return that flows through a nested call is opaque at a single interprocedural level
+/// (`Sym = None`), falling back to `CallDet`: `g(x) = h(x) + 1` numbers identical calls congruent
+/// and a distinct argument distinct, but does not graft the open expression.
+#[test]
+fn symbolic_jump_nested_call_falls_back_to_calldet() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let h = ssa.add_function("h".to_string());
+    let g = ssa.add_function("g".to_string());
+    let c1 = ssa.add_const(Constant::Field(Field::from(1u64)));
+
+    let (hx, hr) = (ssa.fresh_value(), ssa.fresh_value());
+    // h(x) = x + 1
+    {
+        let hf = ssa.get_function_mut(h);
+        hf.add_return_type(Type::field());
+        hf.get_entry_mut().push_parameter(hx, Type::field());
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: hr,
+            lhs: hx,
+            rhs: c1,
+        });
+        hf.get_entry_mut()
+            .set_terminator(Terminator::Return(vec![hr]));
+    }
+
+    let (gx, gc, ga) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+    // g(x) = h(x) + 1
+    {
+        let gf = ssa.get_function_mut(g);
+        gf.add_return_type(Type::field());
+        gf.get_entry_mut().push_parameter(gx, Type::field());
+        gf.get_entry_mut().push_instruction(OpCode::Call {
+            results: vec![gc],
+            function: CallTarget::Static(h),
+            args: vec![gx],
+            unconstrained: false,
+        });
+        gf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: ga,
+            lhs: gc,
+            rhs: c1,
+        });
+        gf.get_entry_mut()
+            .set_terminator(Terminator::Return(vec![ga]));
+    }
+
+    let (a, b) = (ssa.fresh_value(), ssa.fresh_value());
+    let (r1, r2, r3) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+    {
+        let mf = ssa.get_function_mut(main_id);
+        mf.add_return_type(Type::field());
+        mf.add_return_type(Type::field());
+        mf.add_return_type(Type::field());
+        mf.get_entry_mut().push_parameter(a, Type::field());
+        mf.get_entry_mut().push_parameter(b, Type::field());
+        let entry = mf.get_entry_mut();
+        for (res, arg) in [(r1, a), (r2, a), (r3, b)] {
+            entry.push_instruction(OpCode::Call {
+                results: vec![res],
+                function: CallTarget::Static(g),
+                args: vec![arg],
+                unconstrained: false,
+            });
+        }
+        entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
+    }
+
+    let cc = run_in_test(&ssa);
+    assert!(cc.known_equal(main_id, r1, r2)); // CallDet fallback: identical args congruent
+    assert!(!cc.known_equal(main_id, r1, r3)); // distinct arg ⇒ distinct
+}
+
+/// Commutativity is carried verbatim from `op_signature`: a non-commutative `f(x, y) = x - y` does
+/// not equate `f(a, b)` with `f(b, a)` (which an unsound commute would), while identical calls
+/// match.
+#[test]
+fn symbolic_jump_preserves_noncommutativity() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let f = ssa.add_function("f".to_string());
+    let (x, y, fa) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+
+    // f(x, y) = x - y
+    {
+        let hf = ssa.get_function_mut(f);
+        hf.add_return_type(Type::field());
+        hf.get_entry_mut().push_parameter(x, Type::field());
+        hf.get_entry_mut().push_parameter(y, Type::field());
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Sub,
+            result: fa,
+            lhs: x,
+            rhs: y,
+        });
+        hf.get_entry_mut()
+            .set_terminator(Terminator::Return(vec![fa]));
+    }
+
+    let (a, b) = (ssa.fresh_value(), ssa.fresh_value());
+    let (r1, r2, r3) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+    {
+        let mf = ssa.get_function_mut(main_id);
+        mf.add_return_type(Type::field());
+        mf.add_return_type(Type::field());
+        mf.add_return_type(Type::field());
+        mf.get_entry_mut().push_parameter(a, Type::field());
+        mf.get_entry_mut().push_parameter(b, Type::field());
+        let entry = mf.get_entry_mut();
+        for (res, args) in [(r1, vec![a, b]), (r2, vec![b, a]), (r3, vec![a, b])] {
+            entry.push_instruction(OpCode::Call {
+                results: vec![res],
+                function: CallTarget::Static(f),
+                args,
+                unconstrained: false,
+            });
+        }
+        entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
+    }
+
+    let cc = run_in_test(&ssa);
+    assert!(!cc.known_equal(main_id, r1, r2)); // x - y ≢ y - x
+    assert!(cc.known_equal(main_id, r1, r3)); // same operand order ⇒ congruent
+}
+
+/// A return mixing a formal with a fresh witness is not a pure function of the formals: `build_sym`
+/// bails on the witness operand (`Sym = None`) and, being non-deterministic, the return is not
+/// `CallDet`-numbered either, so two such calls stay distinct.
+#[test]
+fn symbolic_jump_witness_operand_is_not_grafted() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let f = ssa.add_function("f".to_string());
+    let (x, wit, fa) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+
+    // f(x) = x + witness
+    {
+        let hf = ssa.get_function_mut(f);
+        hf.add_return_type(Type::field());
+        hf.get_entry_mut().push_parameter(x, Type::field());
+        hf.get_entry_mut().push_instruction(OpCode::FreshWitness {
+            result: wit,
+            result_type: Type::field(),
+        });
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: fa,
+            lhs: x,
+            rhs: wit,
+        });
+        hf.get_entry_mut()
+            .set_terminator(Terminator::Return(vec![fa]));
+    }
+
+    let a = ssa.fresh_value();
+    let (r1, r2) = (ssa.fresh_value(), ssa.fresh_value());
+    {
+        let mf = ssa.get_function_mut(main_id);
+        mf.add_return_type(Type::field());
+        mf.add_return_type(Type::field());
+        mf.get_entry_mut().push_parameter(a, Type::field());
+        let entry = mf.get_entry_mut();
+        for res in [r1, r2] {
+            entry.push_instruction(OpCode::Call {
+                results: vec![res],
+                function: CallTarget::Static(f),
+                args: vec![a],
+                unconstrained: false,
+            });
+        }
+        entry.set_terminator(Terminator::Return(vec![r1, r2]));
+    }
+
+    let cc = run_in_test(&ssa);
+    assert!(!cc.known_equal(main_id, r1, r2)); // witness in return ⇒ neither grafted nor CallDet
+}
+
+/// A grafted return that names a *callee-only* constant must not produce a false congruence by
+/// minting its synthetic scaffolding onto a real value's id.
+#[test]
+fn symbolic_jump_synthetic_does_not_collide_with_callee_only_constant() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let f = ssa.add_function("f".to_string());
+
+    // Caller-side constants used to *synthesize* Field(5) without naming the callee-only constant,
+    // so the caller has a value in `C`'s constant class without referencing `C`'s id.
+    let two = ssa.add_const(Constant::Field(Field::from(2u64)));
+    let three = ssa.add_const(Constant::Field(Field::from(3u64)));
+
+    // `f`'s formal, then every caller value — all minted before the callee-only constant so its id
+    // is exactly one above the caller's local maximum (the single-synthetic window).
+    let x = ssa.fresh_value();
+    let a = ssa.fresh_value();
+    let v = ssa.fresh_value();
+    let w = ssa.fresh_value();
+    let r = ssa.fresh_value();
+
+    // The callee-only constant, interned last. Field(5) so the caller's `2 + 3` folds into its
+    // class.
+    let c = ssa.add_const(Constant::Field(Field::from(5u64)));
+
+    // `f`'s internal op results.
+    let (ft, fa) = (ssa.fresh_value(), ssa.fresh_value());
+
+    // Precondition: `c` sits exactly where a local-max-upward synthetic counter would mint its
+    // first synthetic. The downward allocator avoids it, but this positioning keeps the test a live
+    // regression guard against reverting to the buggy scheme. If id allocation ever shifts, it fails
+    // loudly rather than silently no longer exercising the collision.
+    assert_eq!(c.0, r.0 + 1);
+
+    // f(x) = x + (x * C)
+    {
+        let hf = ssa.get_function_mut(f);
+        hf.add_return_type(Type::field());
+        hf.get_entry_mut().push_parameter(x, Type::field());
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Mul,
+            result: ft,
+            lhs: x,
+            rhs: c,
+        });
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: fa,
+            lhs: x,
+            rhs: ft,
+        });
+        hf.get_entry_mut()
+            .set_terminator(Terminator::Return(vec![fa]));
+    }
+
+    {
+        let mf = ssa.get_function_mut(main_id);
+        mf.add_return_type(Type::field());
+        mf.add_return_type(Type::field());
+        mf.get_entry_mut().push_parameter(a, Type::field());
+        let entry = mf.get_entry_mut();
+        // v = 2 + 3, which folds to Field(5) — the same constant class as `c`.
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: v,
+            lhs: two,
+            rhs: three,
+        });
+        // r = f(a)
+        entry.push_instruction(OpCode::Call {
+            results: vec![r],
+            function: CallTarget::Static(f),
+            args: vec![a],
+            unconstrained: false,
+        });
+        // w = a + v, a genuine `a + 5`.
+        entry.push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: w,
+            lhs: a,
+            rhs: v,
+        });
+        entry.set_terminator(Terminator::Return(vec![r, w]));
+    }
+
+    let cc = run_in_test(&ssa);
+    // f(a) = a + a*5, never a + 5, so `r` must not be congruent to `w`.
+    assert!(!cc.known_equal(main_id, r, w));
+}


### PR DESCRIPTION
This enhancement makes it possible for downstream passes to make simplifications based on argument expressions to functions by passing them symbolically. This means that PRE will be able to perform more-aggressive floating.

The analysis only goes to a fixed depth to ensure it remains tractable. It does not impact the corpus yet as it is not consumed at this stage.

Partial work on #260.