### PR TITLE
Add support for contextual conditional facts

### DIFF
--- a/compiler/src/compiler/analysis/click_cooper/conditional.rs
+++ b/compiler/src/compiler/analysis/click_cooper/conditional.rs
@@ -75,7 +75,11 @@ use crate::{
 #[derive(Debug, Default)]
 pub(crate) struct ConditionalFacts {
     /// Values forced to a constant by a dominating assert: `Assert{v}` ⇒ `v = true`,
-    /// `AssertCmp{Eq, x, c}` (with one side unconditional-constant `c`) ⇒ the other side `= c`.
+    /// `AssertCmp{Eq, x, c}` (with one side an unconditional *scalar* constant `c`) ⇒ the other
+    /// side `= c`.
+    ///
+    /// Aggregate (`Blob`) pins are recorded nowhere as Blob constants are never surfaced to
+    /// consumers.
     assert_const: HashMap<BlockId, HashMap<ValueId, Arc<Constant>>>,
 
     /// Equalities established by a dominating `AssertCmp{Eq, a, b}` where neither side is a
@@ -223,7 +227,8 @@ pub(crate) fn build(
 ) -> ConditionalFacts {
     let mut out = ConditionalFacts::default();
 
-    // The *unconditional* constant of `v` (interned or proven by the lattice), if any.
+    // The *unconditional* constant of `v` (interned or proven by the lattice), if any — including
+    // aggregates, which callers must gate out before recording a fact.
     //
     // Asserts that pin a value to such a constant produce a *conditional* fact; the unconditional
     // view is never touched.
@@ -262,19 +267,30 @@ pub(crate) fn build(
                     lhs,
                     rhs,
                 } => {
-                    if let Some(c) = const_of(*lhs) {
-                        raw_const.entry(*bid).or_default().push((idx, *rhs, c));
-                    } else if let Some(c) = const_of(*rhs) {
-                        raw_const.entry(*bid).or_default().push((idx, *lhs, c));
-                    } else {
-                        // Store the pair canonically (min, max) by value id so `(x, y)` and
-                        // `(y, x)` dedup as one in the cross-block fan-out below.
-                        let (lo, hi) = if lhs.0 <= rhs.0 {
-                            (*lhs, *rhs)
-                        } else {
-                            (*rhs, *lhs)
-                        };
-                        raw_eq.entry(*bid).or_default().push((idx, lo, hi));
+                    // The pinned side, if the other is an unconditional constant: `(value, c)`.
+                    let pin = const_of(*lhs)
+                        .map(|c| (*rhs, c))
+                        .or_else(|| const_of(*rhs).map(|c| (*lhs, c)));
+                    match pin {
+                        Some((v, c)) if c.is_scalar() => {
+                            raw_const.entry(*bid).or_default().push((idx, v, c));
+                        }
+
+                        // An aggregate (`Blob`) pin is recorded in *neither* channel: Blob
+                        // constants are never surfaced to consumers (see `const_in_facts`), and
+                        // routing the pair to the eq channel would put a constant-sided pair into
+                        // the leader machinery.
+                        Some(_) => {}
+                        None => {
+                            // Store the pair canonically (min, max) by value id so `(x, y)` and
+                            // `(y, x)` dedup as one in the cross-block fan-out below.
+                            let (lo, hi) = if lhs.0 <= rhs.0 {
+                                (*lhs, *rhs)
+                            } else {
+                                (*rhs, *lhs)
+                            };
+                            raw_eq.entry(*bid).or_default().push((idx, lo, hi));
+                        }
                     }
                 }
                 OpCode::Cmp {

--- a/compiler/src/compiler/analysis/click_cooper/mod.rs
+++ b/compiler/src/compiler/analysis/click_cooper/mod.rs
@@ -21,7 +21,8 @@
 //!   yield congruent results).
 //! - **Conditional facts** are ones derived from asserts, equalities, disequalities, and unpinned
 //!   witness forwarding. They are computed post-convergence over the same reachability state plus
-//!   CFG dominance, and are intentionally disjoint from the unconditional view.
+//!   CFG dominance — once from the intraprocedural facts and once per `(function, context)` from
+//!   the 1-CFA-specialized facts — and are intentionally disjoint from the unconditional view.
 //!
 //! **Unconditional facts** are those which hold on any path so that any use (replacing a use,
 //! deleting a pure definition, or pruning an unreachable block) maintains soundness. **Conditional
@@ -111,15 +112,10 @@
 //!
 //! # Deferred Improvements
 //!
-//! The following are improvements planned for the future of this analysis.
+//! The following are improvements for the future of this analysis. They are either necessary for
+//! future work, or deferred because they are expected to yield little benefit on our current
+//! circuit corpus.
 //!
-//! - **Per-context Conditional Facts:** The assert/disequality/witness-forwarding conditional facts
-//!   are computed once per function and not refined per 1-CFA context, so they have no `_in(f, ctx,
-//!   …)` query: a caller reads them through the intraprocedural methods, whose (sound,
-//!   context-independent) answer is a per-context under-approximation. Recomputing the conditional
-//!   pass per `(function, context)` — as `specialize` already does for the unconditional facts —
-//!   would let a context-specialized assert or branch expose more facts, and would warrant adding
-//!   the `_in` variants.
 //! - **Sound Post-Dominance for Assert Facts:** Assert facts (`asserted_const`/`asserted_equal`)
 //!   currently fan out by dominance only. The post-dominance direction — an assert in `B` is *bound
 //!   to run* at every block `C` it strictly post-dominates, so its fact would also hold at a use
@@ -203,6 +199,11 @@ pub struct ClickCooper {
     ///
     /// They are intentionally disjoint from the unconditional views above.
     conditional: HashMap<FunctionId, ConditionalFacts>,
+
+    /// Per-`(function, context)` **conditional** facts (the 1-CFA refinement of `conditional`).
+    ///
+    /// Disjoint from `contexts`, exactly as `conditional` is from `functions`.
+    conditional_contexts: HashMap<(FunctionId, Context), ConditionalFacts>,
 }
 
 impl Analysis for ClickCooper {
@@ -237,6 +238,33 @@ impl ClickCooper {
         let sym = compute_sym_summaries(ssa, &consts, &sym_cache);
         drop(sym_cache);
 
+        // One dominance-consistent definition order per function, shared by the congruence-leader
+        // finalization (intraprocedural here, per-context inside `specialize`) and every
+        // conditional build below: it depends only on function structure and CFG dominance, both
+        // context-independent.
+        let orders: HashMap<FunctionId, DefOrder> = ssa
+            .get_function_ids()
+            .map(|fid| {
+                (
+                    fid,
+                    DefOrder::new(ssa.get_function(fid), flow.get_function_cfg(fid)),
+                )
+            })
+            .collect();
+
+        // One conditional build, shared verbatim by the intraprocedural and per-context loops
+        // below; only the converged facts differ between the two.
+        let build_conditional = |fid: FunctionId, facts: &FunctionFacts| {
+            conditional::build(
+                ssa.get_function(fid),
+                facts,
+                flow.get_function_cfg(fid),
+                &consts,
+                types.get_function(fid),
+                &orders[&fid],
+            )
+        };
+
         // Per-function intraprocedural facts: parameters and call results `Bottom`. The conditional
         // facts are computed from the same converged state plus CFG dominance, kept in a disjoint
         // map so the unconditional view is untouched.
@@ -263,34 +291,34 @@ impl ClickCooper {
                 &HashMap::default(),
             );
 
-            // The shared dominance-consistent definition order, built once and reused for both the
-            // congruence leaders and the conditional-fact leaders below.
-            let order = DefOrder::new(function, flow.get_function_cfg(fid));
-
             // Finalize dominance-aware congruence leaders, so `leader` returns a legal redirect
             // target.
-            facts.congruence.compute_leaders(&order);
-            let cond = conditional::build(
-                function,
-                &facts,
-                flow.get_function_cfg(fid),
-                &consts,
-                types.get_function(fid),
-                &order,
-            );
-            conditional.insert(fid, cond);
+            facts.congruence.compute_leaders(&orders[&fid]);
+            conditional.insert(fid, build_conditional(fid, &facts));
             functions.insert(fid, facts);
         }
 
         // The 1-CFA contextual facts, built from the polymorphic summaries (computed above) plus
         // the symbolic congruence projection.
-        let contexts = specialize(ssa, flow, &consts, &summaries, &sym, &det);
+        let contexts = specialize(ssa, &consts, &summaries, &sym, &det, &orders);
+
+        // The per-`(function, context)` conditional facts, rebuilt by the same `conditional::build`
+        // from each context's specialized facts, so every fact is anchored to context-reachable
+        // blocks and context-live values — which is what makes the `_in` queries safe to drive
+        // context-specialized rewrites, and why they read this map exclusively. Neither view
+        // refines the other in general. The map iteration order is immaterial: each build is
+        // independent and internally deterministic, and the results land in a keyed map.
+        let mut conditional_contexts = HashMap::default();
+        for ((fid, ctx), facts) in &contexts {
+            conditional_contexts.insert((*fid, ctx.clone()), build_conditional(*fid, facts));
+        }
 
         ClickCooper {
             consts,
             functions,
             contexts,
             conditional,
+            conditional_contexts,
         }
     }
 }
@@ -305,6 +333,16 @@ impl ClickCooper {
     /// The context-specialized (1-CFA) facts of `f` under `ctx`, or `None`.
     fn facts_in(&self, f: FunctionId, ctx: &Context) -> Option<&FunctionFacts> {
         self.contexts.get(&(f, ctx.clone()))
+    }
+
+    /// The intraprocedural conditional facts of `f`, or `None` if `f` was not analyzed.
+    fn conditional(&self, f: FunctionId) -> Option<&ConditionalFacts> {
+        self.conditional.get(&f)
+    }
+
+    /// The per-context conditional facts of `f` under `ctx`, or `None`.
+    fn conditional_in(&self, f: FunctionId, ctx: &Context) -> Option<&ConditionalFacts> {
+        self.conditional_contexts.get(&(f, ctx.clone()))
     }
 
     /// The constant `v` holds in `facts`, or `None`: interned constants first, then the constant
@@ -447,12 +485,31 @@ impl ClickCooper {
 /// that keeps the establishing branch/assert (never folding away the constraint that proves the
 /// fact).
 ///
-/// These are **intraprocedural** and hence have no context. A conditional fact is established by
-/// control flow *internal to `f`* (a dominating assert, a branch predicate, a witness write), so it
-/// holds in *every* calling context. A context only adds parameter constants and prunes blocks, so
-/// it can make a block unreachable but can never invalidate a fact on a block that remains
-/// reachable. The intraprocedural answer is thus a sound **under-approximation** of the per-context
-/// one.
+/// These are **intraprocedural**: a conditional fact here is established by control flow _internal
+/// to `f`_ (a dominating assert, a branch predicate, a witness write), so the fact itself holds in
+/// _every_ calling context. Reading them is sound for **context-independent** rewrites.
+///
+/// A **context-specialized** rewrite — one applied to a per-context clone that prunes context-dead
+/// blocks — must use the `_in` analogs instead (rebuilt per `(function, context)` from the
+/// specialized facts; see [`Self::asserted_const_in`] and its sibling `_in` queries). This is
+/// because an intraprocedural fact can name a value whose definition the clone prunes (e.g. a
+/// `ValueOf`-derived witness-forward member defined in a context-dead block).
+///
+/// **No pointwise inclusion holds between the two views, in either direction, on any channel.**
+/// Context seeding usually adds facts (a pinned parameter turns an asserted equality into an
+/// asserted constant; a pruned edge creates a disequality) but can also remove them. The following
+/// are examples:
+///
+/// - An equality migrates to the const channel when one side becomes a per-context constant.
+/// - An assert whose *asserted* side becomes a per-context constant moves to the (strictly
+///   stronger) unconditional channel and out of `asserted_const_in`.
+/// - An aggregate-pinning assert contributes nothing.
+/// - A per-context constant can *split* an intraprocedurally-proven congruence so a branch the
+///   intraprocedural writeback folded stays live in the context — shifting reachability, and every
+///   reachability-derived fact, in the *growing* direction.
+///
+/// A consumer wanting the full per-context picture must consult both families, applying each fact
+/// only under its own contract.
 impl ClickCooper {
     /// The constant `v` holds on entry to `bid` in `f`, honoring path-sensitive branch facts.
     pub fn const_in_block(&self, f: FunctionId, bid: BlockId, v: ValueId) -> Option<Arc<Constant>> {
@@ -504,14 +561,16 @@ impl ClickCooper {
     /// assert never folds its own operand and vacuums the constraint.
     ///
     /// A conditional fact, deliberately disjoint from [`Self::const_of`] as a consumer must keep
-    /// the establishing assert.
+    /// the establishing assert. The constant is always scalar: an assert pinning a value to an
+    /// aggregate contributes no fact, upholding the module contract that `Blob` constants are
+    /// never surfaced.
     pub fn asserted_const(
         &self,
         f: FunctionId,
         point: ProgramPoint,
         v: ValueId,
     ) -> Option<Arc<Constant>> {
-        self.conditional.get(&f)?.asserted_const(point, v)
+        self.conditional(f)?.asserted_const(point, v)
     }
 
     /// `true` if `a == b` is proven at `point` in `f` by a dominating `AssertCmp{Eq}` or one
@@ -526,8 +585,7 @@ impl ClickCooper {
         a: ValueId,
         b: ValueId,
     ) -> bool {
-        self.conditional
-            .get(&f)
+        self.conditional(f)
             .is_some_and(|c| c.asserted_equal(point, a, b))
     }
 
@@ -547,7 +605,7 @@ impl ClickCooper {
         point: ProgramPoint,
         v: ValueId,
     ) -> Option<ValueId> {
-        self.conditional.get(&f)?.asserted_leader(point, v)
+        self.conditional(f)?.asserted_leader(point, v)
     }
 
     /// `true` if `a` and `b` are proven unequal on entry to `bid` in `f` (the false edge of an
@@ -556,8 +614,7 @@ impl ClickCooper {
     /// Note that this only accounts for _disequality_ `a != b`, and not expanded linear
     /// inequalities.
     pub fn known_unequal(&self, f: FunctionId, bid: BlockId, a: ValueId, b: ValueId) -> bool {
-        self.conditional
-            .get(&f)
+        self.conditional(f)
             .is_some_and(|c| c.known_disequal(bid, a, b))
     }
 
@@ -572,15 +629,15 @@ impl ClickCooper {
     /// rejecting the honest run), not a structural congruence — so it lives here, never in
     /// [`Self::known_equal`], and two free witnesses are never unified.
     pub fn witness_forward(&self, f: FunctionId, r: ValueId) -> &[ValueId] {
-        self.conditional
-            .get(&f)
+        self.conditional(f)
             .map(|c| c.witness_forward(r))
             .unwrap_or_default()
     }
 }
 
-/// Interprocedural conditional queries — the per-context analogs of the *branch-fact*
-/// intraprocedural conditional queries above (e.g. for a clone of `f` specialized to `ctx`).
+/// Interprocedural conditional queries, the *branch-fact* family — the per-context analogs of the
+/// branch-fact intraprocedural conditional queries above (e.g. for a clone of `f` specialized to
+/// `ctx`).
 ///
 /// They are sound *only* under constraint-preserving use: a local, structure-preserving rewrite
 /// that keeps the establishing branch (never folding away the constraint that proves the fact).
@@ -650,5 +707,83 @@ impl ClickCooper {
             m.iter().map(|(v, b)| (*v, bool_constant(*b))).collect();
         out.sort_by_key(|(v, _)| v.0);
         out
+    }
+}
+
+/// Interprocedural conditional queries, the *assert/disequality/witness* family — reading the
+/// `ConditionalFacts` rebuilt per `(function, context)` from the context-specialized facts.
+///
+/// They inherit **both** contracts.
+///
+/// - **Constraint-Preserving Use:** A local, structure-preserving rewrite that keeps the
+///   establishing assert/branch (never folding away the constraint that proves the fact).
+/// - **Context-Locality:** An answer that is conditional on `ctx` must drive a context-specialized
+///   rewrite only — never be lifted into a context-independent change.
+///
+/// The context refinement *typically* strengthens the assert-const and disequality channels (e.g.
+/// an `AssertCmp{Eq, x, p}` whose `p` is a per-context constant pins `x` to an asserted *constant*
+/// where the intraprocedural view only has an asserted _equality_), but no channel is a pointwise
+/// superset or subset of its intraprocedural counterpart. These queries read the per-context map
+/// exclusively: its facts are anchored to context-live blocks and values, which is what makes them
+/// safe to drive context-specialized rewrites.
+impl ClickCooper {
+    /// [`Self::asserted_const`] under calling context `ctx`.
+    pub fn asserted_const_in(
+        &self,
+        f: FunctionId,
+        ctx: &Context,
+        point: ProgramPoint,
+        v: ValueId,
+    ) -> Option<Arc<Constant>> {
+        self.conditional_in(f, ctx)?.asserted_const(point, v)
+    }
+
+    /// [`Self::asserted_equal`] under calling context `ctx`.
+    pub fn asserted_equal_in(
+        &self,
+        f: FunctionId,
+        ctx: &Context,
+        point: ProgramPoint,
+        a: ValueId,
+        b: ValueId,
+    ) -> bool {
+        self.conditional_in(f, ctx)
+            .is_some_and(|c| c.asserted_equal(point, a, b))
+    }
+
+    /// [`Self::asserted_leader`] under calling context `ctx`.
+    pub fn asserted_leader_in(
+        &self,
+        f: FunctionId,
+        ctx: &Context,
+        point: ProgramPoint,
+        v: ValueId,
+    ) -> Option<ValueId> {
+        self.conditional_in(f, ctx)?.asserted_leader(point, v)
+    }
+
+    /// [`Self::known_unequal`] under calling context `ctx`.
+    pub fn known_unequal_in(
+        &self,
+        f: FunctionId,
+        ctx: &Context,
+        bid: BlockId,
+        a: ValueId,
+        b: ValueId,
+    ) -> bool {
+        self.conditional_in(f, ctx)
+            .is_some_and(|c| c.known_disequal(bid, a, b))
+    }
+
+    /// [`Self::witness_forward`] under calling context `ctx`.
+    ///
+    /// Reads the per-context scan exclusively: a forward established in a context-dead block is
+    /// dropped (so every member is context-live), while a block live only under the context's
+    /// refinement can contribute a forward the intraprocedural set lacks — neither set contains
+    /// the other in general.
+    pub fn witness_forward_in(&self, f: FunctionId, ctx: &Context, r: ValueId) -> &[ValueId] {
+        self.conditional_in(f, ctx)
+            .map(|c| c.witness_forward(r))
+            .unwrap_or_default()
     }
 }

--- a/compiler/src/compiler/analysis/click_cooper/summary.rs
+++ b/compiler/src/compiler/analysis/click_cooper/summary.rs
@@ -499,13 +499,16 @@ fn build_sym(
 
 /// Phase 2: re-solve every reachable `(function, context)` with parameters seeded by the calling
 /// context's argument constants.
+///
+/// `orders` is the caller's per-function definition order (context-independent, so shared across
+/// every context of a function), consumed by the per-context congruence-leader finalization.
 pub(crate) fn specialize(
     ssa: &HLSSA,
-    flow: &FlowAnalysis,
     consts: &HLSSAConstantsSnapshot,
     summaries: &HashMap<FunctionId, FnSummary>,
     sym: &SymSummaries,
     det: &DetSummaries,
+    orders: &HashMap<FunctionId, DefOrder>,
 ) -> HashMap<(FunctionId, Context), FunctionFacts> {
     let main = ssa.get_unique_entrypoint_id();
 
@@ -556,8 +559,7 @@ pub(crate) fn specialize(
 
         // Build the dominance-aware congruence leaders so `leader_in` yields a legal redirect
         // target.
-        let order = DefOrder::new(func, flow.get_function_cfg(f));
-        facts.congruence.compute_leaders(&order);
+        facts.congruence.compute_leaders(&orders[&f]);
 
         // Propagate argument constants from each reachable static call into the callee's context.
         for (bid, block) in func.get_blocks() {

--- a/compiler/src/compiler/analysis/click_cooper/test.rs
+++ b/compiler/src/compiler/analysis/click_cooper/test.rs
@@ -5,7 +5,7 @@ use crate::compiler::{
         types::Types,
     },
     ssa::{
-        ProgramPoint, Terminator,
+        FunctionId, ProgramPoint, Terminator,
         hlssa::{
             BinaryArithOpKind, Blob, CallTarget, CastTarget, CmpKind, Constant, HLSSA, OpCode,
             ScalarFold, SequenceTargetType, SliceOpDir, Type,
@@ -21,6 +21,13 @@ pub(crate) fn run_in_test(ssa: &HLSSA) -> ClickCooper {
     let flow = FlowAnalysis::run(ssa);
     let types = Types::new().run(ssa, &flow);
     ClickCooper::run(ssa, &flow, &types)
+}
+
+/// The single context `f` was specialized in, asserting there is exactly one.
+fn sole_context(cc: &ClickCooper, f: FunctionId) -> Context {
+    let ctxs = cc.contexts_of(f);
+    assert_eq!(ctxs.len(), 1);
+    ctxs.into_iter().next().unwrap()
 }
 
 // TESTS
@@ -2075,10 +2082,10 @@ fn interproc_writeback_terminates_under_recursion() {
     }
 }
 
-/// The context-parameterized conditional queries. The branch-fact family (`const_in_block_in`)
+/// The context-parameterized conditional queries: the branch-fact family (`const_in_block_in`)
 /// is context-*precise* — it sees the per-context parameter constant the intraprocedural query
-/// cannot — while the assert/witness family forwards to the (sound, context-independent)
-/// intraprocedural facts.
+/// cannot. (The assert/disequality/witness family is likewise rebuilt per context; see the
+/// `*_in` conditional tests below.)
 #[test]
 fn context_parameterized_conditional_queries() {
     let mut ssa = HLSSA::with_main("main".to_string());
@@ -2110,16 +2117,551 @@ fn context_parameterized_conditional_queries() {
 
     let entry_id = ssa.get_function(id).get_entry_id();
     let cc = run_in_test(&ssa);
-    let ctxs = cc.contexts_of(id);
-    assert_eq!(ctxs.len(), 1);
-    let ctx = &ctxs[0];
+    let ctx = sole_context(&cc, id);
 
     // Intraprocedurally `p` is unconstrained; under the single call context it is the constant 7.
     assert_eq!(cc.const_in_block(id, entry_id, p), None);
     assert_eq!(
-        cc.const_in_block_in(id, ctx, entry_id, p).as_deref(),
+        cc.const_in_block_in(id, &ctx, entry_id, p).as_deref(),
         Some(&Constant::Field(Field::from(7u64)))
     );
+}
+
+/// Per-context conditional facts can be more precise: `assert(x == p)` is only an asserted
+/// *equality* intraprocedurally (`p` opaque), but pins `x` to an asserted *constant* in a context
+/// where `p` is a lattice constant. The pair then *migrates* channels — it leaves the per-context
+/// eq channel, so `asserted_equal_in` is deliberately not a pointwise superset of `asserted_equal`.
+#[test]
+fn asserted_const_refines_per_context() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let g = ssa.add_function("g".to_string());
+    let (x, p) = (ssa.fresh_value(), ssa.fresh_value());
+    let c7 = ssa.add_const(Constant::Field(Field::from(7u64)));
+    let x0 = ssa.fresh_value();
+
+    let after = {
+        let hf = ssa.get_function_mut(g);
+        let after = hf.add_block();
+        hf.get_entry_mut().push_parameter(x, Type::field());
+        hf.get_entry_mut().push_parameter(p, Type::field());
+        hf.get_entry_mut().push_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: p,
+        });
+        hf.get_entry_mut()
+            .set_terminator(Terminator::Jmp(after, vec![]));
+        hf.get_block_mut(after)
+            .set_terminator(Terminator::Return(vec![]));
+        after
+    };
+    {
+        let mf = ssa.get_function_mut(main_id);
+        let entry = mf.get_entry_mut();
+        entry.push_parameter(x0, Type::field());
+        entry.push_instruction(OpCode::Call {
+            results: vec![],
+            function: CallTarget::Static(g),
+            args: vec![x0, c7],
+            unconstrained: false,
+        });
+        entry.set_terminator(Terminator::Return(vec![]));
+    }
+
+    let cc = run_in_test(&ssa);
+    let ctx = sole_context(&cc, g);
+    let pp = ProgramPoint::new(after, 0);
+
+    // Intraprocedurally `p` is opaque: the assert is an equality, not a constant pin.
+    assert_eq!(cc.asserted_const(g, pp, x), None);
+    assert!(cc.asserted_equal(g, pp, x, p));
+    // In the context `p` is the constant 7, so the same assert pins `x` to it...
+    assert_eq!(
+        cc.asserted_const_in(g, &ctx, pp, x).as_deref(),
+        Some(&Constant::Field(Field::from(7u64)))
+    );
+    // ...and the pair has migrated out of the per-context eq channel.
+    assert!(!cc.asserted_equal_in(g, &ctx, pp, x, p));
+}
+
+/// `witness_forward_in` drops a forward established in a context-dead block: the witness scan is
+/// reachability-gated, so a forward the intraprocedural view reports can be absent per context —
+/// the hazard that forbids `witness_forward_in` from delegating to the intraprocedural map. The
+/// other direction exists too; see `context_constant_can_split_congruence`
+#[test]
+fn witness_forward_in_prunes_context_dead_forward() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let g = ssa.add_function("g".to_string());
+    let (p, w, r) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+    let c_true = ssa.add_const(Constant::U(1, 1));
+    let w0 = ssa.fresh_value();
+
+    {
+        let hf = ssa.get_function_mut(g);
+        let then_b = hf.add_block();
+        let else_b = hf.add_block();
+        let after = hf.add_block();
+        hf.get_entry_mut().push_parameter(p, Type::u(1));
+        hf.get_entry_mut().push_parameter(w, Type::u(32));
+        hf.get_entry_mut()
+            .set_terminator(Terminator::JmpIf(p, then_b, else_b));
+        hf.get_block_mut(then_b)
+            .set_terminator(Terminator::Jmp(after, vec![]));
+        // The false arm establishes the forward `r → w`; it is dead once a context pins `p`.
+        hf.get_block_mut(else_b)
+            .push_instruction(OpCode::WriteWitness {
+                result: Some(r),
+                value: w,
+                pinned: false,
+            });
+        hf.get_block_mut(else_b)
+            .set_terminator(Terminator::Jmp(after, vec![]));
+        hf.get_block_mut(after)
+            .set_terminator(Terminator::Return(vec![]));
+    }
+    {
+        let mf = ssa.get_function_mut(main_id);
+        let entry = mf.get_entry_mut();
+        entry.push_parameter(w0, Type::u(32));
+        entry.push_instruction(OpCode::Call {
+            results: vec![],
+            function: CallTarget::Static(g),
+            args: vec![c_true, w0],
+            unconstrained: false,
+        });
+        entry.set_terminator(Terminator::Return(vec![]));
+    }
+
+    let cc = run_in_test(&ssa);
+    let ctx = sole_context(&cc, g);
+
+    // Intraprocedurally `p` is opaque, both arms live: the forward is gathered.
+    assert_eq!(cc.witness_forward(g, r), [w].as_slice());
+    // In the context `p = true` kills the false arm — and its forward with it.
+    assert!(cc.witness_forward_in(g, &ctx, r).is_empty());
+}
+
+/// Parity when nothing refines: under `main`'s empty context the seeds are Bottom, and `main` has
+/// no static calls (the per-context solve enables the eval-call summary channel the
+/// intraprocedural one keeps off, so a folding call would break the "nothing refines" premise) —
+/// every per-context conditional channel coincides with its intraprocedural counterpart.
+#[test]
+fn conditional_queries_parity_under_empty_context() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let (x, a, b) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+    let (d, e) = (ssa.fresh_value(), ssa.fresh_value());
+    let (eq, r) = (ssa.fresh_value(), ssa.fresh_value());
+    let c5 = ssa.add_const(Constant::U(32, 5));
+
+    let f = ssa.get_unique_entrypoint_mut();
+    let then_b = f.add_block();
+    let else_b = f.add_block();
+    let after = f.add_block();
+    for v in [x, a, b, d, e] {
+        f.get_entry_mut().push_parameter(v, Type::u(32));
+    }
+    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+        kind: CmpKind::Eq,
+        lhs: x,
+        rhs: c5,
+    });
+    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+        kind: CmpKind::Eq,
+        lhs: a,
+        rhs: b,
+    });
+    f.get_entry_mut().push_instruction(OpCode::WriteWitness {
+        result: Some(r),
+        value: x,
+        pinned: false,
+    });
+    f.get_entry_mut().push_instruction(OpCode::Cmp {
+        kind: CmpKind::Eq,
+        result: eq,
+        lhs: d,
+        rhs: e,
+    });
+    f.get_entry_mut()
+        .set_terminator(Terminator::JmpIf(eq, then_b, else_b));
+    f.get_block_mut(then_b)
+        .set_terminator(Terminator::Jmp(after, vec![]));
+    f.get_block_mut(else_b)
+        .set_terminator(Terminator::Jmp(after, vec![]));
+    f.get_block_mut(after)
+        .set_terminator(Terminator::Return(vec![]));
+
+    let cc = run_in_test(&ssa);
+    let ctx = Context::empty();
+    let pp = ProgramPoint::new(after, 0);
+
+    // Assert-const channel.
+    assert_eq!(
+        cc.asserted_const(main_id, pp, x).as_deref(),
+        Some(&Constant::U(32, 5))
+    );
+    assert_eq!(
+        cc.asserted_const_in(main_id, &ctx, pp, x),
+        cc.asserted_const(main_id, pp, x)
+    );
+    // Assert-eq channel and its leaders.
+    assert!(cc.asserted_equal(main_id, pp, a, b));
+    assert!(cc.asserted_equal_in(main_id, &ctx, pp, a, b));
+    assert_eq!(cc.asserted_leader(main_id, pp, b), Some(a));
+    assert_eq!(
+        cc.asserted_leader_in(main_id, &ctx, pp, b),
+        cc.asserted_leader(main_id, pp, b)
+    );
+    // Disequality channel (the false edge is the sole in-edge of `else_b` in both views).
+    assert!(cc.known_unequal(main_id, else_b, d, e));
+    assert!(cc.known_unequal_in(main_id, &ctx, else_b, d, e));
+    // Witness channel.
+    assert_eq!(cc.witness_forward(main_id, r), [x].as_slice());
+    assert_eq!(
+        cc.witness_forward_in(main_id, &ctx, r),
+        cc.witness_forward(main_id, r)
+    );
+}
+
+/// A context can *create* a disequality: pinning the branch predicate prunes one predecessor of
+/// the false-edge target, making the false edge its sole executable in-edge — so `known_unequal_in`
+/// holds where the intraprocedural `known_unequal` (two live in-edges) cannot.
+#[test]
+fn known_unequal_in_gains_from_pruned_predecessor() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let g = ssa.add_function("g".to_string());
+    let (p, d, e, eq) = (
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+    );
+    let c_false = ssa.add_const(Constant::U(1, 0));
+    let (d0, e0) = (ssa.fresh_value(), ssa.fresh_value());
+
+    let join = {
+        let hf = ssa.get_function_mut(g);
+        let side = hf.add_block();
+        let main_b = hf.add_block();
+        let then_b = hf.add_block();
+        let join = hf.add_block();
+        hf.get_entry_mut().push_parameter(p, Type::u(1));
+        hf.get_entry_mut().push_parameter(d, Type::u(32));
+        hf.get_entry_mut().push_parameter(e, Type::u(32));
+        hf.get_entry_mut().push_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: d,
+            rhs: e,
+        });
+        hf.get_entry_mut()
+            .set_terminator(Terminator::JmpIf(p, side, main_b));
+        // `side` is `join`'s second predecessor; it dies once a context pins `p = false`.
+        hf.get_block_mut(side)
+            .set_terminator(Terminator::Jmp(join, vec![]));
+        hf.get_block_mut(main_b)
+            .set_terminator(Terminator::JmpIf(eq, then_b, join));
+        hf.get_block_mut(then_b)
+            .set_terminator(Terminator::Return(vec![]));
+        hf.get_block_mut(join)
+            .set_terminator(Terminator::Return(vec![]));
+        join
+    };
+    {
+        let mf = ssa.get_function_mut(main_id);
+        let entry = mf.get_entry_mut();
+        entry.push_parameter(d0, Type::u(32));
+        entry.push_parameter(e0, Type::u(32));
+        entry.push_instruction(OpCode::Call {
+            results: vec![],
+            function: CallTarget::Static(g),
+            args: vec![c_false, d0, e0],
+            unconstrained: false,
+        });
+        entry.set_terminator(Terminator::Return(vec![]));
+    }
+
+    let cc = run_in_test(&ssa);
+    let ctx = sole_context(&cc, g);
+
+    // Intraprocedurally `join` has two live in-edges (`side` and the false edge): no diseq.
+    assert!(!cc.known_unequal(g, join, d, e));
+    // The context pins `p = false`, killing `side`: the false edge becomes `join`'s sole
+    // executable in-edge, and the disequality appears.
+    assert!(cc.known_unequal_in(g, &ctx, join, d, e));
+}
+
+/// An assert pinning a value to an *aggregate* constant contributes no conditional fact: `Blob`
+/// constants are never surfaced (the module "Aggregate Folding" contract), so the pin enters
+/// neither the assert-const channel — whose consumers materialise the constant — nor the eq
+/// channel, whose pairs must be constant-free.
+#[test]
+fn asserted_const_never_aggregate() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let c0 = ssa.add_const(Constant::U(32, 10));
+    let c1 = ssa.add_const(Constant::U(32, 20));
+    let (x, s) = (ssa.fresh_value(), ssa.fresh_value());
+
+    let f = ssa.get_unique_entrypoint_mut();
+    let after = f.add_block();
+    f.get_entry_mut().push_parameter(x, Type::u(32).array_of(2));
+    let entry = f.get_entry_mut();
+    // `s` aggregate-folds to a lattice `Const(Blob)`, so the assert pins `x` to a Blob.
+    entry.push_instruction(OpCode::MkSeq {
+        result: s,
+        elems: vec![c0, c1],
+        seq_type: SequenceTargetType::Array(2),
+        elem_type: Type::u(32),
+    });
+    entry.push_instruction(OpCode::AssertCmp {
+        kind: CmpKind::Eq,
+        lhs: x,
+        rhs: s,
+    });
+    entry.set_terminator(Terminator::Jmp(after, vec![]));
+    f.get_block_mut(after)
+        .set_terminator(Terminator::Return(vec![]));
+
+    let cc = run_in_test(&ssa);
+    let pp = ProgramPoint::new(after, 0);
+
+    // The Blob must not surface through the conditional channel...
+    assert_eq!(cc.asserted_const(main_id, pp, x), None);
+    // ...nor reroute into the eq channel as a constant-sided pair.
+    assert!(!cc.asserted_equal(main_id, pp, x, s));
+}
+
+/// The per-context analog: a callee parameter seeded with the caller's constant-aggregate argument
+/// pins the asserted side to a `Blob` in that context. The pin is dropped there too — per context
+/// the assert contributes *no* fact at all (the intraprocedural eq view keeps the pair), one of the
+/// fact-losing directions the impl docs call out.
+#[test]
+fn asserted_const_in_never_aggregate() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let g = ssa.add_function("g".to_string());
+    let c0 = ssa.add_const(Constant::U(32, 10));
+    let c1 = ssa.add_const(Constant::U(32, 20));
+    let (a, x) = (ssa.fresh_value(), ssa.fresh_value());
+    let (s, y) = (ssa.fresh_value(), ssa.fresh_value());
+
+    let after = {
+        let hf = ssa.get_function_mut(g);
+        let after = hf.add_block();
+        hf.get_entry_mut()
+            .push_parameter(a, Type::u(32).array_of(2));
+        hf.get_entry_mut()
+            .push_parameter(x, Type::u(32).array_of(2));
+        hf.get_entry_mut().push_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: a,
+        });
+        hf.get_entry_mut()
+            .set_terminator(Terminator::Jmp(after, vec![]));
+        hf.get_block_mut(after)
+            .set_terminator(Terminator::Return(vec![]));
+        after
+    };
+    {
+        let mf = ssa.get_function_mut(main_id);
+        let entry = mf.get_entry_mut();
+        entry.push_parameter(y, Type::u(32).array_of(2));
+        entry.push_instruction(OpCode::MkSeq {
+            result: s,
+            elems: vec![c0, c1],
+            seq_type: SequenceTargetType::Array(2),
+            elem_type: Type::u(32),
+        });
+        entry.push_instruction(OpCode::Call {
+            results: vec![],
+            function: CallTarget::Static(g),
+            args: vec![s, y],
+            unconstrained: false,
+        });
+        entry.set_terminator(Terminator::Return(vec![]));
+    }
+
+    let cc = run_in_test(&ssa);
+    let ctx = sole_context(&cc, g);
+    let pp = ProgramPoint::new(after, 0);
+
+    // Intraprocedurally both sides are opaque: an ordinary asserted equality.
+    assert!(cc.asserted_equal(g, pp, x, a));
+    assert_eq!(cc.asserted_const(g, pp, x), None);
+    // In the context `a` is a Blob: the pin surfaces through no per-context channel.
+    assert_eq!(cc.asserted_const_in(g, &ctx, pp, x), None);
+    assert!(!cc.asserted_equal_in(g, &ctx, pp, x, a));
+}
+
+/// When the *asserted* side itself becomes a per-context constant, the fact leaves
+/// `asserted_const_in` — but only because it migrated to the strictly stronger *unconditional*
+/// per-context channel, where `const_of_in` answers it without any constraint-preservation proviso.
+/// Nothing is lost; the documented "no pointwise inclusion" is this migration.
+#[test]
+fn asserted_const_migrates_to_unconditional_channel() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let g = ssa.add_function("g".to_string());
+    let x = ssa.fresh_value();
+    let c7 = ssa.add_const(Constant::Field(Field::from(7u64)));
+
+    let after = {
+        let hf = ssa.get_function_mut(g);
+        let after = hf.add_block();
+        hf.get_entry_mut().push_parameter(x, Type::field());
+        hf.get_entry_mut().push_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c7,
+        });
+        hf.get_entry_mut()
+            .set_terminator(Terminator::Jmp(after, vec![]));
+        hf.get_block_mut(after)
+            .set_terminator(Terminator::Return(vec![]));
+        after
+    };
+    {
+        let mf = ssa.get_function_mut(main_id);
+        let entry = mf.get_entry_mut();
+        entry.push_instruction(OpCode::Call {
+            results: vec![],
+            function: CallTarget::Static(g),
+            args: vec![c7],
+            unconstrained: false,
+        });
+        entry.set_terminator(Terminator::Return(vec![]));
+    }
+
+    let cc = run_in_test(&ssa);
+    let ctx = sole_context(&cc, g);
+    let pp = ProgramPoint::new(after, 0);
+
+    // Intraprocedurally `x` is opaque, so the assert pins it conditionally.
+    assert_eq!(
+        cc.asserted_const(g, pp, x).as_deref(),
+        Some(&Constant::Field(Field::from(7u64)))
+    );
+    // In the context the seed already proves `x = 7` unconditionally: the conditional entry is
+    // gone...
+    assert_eq!(cc.asserted_const_in(g, &ctx, pp, x), None);
+    // ...because the unconditional channel now carries it.
+    assert_eq!(
+        cc.const_of_in(g, &ctx, x).as_deref(),
+        Some(&Constant::Field(Field::from(7u64)))
+    );
+}
+
+/// A per-context constant can *split* an intraprocedurally-proven congruence. Intraprocedurally
+/// `x = call g(a)` is value-numbered equal to `y = a*3` via `g`'s grafted symbolic return, the
+/// writeback folds the `x == y` branch, and the else arm is dead — its forward never gathered. Per
+/// context `a = 5` folds `y` to a constant, whose `Const` label replaces the structural one, while
+/// the call result `x` (lattice-opaque) keeps its `Op` class: the classes split, the branch stays
+/// live, and the forward appears in `witness_forward_in` only. Reachability-derived facts can thus
+/// flow in the *growing* direction per context — the reason the impl docs promise no inclusion
+/// between the two views in either direction.
+#[test]
+fn context_constant_can_split_congruence() {
+    let mut ssa = HLSSA::with_main("main".to_string());
+    let main_id = ssa.get_unique_entrypoint_id();
+    let f = ssa.add_function("f".to_string());
+    let g = ssa.add_function("g".to_string());
+    let c3 = ssa.add_const(Constant::Field(Field::from(3u64)));
+    let c5 = ssa.add_const(Constant::Field(Field::from(5u64)));
+    let (p, m) = (ssa.fresh_value(), ssa.fresh_value());
+    let (a, w, x, y, eq, r) = (
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+        ssa.fresh_value(),
+    );
+    let w0 = ssa.fresh_value();
+
+    // g(p) { return p * 3 } — pure, so its symbolic return `Mul(Param0, 3)` grafts.
+    {
+        let hf = ssa.get_function_mut(g);
+        hf.add_return_type(Type::field());
+        hf.get_entry_mut().push_parameter(p, Type::field());
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Mul,
+            result: m,
+            lhs: p,
+            rhs: c3,
+        });
+        hf.get_entry_mut()
+            .set_terminator(Terminator::Return(vec![m]));
+    }
+    // f(a, w) { x = g(a); y = a*3; if x == y { } else { r = write_witness(w) } }
+    {
+        let hf = ssa.get_function_mut(f);
+        let then_b = hf.add_block();
+        let else_b = hf.add_block();
+        let after = hf.add_block();
+        hf.get_entry_mut().push_parameter(a, Type::field());
+        hf.get_entry_mut().push_parameter(w, Type::u(32));
+        hf.get_entry_mut().push_instruction(OpCode::Call {
+            results: vec![x],
+            function: CallTarget::Static(g),
+            args: vec![a],
+            unconstrained: false,
+        });
+        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Mul,
+            result: y,
+            lhs: a,
+            rhs: c3,
+        });
+        hf.get_entry_mut().push_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: x,
+            rhs: y,
+        });
+        hf.get_entry_mut()
+            .set_terminator(Terminator::JmpIf(eq, then_b, else_b));
+        hf.get_block_mut(then_b)
+            .set_terminator(Terminator::Jmp(after, vec![]));
+        hf.get_block_mut(else_b)
+            .push_instruction(OpCode::WriteWitness {
+                result: Some(r),
+                value: w,
+                pinned: false,
+            });
+        hf.get_block_mut(else_b)
+            .set_terminator(Terminator::Jmp(after, vec![]));
+        hf.get_block_mut(after)
+            .set_terminator(Terminator::Return(vec![]));
+    }
+    {
+        let mf = ssa.get_function_mut(main_id);
+        let entry = mf.get_entry_mut();
+        entry.push_parameter(w0, Type::u(32));
+        entry.push_instruction(OpCode::Call {
+            results: vec![],
+            function: CallTarget::Static(f),
+            args: vec![c5, w0],
+            unconstrained: false,
+        });
+        entry.set_terminator(Terminator::Return(vec![]));
+    }
+
+    let cc = run_in_test(&ssa);
+    let ctx = sole_context(&cc, f);
+
+    // Intraprocedurally the sym graft proves `x ≡ y`, the branch folds, the else arm dies: no
+    // forward.
+    assert!(cc.known_equal(f, x, y));
+    assert!(cc.witness_forward(f, r).is_empty());
+    // Per context `y` is `Const(15)` while `x` stays opaque: the congruence splits, the else arm
+    // is live, and the forward exists only in the per-context view.
+    assert!(!cc.known_equal_in(f, &ctx, x, y));
+    assert_eq!(cc.witness_forward_in(f, &ctx, r), [w].as_slice());
 }
 
 /// Two call sites of one helper get distinct contexts with distinct per-context parameter


### PR DESCRIPTION
These extend the conditional facts into the 1-CFA analysis so that we can drive better specialisation and optimisation using them. They are not yet consumed, so this has no impact on the corpus, but are setting the stage for the future PRE.

Partial work for #260.