### PR TITLE
Remove optionality for source locations

### DIFF
--- a/compiler/src/compiler/analysis/click_cooper/test.rs
+++ b/compiler/src/compiler/analysis/click_cooper/test.rs
@@ -5,7 +5,7 @@ use crate::compiler::{
         types::Types,
     },
     ssa::{
-        FunctionId, Located, ProgramPoint, SourceLocation, Terminator,
+        FunctionId, ProgramPoint, Terminator,
         hlssa::{
             BinaryArithOpKind, Blob, CallTarget, CastTarget, CmpKind, Constant, HLSSA, OpCode,
             ScalarFold, SequenceTargetType, SliceOpDir, Type,
@@ -224,24 +224,18 @@ fn equal_constants_are_congruent() {
 
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: a,
-            lhs: c2,
-            rhs: c3,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: c1,
-            rhs: c4,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: a,
+        lhs: c2,
+        rhs: c3,
+    });
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: b,
+        lhs: c1,
+        rhs: c4,
+    });
     entry.set_terminator(Terminator::Return(vec![a, b]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -269,42 +263,30 @@ fn structural_congruence_is_commutative() {
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(y, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: a,
-            lhs: x,
-            rhs: y,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: x,
-            rhs: y,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: c,
-            lhs: y,
-            rhs: x,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Sub,
-            result: d,
-            lhs: x,
-            rhs: y,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: a,
+        lhs: x,
+        rhs: y,
+    });
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: b,
+        lhs: x,
+        rhs: y,
+    });
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: c,
+        lhs: y,
+        rhs: x,
+    });
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Sub,
+        result: d,
+        lhs: x,
+        rhs: y,
+    });
     entry.set_terminator(Terminator::Return(vec![a, b, c, d]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -342,68 +324,47 @@ fn array_ops_are_value_numbered() {
     f.get_entry_mut().push_parameter(j, Type::u(32));
     let entry = f.get_entry_mut();
     // g1, g2 are arr[i]; g3 is arr[j].
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: g1,
-            array: arr,
-            index: i,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: g2,
-            array: arr,
-            index: i,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: g3,
-            array: arr,
-            index: j,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: g1,
+        array: arr,
+        index: i,
+    });
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: g2,
+        array: arr,
+        index: i,
+    });
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: g3,
+        array: arr,
+        index: j,
+    });
     // s1 and s2 are the same array `[arr[i], arr[j]]` built twice — congruent elementwise.
-    entry.push_instruction(Located::with(
-        OpCode::MkSeq {
-            result: s1,
-            elems: vec![g1, g3],
-            seq_type: SequenceTargetType::Array(2),
-            elem_type: Type::field(),
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::MkSeq {
-            result: s2,
-            elems: vec![g2, g3],
-            seq_type: SequenceTargetType::Array(2),
-            elem_type: Type::field(),
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::MkSeq {
+        result: s1,
+        elems: vec![g1, g3],
+        seq_type: SequenceTargetType::Array(2),
+        elem_type: Type::field(),
+    });
+    entry.push_test_instruction(OpCode::MkSeq {
+        result: s2,
+        elems: vec![g2, g3],
+        seq_type: SequenceTargetType::Array(2),
+        elem_type: Type::field(),
+    });
     // s3 differs only in sequence kind (Slice), s4 only in element type (u32): neither merges.
-    entry.push_instruction(Located::with(
-        OpCode::MkSeq {
-            result: s3,
-            elems: vec![g1, g3],
-            seq_type: SequenceTargetType::Slice,
-            elem_type: Type::field(),
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::MkSeq {
-            result: s4,
-            elems: vec![g1, g3],
-            seq_type: SequenceTargetType::Array(2),
-            elem_type: Type::u(32),
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::MkSeq {
+        result: s3,
+        elems: vec![g1, g3],
+        seq_type: SequenceTargetType::Slice,
+        elem_type: Type::field(),
+    });
+    entry.push_test_instruction(OpCode::MkSeq {
+        result: s4,
+        elems: vec![g1, g3],
+        seq_type: SequenceTargetType::Array(2),
+        elem_type: Type::u(32),
+    });
     entry.set_terminator(Terminator::Return(vec![g1, g2, g3, s1, s2, s3, s4]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -513,35 +474,26 @@ fn loop_carried_parallel_induction_is_congruent() {
     let header_block = f.get_block_mut(header);
     header_block.push_parameter(i, Type::u(32));
     header_block.push_parameter(j, Type::u(32));
-    header_block.push_instruction(Located::with(
-        OpCode::Cmp {
-            kind: CmpKind::Lt,
-            result: lt,
-            lhs: i,
-            rhs: c10,
-        },
-        SourceLocation::test(),
-    ));
+    header_block.push_test_instruction(OpCode::Cmp {
+        kind: CmpKind::Lt,
+        result: lt,
+        lhs: i,
+        rhs: c10,
+    });
     header_block.set_terminator(Terminator::JmpIf(lt, body, exit));
     let body_block = f.get_block_mut(body);
-    body_block.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: i2,
-            lhs: i,
-            rhs: c1,
-        },
-        SourceLocation::test(),
-    ));
-    body_block.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: j2,
-            lhs: j,
-            rhs: c1,
-        },
-        SourceLocation::test(),
-    ));
+    body_block.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: i2,
+        lhs: i,
+        rhs: c1,
+    });
+    body_block.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: j2,
+        lhs: j,
+        rhs: c1,
+    });
     body_block.set_terminator(Terminator::Jmp(header, vec![i2, j2]));
     f.get_block_mut(exit)
         .set_terminator(Terminator::Return(vec![i, j]));
@@ -577,27 +529,22 @@ fn leader_is_dominating_definition() {
     f.get_entry_mut().push_parameter(x, Type::field());
     f.get_entry_mut().push_parameter(y, Type::field());
     // `a = x + y` in the entry, recomputed as `b = x + y` in a strictly dominated block.
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::BinaryArithOp {
+    f.get_entry_mut()
+        .push_test_instruction(OpCode::BinaryArithOp {
             kind: BinaryArithOpKind::Add,
             result: a,
             lhs: x,
             rhs: y,
-        },
-        SourceLocation::test(),
-    ));
+        });
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(next, vec![]));
     let next_block = f.get_block_mut(next);
-    next_block.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: x,
-            rhs: y,
-        },
-        SourceLocation::test(),
-    ));
+    next_block.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: b,
+        lhs: x,
+        rhs: y,
+    });
     next_block.set_terminator(Terminator::Return(vec![a, b]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -622,24 +569,18 @@ fn leader_is_earlier_in_block() {
     f.get_entry_mut().push_parameter(x, Type::field());
     f.get_entry_mut().push_parameter(y, Type::field());
     let entry = f.get_entry_mut();
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: a,
-            lhs: x,
-            rhs: y,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: x,
-            rhs: y,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: a,
+        lhs: x,
+        rhs: y,
+    });
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: b,
+        lhs: x,
+        rhs: y,
+    });
     entry.set_terminator(Terminator::Return(vec![a, b]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -675,37 +616,28 @@ fn leader_never_crosses_incomparable_branches() {
         .set_terminator(Terminator::JmpIf(cond, e1, e2));
     // `x + y` recomputed in both incomparable branches and again at the merge.
     let e1_block = f.get_block_mut(e1);
-    e1_block.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: a,
-            lhs: x,
-            rhs: y,
-        },
-        SourceLocation::test(),
-    ));
+    e1_block.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: a,
+        lhs: x,
+        rhs: y,
+    });
     e1_block.set_terminator(Terminator::Jmp(merge, vec![]));
     let e2_block = f.get_block_mut(e2);
-    e2_block.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: x,
-            rhs: y,
-        },
-        SourceLocation::test(),
-    ));
+    e2_block.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: b,
+        lhs: x,
+        rhs: y,
+    });
     e2_block.set_terminator(Terminator::Jmp(merge, vec![]));
     let merge_block = f.get_block_mut(merge);
-    merge_block.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: c,
-            lhs: x,
-            rhs: y,
-        },
-        SourceLocation::test(),
-    ));
+    merge_block.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: c,
+        lhs: x,
+        rhs: y,
+    });
     merge_block.set_terminator(Terminator::Return(vec![a, b, c]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -732,15 +664,12 @@ fn leader_of_constant_class_is_the_interned_constant() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
     // `a = 2 + 3` folds to 5, congruent to the interned constant `c5`.
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: a,
-            lhs: c2,
-            rhs: c3,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: a,
+        lhs: c2,
+        rhs: c3,
+    });
     entry.set_terminator(Terminator::Return(vec![a, c5]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -762,14 +691,11 @@ fn assert_eq_const_is_conditional_not_unconditional() {
     let entry_id = f.get_entry_id();
     let after = f.add_block();
     f.get_entry_mut().push_parameter(x, Type::u(32));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            kind: CmpKind::Eq,
-            lhs: x,
-            rhs: c5,
-        },
-        SourceLocation::test(),
-    ));
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        kind: CmpKind::Eq,
+        lhs: x,
+        rhs: c5,
+    });
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(after, vec![]));
     f.get_block_mut(after)
@@ -811,10 +737,8 @@ fn assert_bool_is_conditional() {
     let entry_id = f.get_entry_id();
     let after = f.add_block();
     f.get_entry_mut().push_parameter(b, Type::u(1));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::Assert { value: b },
-        SourceLocation::test(),
-    ));
+    f.get_entry_mut()
+        .push_test_instruction(OpCode::Assert { value: b });
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(after, vec![]));
     f.get_block_mut(after)
@@ -853,14 +777,11 @@ fn assert_eq_pure_equality_is_conditional() {
     let after = f.add_block();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(y, Type::u(32));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            kind: CmpKind::Eq,
-            lhs: x,
-            rhs: y,
-        },
-        SourceLocation::test(),
-    ));
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        kind: CmpKind::Eq,
+        lhs: x,
+        rhs: y,
+    });
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(after, vec![]));
     f.get_block_mut(after)
@@ -894,25 +815,19 @@ fn asserted_leader_picks_dominating_member() {
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(mid, vec![]));
     let mid_block = f.get_block_mut(mid);
-    mid_block.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            // index 0: def(b) in mid, dominated by entry
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: a,
-            rhs: a,
-        },
-        SourceLocation::test(),
-    ));
-    mid_block.push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 1: a == b (neither constant ⇒ an equality pair)
-            kind: CmpKind::Eq,
-            lhs: a,
-            rhs: b,
-        },
-        SourceLocation::test(),
-    ));
+    mid_block.push_test_instruction(OpCode::BinaryArithOp {
+        // index 0: def(b) in mid, dominated by entry
+        kind: BinaryArithOpKind::Add,
+        result: b,
+        lhs: a,
+        rhs: a,
+    });
+    mid_block.push_test_instruction(OpCode::AssertCmp {
+        // index 1: a == b (neither constant ⇒ an equality pair)
+        kind: CmpKind::Eq,
+        lhs: a,
+        rhs: b,
+    });
     mid_block.set_terminator(Terminator::Return(vec![])); // index 2
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -946,24 +861,18 @@ fn asserted_leader_is_transitive() {
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(b, Type::u(32));
     f.get_entry_mut().push_parameter(c, Type::u(32));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 0: a == b
-            kind: CmpKind::Eq,
-            lhs: a,
-            rhs: b,
-        },
-        SourceLocation::test(),
-    ));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 1: b == c
-            kind: CmpKind::Eq,
-            lhs: b,
-            rhs: c,
-        },
-        SourceLocation::test(),
-    ));
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // index 0: a == b
+        kind: CmpKind::Eq,
+        lhs: a,
+        rhs: b,
+    });
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // index 1: b == c
+        kind: CmpKind::Eq,
+        lhs: b,
+        rhs: c,
+    });
     f.get_entry_mut().set_terminator(Terminator::Return(vec![])); // index 2
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -996,15 +905,12 @@ fn asserted_leader_index_granular() {
     let after = f.add_block();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(y, Type::u(32));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 0
-            kind: CmpKind::Eq,
-            lhs: x,
-            rhs: y,
-        },
-        SourceLocation::test(),
-    ));
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // index 0
+        kind: CmpKind::Eq,
+        lhs: x,
+        rhs: y,
+    });
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(after, vec![])); // index 1
     f.get_block_mut(after)
@@ -1059,15 +965,13 @@ fn asserted_leader_respects_dominance_fanout() {
     f.get_entry_mut().push_parameter(y, Type::u(32));
     f.get_entry_mut()
         .set_terminator(Terminator::JmpIf(cond, then_b, else_b));
-    f.get_block_mut(then_b).push_instruction(Located::with(
-        OpCode::AssertCmp {
+    f.get_block_mut(then_b)
+        .push_test_instruction(OpCode::AssertCmp {
             // index 0: x == y, only on the `then` branch
             kind: CmpKind::Eq,
             lhs: x,
             rhs: y,
-        },
-        SourceLocation::test(),
-    ));
+        });
     f.get_block_mut(then_b)
         .set_terminator(Terminator::Jmp(merge, vec![]));
     f.get_block_mut(else_b)
@@ -1118,15 +1022,12 @@ fn asserted_leader_none_without_equality() {
     let entry_id = f.get_entry_id();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(z, Type::u(32));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 0: x == 5 — a constant pin, not an equality pair
-            kind: CmpKind::Eq,
-            lhs: x,
-            rhs: c5,
-        },
-        SourceLocation::test(),
-    ));
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // index 0: x == 5 — a constant pin, not an equality pair
+        kind: CmpKind::Eq,
+        lhs: x,
+        rhs: c5,
+    });
     f.get_entry_mut().set_terminator(Terminator::Return(vec![])); // index 1
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -1155,15 +1056,12 @@ fn asserted_leader_none_for_non_pair_value_amid_classes() {
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(b, Type::u(32));
     f.get_entry_mut().push_parameter(z, Type::u(32)); // never in any assert
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 0: a == b — a real equality pair, so the function has a non-empty `def_key`
-            kind: CmpKind::Eq,
-            lhs: a,
-            rhs: b,
-        },
-        SourceLocation::test(),
-    ));
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // index 0: a == b — a real equality pair, so the function has a non-empty `def_key`
+        kind: CmpKind::Eq,
+        lhs: a,
+        rhs: b,
+    });
     f.get_entry_mut().set_terminator(Terminator::Return(vec![])); // index 1
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -1190,24 +1088,18 @@ fn asserted_leader_multi_threshold_same_block() {
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(c, Type::u(32));
     f.get_entry_mut().push_parameter(d, Type::u(32));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 0: c == d ⇒ class {c, d}, leader c
-            kind: CmpKind::Eq,
-            lhs: c,
-            rhs: d,
-        },
-        SourceLocation::test(),
-    ));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 1: a == c ⇒ merges into {a, c, d}, leader a
-            kind: CmpKind::Eq,
-            lhs: a,
-            rhs: c,
-        },
-        SourceLocation::test(),
-    ));
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // index 0: c == d ⇒ class {c, d}, leader c
+        kind: CmpKind::Eq,
+        lhs: c,
+        rhs: d,
+    });
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // index 1: a == c ⇒ merges into {a, c, d}, leader a
+        kind: CmpKind::Eq,
+        lhs: a,
+        rhs: c,
+    });
     f.get_entry_mut().set_terminator(Terminator::Return(vec![])); // index 2
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -1247,35 +1139,27 @@ fn asserted_leader_local_merges_two_cross_classes() {
     f.get_entry_mut().push_parameter(b, Type::u(32));
     f.get_entry_mut().push_parameter(c, Type::u(32));
     f.get_entry_mut().push_parameter(d, Type::u(32));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 0: a == b ⇒ dominating class {a, b}
-            kind: CmpKind::Eq,
-            lhs: a,
-            rhs: b,
-        },
-        SourceLocation::test(),
-    ));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 1: c == d ⇒ dominating class {c, d}
-            kind: CmpKind::Eq,
-            lhs: c,
-            rhs: d,
-        },
-        SourceLocation::test(),
-    ));
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // index 0: a == b ⇒ dominating class {a, b}
+        kind: CmpKind::Eq,
+        lhs: a,
+        rhs: b,
+    });
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // index 1: c == d ⇒ dominating class {c, d}
+        kind: CmpKind::Eq,
+        lhs: c,
+        rhs: d,
+    });
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(mid, vec![])); // index 2
-    f.get_block_mut(mid).push_instruction(Located::with(
-        OpCode::AssertCmp {
+    f.get_block_mut(mid)
+        .push_test_instruction(OpCode::AssertCmp {
             // index 0 (in `mid`): b == c ⇒ merges the two cross classes into {a, b, c, d}
             kind: CmpKind::Eq,
             lhs: b,
             rhs: c,
-        },
-        SourceLocation::test(),
-    ));
+        });
     f.get_block_mut(mid)
         .set_terminator(Terminator::Return(vec![])); // index 1
 
@@ -1309,15 +1193,12 @@ fn disequality_from_false_edge() {
     let after = f.add_block();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(y, Type::u(32));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: eq,
-            lhs: x,
-            rhs: y,
-        },
-        SourceLocation::test(),
-    ));
+    f.get_entry_mut().push_test_instruction(OpCode::Cmp {
+        kind: CmpKind::Eq,
+        result: eq,
+        lhs: x,
+        rhs: y,
+    });
     f.get_entry_mut()
         .set_terminator(Terminator::JmpIf(eq, then_b, else_b));
     f.get_block_mut(then_b)
@@ -1350,30 +1231,21 @@ fn unpinned_witness_forwards_distinct_not_merged() {
     f.get_entry_mut().push_parameter(v1, Type::u(32));
     f.get_entry_mut().push_parameter(v2, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(Located::with(
-        OpCode::WriteWitness {
-            result: Some(r1),
-            value: v1,
-            pinned: false,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::WriteWitness {
-            result: Some(r2),
-            value: v2,
-            pinned: false,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::WriteWitness {
-            result: Some(rp),
-            value: v1,
-            pinned: true,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::WriteWitness {
+        result: Some(r1),
+        value: v1,
+        pinned: false,
+    });
+    entry.push_test_instruction(OpCode::WriteWitness {
+        result: Some(r2),
+        value: v2,
+        pinned: false,
+    });
+    entry.push_test_instruction(OpCode::WriteWitness {
+        result: Some(rp),
+        value: v1,
+        pinned: true,
+    });
     entry.set_terminator(Terminator::Return(vec![]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -1400,40 +1272,28 @@ fn witness_forward_unions_hint_and_value_of_reads() {
     f.get_entry_mut().push_parameter(v, Type::u(32));
     f.get_entry_mut().push_parameter(v2, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(Located::with(
-        OpCode::WriteWitness {
-            result: Some(r),
-            value: v,
-            pinned: false,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::WriteWitness {
+        result: Some(r),
+        value: v,
+        pinned: false,
+    });
     // `value_of(r)` strips r's witness wrapper: w1, w2 are honestly equal to r. Two separate
     // reads stay distinct (ValueOf is excluded from value-numbering), so both join r's set.
-    entry.push_instruction(Located::with(
-        OpCode::Cast {
-            result: w1,
-            value: r,
-            target: CastTarget::ValueOf,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::Cast {
-            result: w2,
-            value: r,
-            target: CastTarget::ValueOf,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::WriteWitness {
-            result: Some(r2),
-            value: v2,
-            pinned: false,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::Cast {
+        result: w1,
+        value: r,
+        target: CastTarget::ValueOf,
+    });
+    entry.push_test_instruction(OpCode::Cast {
+        result: w2,
+        value: r,
+        target: CastTarget::ValueOf,
+    });
+    entry.push_test_instruction(OpCode::WriteWitness {
+        result: Some(r2),
+        value: v2,
+        pinned: false,
+    });
     entry.set_terminator(Terminator::Return(vec![]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -1471,14 +1331,12 @@ fn post_dominance_not_propagated_at_block_granularity() {
         .set_terminator(Terminator::Jmp(mid, vec![]));
     f.get_block_mut(mid)
         .set_terminator(Terminator::Jmp(tail, vec![]));
-    f.get_block_mut(tail).push_instruction(Located::with(
-        OpCode::AssertCmp {
+    f.get_block_mut(tail)
+        .push_test_instruction(OpCode::AssertCmp {
             kind: CmpKind::Eq,
             lhs: x,
             rhs: c5,
-        },
-        SourceLocation::test(),
-    ));
+        });
     f.get_block_mut(tail)
         .set_terminator(Terminator::Return(vec![]));
 
@@ -1548,44 +1406,32 @@ fn post_dominating_assert_unsound_for_loop_carried_value() {
         .set_terminator(Terminator::Jmp(header, vec![c0]));
     let header_block = f.get_block_mut(header);
     header_block.push_parameter(v, Type::u(32));
-    header_block.push_instruction(Located::with(
-        OpCode::Cmp {
-            kind: CmpKind::Lt,
-            result: lt,
-            lhs: v,
-            rhs: c10,
-        },
-        SourceLocation::test(),
-    ));
+    header_block.push_test_instruction(OpCode::Cmp {
+        kind: CmpKind::Lt,
+        result: lt,
+        lhs: v,
+        rhs: c10,
+    });
     header_block.set_terminator(Terminator::JmpIf(lt, body, after));
     let body_block = f.get_block_mut(body);
-    body_block.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: v1,
-            lhs: v,
-            rhs: c1,
-        },
-        SourceLocation::test(),
-    ));
+    body_block.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: v1,
+        lhs: v,
+        rhs: c1,
+    });
     body_block.set_terminator(Terminator::Jmp(header, vec![v1]));
     let after_block = f.get_block_mut(after);
-    after_block.push_instruction(Located::with(
-        OpCode::AssertCmp {
-            kind: CmpKind::Eq,
-            lhs: v,
-            rhs: c10,
-        },
-        SourceLocation::test(),
-    ));
-    after_block.push_instruction(Located::with(
-        OpCode::AssertCmp {
-            kind: CmpKind::Eq,
-            lhs: s,
-            rhs: c5,
-        },
-        SourceLocation::test(),
-    ));
+    after_block.push_test_instruction(OpCode::AssertCmp {
+        kind: CmpKind::Eq,
+        lhs: v,
+        rhs: c10,
+    });
+    after_block.push_test_instruction(OpCode::AssertCmp {
+        kind: CmpKind::Eq,
+        lhs: s,
+        rhs: c5,
+    });
     after_block.set_terminator(Terminator::Return(vec![]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -1643,14 +1489,12 @@ fn assert_on_one_branch_does_not_post_dominate() {
     f.get_entry_mut()
         .set_terminator(Terminator::JmpIf(cond, then_b, else_b));
     // The assert lives only on the `then` branch.
-    f.get_block_mut(then_b).push_instruction(Located::with(
-        OpCode::AssertCmp {
+    f.get_block_mut(then_b)
+        .push_test_instruction(OpCode::AssertCmp {
             kind: CmpKind::Eq,
             lhs: x,
             rhs: c5,
-        },
-        SourceLocation::test(),
-    ));
+        });
     f.get_block_mut(then_b)
         .set_terminator(Terminator::Jmp(merge, vec![]));
     f.get_block_mut(else_b)
@@ -1706,18 +1550,19 @@ fn anticipated_fact_gated_on_scope() {
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(mid, vec![]));
     let mid_block = f.get_block_mut(mid);
-    mid_block.push_instruction(OpCode::BinaryArithOp {
+    mid_block.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: v,
         lhs: x,
         rhs: c1,
     });
     mid_block.set_terminator(Terminator::Jmp(tail, vec![]));
-    f.get_block_mut(tail).push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: v,
-        rhs: c5,
-    });
+    f.get_block_mut(tail)
+        .push_test_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: v,
+            rhs: c5,
+        });
     f.get_block_mut(tail)
         .set_terminator(Terminator::Return(vec![]));
 
@@ -1755,11 +1600,12 @@ fn no_exit_path_assert_contributes_nothing() {
     f.get_entry_mut()
         .set_terminator(Terminator::JmpIf(p, spin, ret));
     // The asserting block loops on itself forever: reachable, but never exiting.
-    f.get_block_mut(spin).push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: c5,
-    });
+    f.get_block_mut(spin)
+        .push_test_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c5,
+        });
     f.get_block_mut(spin)
         .set_terminator(Terminator::Jmp(spin, vec![]));
     f.get_block_mut(ret)
@@ -1797,11 +1643,12 @@ fn anticipated_gains_from_constant_branch() {
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut()
         .set_terminator(Terminator::JmpIf(c_true, then_b, else_b));
-    f.get_block_mut(then_b).push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: c5,
-    });
+    f.get_block_mut(then_b)
+        .push_test_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c5,
+        });
     f.get_block_mut(then_b)
         .set_terminator(Terminator::Jmp(merge, vec![]));
     f.get_block_mut(else_b)
@@ -1860,14 +1707,12 @@ fn anticipated_const_in_gains_from_pinned_branch() {
         hf.get_entry_mut().push_parameter(x, Type::u(32));
         hf.get_entry_mut()
             .set_terminator(Terminator::JmpIf(p, then_b, else_b));
-        hf.get_block_mut(then_b).push_instruction(Located::with(
-            OpCode::AssertCmp {
+        hf.get_block_mut(then_b)
+            .push_test_instruction(OpCode::AssertCmp {
                 kind: CmpKind::Eq,
                 lhs: x,
                 rhs: c5,
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_block_mut(then_b)
             .set_terminator(Terminator::Jmp(merge, vec![]));
         hf.get_block_mut(else_b)
@@ -1879,7 +1724,7 @@ fn anticipated_const_in_gains_from_pinned_branch() {
     {
         let mf = ssa.get_function_mut(main_id);
         mf.get_entry_mut().push_parameter(x0, Type::u(32));
-        mf.get_entry_mut().push_instruction(OpCode::Call {
+        mf.get_entry_mut().push_test_instruction(OpCode::Call {
             results: vec![],
             function: CallTarget::Static(g),
             args: vec![c_true, x0],
@@ -1933,16 +1778,18 @@ fn anticipated_gains_from_dead_back_edge() {
         let hf = ssa.get_function_mut(g);
         hf.add_return_type(Type::u(32));
         hf.get_entry_mut().push_parameter(a, Type::u(32));
-        hf.get_entry_mut().push_instruction(OpCode::FreshWitness {
-            result: wit,
-            result_type: Type::u(32),
-        });
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: a,
-            rhs: wit,
-        });
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::FreshWitness {
+                result: wit,
+                result_type: Type::u(32),
+            });
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: b,
+                lhs: a,
+                rhs: wit,
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![b]));
     }
@@ -1955,7 +1802,7 @@ fn anticipated_gains_from_dead_back_edge() {
         mf.get_entry_mut()
             .set_terminator(Terminator::Jmp(header, vec![]));
         let header_block = mf.get_block_mut(header);
-        header_block.push_instruction(OpCode::Call {
+        header_block.push_test_instruction(OpCode::Call {
             results: vec![r],
             function: CallTarget::Static(g),
             args: vec![w],
@@ -1965,11 +1812,12 @@ fn anticipated_gains_from_dead_back_edge() {
         header_block.set_terminator(Terminator::JmpIf(c_false, body, after));
         mf.get_block_mut(body)
             .set_terminator(Terminator::Jmp(header, vec![]));
-        mf.get_block_mut(after).push_instruction(OpCode::AssertCmp {
-            kind: CmpKind::Eq,
-            lhs: r,
-            rhs: c5,
-        });
+        mf.get_block_mut(after)
+            .push_test_instruction(OpCode::AssertCmp {
+                kind: CmpKind::Eq,
+                lhs: r,
+                rhs: c5,
+            });
         mf.get_block_mut(after)
             .set_terminator(Terminator::Return(vec![]));
         (header, after)
@@ -2025,16 +1873,18 @@ fn live_back_edge_keeps_call_result_unstable() {
         let hf = ssa.get_function_mut(g);
         hf.add_return_type(Type::u(32));
         hf.get_entry_mut().push_parameter(a, Type::u(32));
-        hf.get_entry_mut().push_instruction(OpCode::FreshWitness {
-            result: wit,
-            result_type: Type::u(32),
-        });
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: a,
-            rhs: wit,
-        });
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::FreshWitness {
+                result: wit,
+                result_type: Type::u(32),
+            });
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: b,
+                lhs: a,
+                rhs: wit,
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![b]));
     }
@@ -2048,7 +1898,7 @@ fn live_back_edge_keeps_call_result_unstable() {
         mf.get_entry_mut()
             .set_terminator(Terminator::Jmp(header, vec![]));
         let header_block = mf.get_block_mut(header);
-        header_block.push_instruction(OpCode::Call {
+        header_block.push_test_instruction(OpCode::Call {
             results: vec![r],
             function: CallTarget::Static(g),
             args: vec![w],
@@ -2057,11 +1907,12 @@ fn live_back_edge_keeps_call_result_unstable() {
         header_block.set_terminator(Terminator::JmpIf(p, body, after));
         mf.get_block_mut(body)
             .set_terminator(Terminator::Jmp(header, vec![]));
-        mf.get_block_mut(after).push_instruction(OpCode::AssertCmp {
-            kind: CmpKind::Eq,
-            lhs: r,
-            rhs: c5,
-        });
+        mf.get_block_mut(after)
+            .push_test_instruction(OpCode::AssertCmp {
+                kind: CmpKind::Eq,
+                lhs: r,
+                rhs: c5,
+            });
         mf.get_block_mut(after)
             .set_terminator(Terminator::Return(vec![]));
         header
@@ -2101,7 +1952,7 @@ fn anticipated_finality_gains_from_pruned_back_path() {
         .set_terminator(Terminator::Jmp(header, vec![c0]));
     let header_block = f.get_block_mut(header);
     header_block.push_parameter(v, Type::u(32));
-    header_block.push_instruction(OpCode::Cmp {
+    header_block.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: lt,
         lhs: v,
@@ -2109,7 +1960,7 @@ fn anticipated_finality_gains_from_pruned_back_path() {
     });
     header_block.set_terminator(Terminator::JmpIf(lt, body, c_block));
     let body_block = f.get_block_mut(body);
-    body_block.push_instruction(OpCode::BinaryArithOp {
+    body_block.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: v1,
         lhs: v,
@@ -2122,11 +1973,12 @@ fn anticipated_finality_gains_from_pruned_back_path() {
         .set_terminator(Terminator::JmpIf(c_false, tramp, next));
     f.get_block_mut(tramp)
         .set_terminator(Terminator::Jmp(header, vec![c0]));
-    f.get_block_mut(next).push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: v,
-        rhs: c10,
-    });
+    f.get_block_mut(next)
+        .push_test_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: v,
+            rhs: c10,
+        });
     f.get_block_mut(next)
         .set_terminator(Terminator::Return(vec![]));
 
@@ -2181,11 +2033,12 @@ fn pruned_build_keeps_static_post_dominance_fact() {
     // `check` stays reachable (so its assert establishes a fact) via the other arm.
     f.get_block_mut(bypass)
         .set_terminator(Terminator::Jmp(check, vec![]));
-    f.get_block_mut(check).push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: c5,
-    });
+    f.get_block_mut(check)
+        .push_test_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c5,
+        });
     f.get_block_mut(check)
         .set_terminator(Terminator::Return(vec![]));
 
@@ -2222,13 +2075,14 @@ fn local_anticipated_before_the_assert() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry_id = f.get_entry_id();
     f.get_entry_mut().push_parameter(x, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: y,
-        lhs: x,
-        rhs: c1,
-    });
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+    f.get_entry_mut()
+        .push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: y,
+            lhs: x,
+            rhs: c1,
+        });
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: x,
         rhs: c5,
@@ -2290,18 +2144,18 @@ fn local_anticipated_needs_no_stability_gate() {
         .set_terminator(Terminator::Jmp(looping, vec![c0]));
     let loop_block = f.get_block_mut(looping);
     loop_block.push_parameter(w, Type::u(32));
-    loop_block.push_instruction(OpCode::BinaryArithOp {
+    loop_block.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: y,
         lhs: w,
         rhs: c1,
     });
-    loop_block.push_instruction(OpCode::AssertCmp {
+    loop_block.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: w,
         rhs: c9,
     });
-    loop_block.push_instruction(OpCode::Cmp {
+    loop_block.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: lt,
         lhs: y,
@@ -2348,7 +2202,7 @@ fn anticipated_equalities_and_leaders() {
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(mid, vec![]));
     let mid_block = f.get_block_mut(mid);
-    mid_block.push_instruction(OpCode::BinaryArithOp {
+    mid_block.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: m,
         lhs: a,
@@ -2356,12 +2210,12 @@ fn anticipated_equalities_and_leaders() {
     });
     mid_block.set_terminator(Terminator::Jmp(tail, vec![]));
     let tail_block = f.get_block_mut(tail);
-    tail_block.push_instruction(OpCode::AssertCmp {
+    tail_block.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
     });
-    tail_block.push_instruction(OpCode::AssertCmp {
+    tail_block.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: m,
         rhs: b,
@@ -2411,14 +2265,15 @@ fn anticipated_leader_before_same_block_assert() {
     let entry_id = f.get_entry_id();
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(b, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-        // index 0: a pre-assert use of `b`
-        kind: BinaryArithOpKind::Add,
-        result: m,
-        lhs: b,
-        rhs: c1,
-    });
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+    f.get_entry_mut()
+        .push_test_instruction(OpCode::BinaryArithOp {
+            // index 0: a pre-assert use of `b`
+            kind: BinaryArithOpKind::Add,
+            result: m,
+            lhs: b,
+            rhs: c1,
+        });
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
         // index 1: a == b
         kind: CmpKind::Eq,
         lhs: a,
@@ -2476,20 +2331,20 @@ fn anticipated_leader_before_assert_in_cyclic_block() {
         .set_terminator(Terminator::Jmp(looping, vec![c0]));
     let loop_block = f.get_block_mut(looping);
     loop_block.push_parameter(w, Type::u(32));
-    loop_block.push_instruction(OpCode::BinaryArithOp {
+    loop_block.push_test_instruction(OpCode::BinaryArithOp {
         // index 0: a pre-assert use of `w`
         kind: BinaryArithOpKind::Add,
         result: y,
         lhs: w,
         rhs: c1,
     });
-    loop_block.push_instruction(OpCode::AssertCmp {
+    loop_block.push_test_instruction(OpCode::AssertCmp {
         // index 1: w == a
         kind: CmpKind::Eq,
         lhs: w,
         rhs: a,
     });
-    loop_block.push_instruction(OpCode::Cmp {
+    loop_block.push_test_instruction(OpCode::Cmp {
         // index 2
         kind: CmpKind::Lt,
         result: lt,
@@ -2549,21 +2404,23 @@ fn anticipated_leader_threshold_for_block_defined_leader() {
     let entry_id = f.get_entry_id();
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(b, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-        // index 0: def(x)
-        kind: BinaryArithOpKind::Add,
-        result: x,
-        lhs: a,
-        rhs: c1,
-    });
-    f.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-        // index 1: def(y)
-        kind: BinaryArithOpKind::Add,
-        result: y,
-        lhs: b,
-        rhs: c2,
-    });
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+    f.get_entry_mut()
+        .push_test_instruction(OpCode::BinaryArithOp {
+            // index 0: def(x)
+            kind: BinaryArithOpKind::Add,
+            result: x,
+            lhs: a,
+            rhs: c1,
+        });
+    f.get_entry_mut()
+        .push_test_instruction(OpCode::BinaryArithOp {
+            // index 1: def(y)
+            kind: BinaryArithOpKind::Add,
+            result: y,
+            lhs: b,
+            rhs: c2,
+        });
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
         // index 2: x == y
         kind: CmpKind::Eq,
         lhs: x,
@@ -2614,20 +2471,21 @@ fn anticipated_leader_merges_across_directions() {
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(y, Type::u(32));
     f.get_entry_mut().push_parameter(z, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
         // index 0: x == y
         kind: CmpKind::Eq,
         lhs: x,
         rhs: y,
     });
-    f.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-        // index 1: the between point
-        kind: BinaryArithOpKind::Add,
-        result: m,
-        lhs: z,
-        rhs: c1,
-    });
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+    f.get_entry_mut()
+        .push_test_instruction(OpCode::BinaryArithOp {
+            // index 1: the between point
+            kind: BinaryArithOpKind::Add,
+            result: m,
+            lhs: z,
+            rhs: c1,
+        });
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
         // index 2: y == z
         kind: CmpKind::Eq,
         lhs: y,
@@ -2662,7 +2520,7 @@ fn anticipated_leader_at_establishing_assert_is_gate3_guarded() {
     let entry_id = f.get_entry_id();
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(b, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
         // index 0: a == b
         kind: CmpKind::Eq,
         lhs: a,
@@ -2689,7 +2547,7 @@ fn anticipated_leader_cross_only_block_falls_back() {
     let f = ssa.get_unique_entrypoint_mut();
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(b, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
         // index 0: a == b, fanned out to `tail` as a cross pair
         kind: CmpKind::Eq,
         lhs: a,
@@ -2699,7 +2557,7 @@ fn anticipated_leader_cross_only_block_falls_back() {
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(tail, vec![]));
     let tail_block = f.get_block_mut(tail);
-    tail_block.push_instruction(OpCode::BinaryArithOp {
+    tail_block.push_test_instruction(OpCode::BinaryArithOp {
         // index 0: an ordinary use point in `tail`
         kind: BinaryArithOpKind::Add,
         result: m,
@@ -2746,21 +2604,21 @@ fn anticipated_admits_loop_invariant_pure_chain() {
         .set_terminator(Terminator::Jmp(looping, vec![c0]));
     let loop_block = f.get_block_mut(looping);
     loop_block.push_parameter(i, Type::u(32));
-    loop_block.push_instruction(OpCode::BinaryArithOp {
+    loop_block.push_test_instruction(OpCode::BinaryArithOp {
         // index 0: loop-invariant — pure over the stable `n` and a constant.
         kind: BinaryArithOpKind::Add,
         result: t,
         lhs: n,
         rhs: c1,
     });
-    loop_block.push_instruction(OpCode::BinaryArithOp {
+    loop_block.push_test_instruction(OpCode::BinaryArithOp {
         // index 1: loop-variant — pure, but over the loop-carried `i`.
         kind: BinaryArithOpKind::Add,
         result: i2,
         lhs: i,
         rhs: c1,
     });
-    loop_block.push_instruction(OpCode::Cmp {
+    loop_block.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: lt,
         lhs: i2,
@@ -2768,12 +2626,12 @@ fn anticipated_admits_loop_invariant_pure_chain() {
     });
     loop_block.set_terminator(Terminator::JmpIf(lt, looping, exit));
     let exit_block = f.get_block_mut(exit);
-    exit_block.push_instruction(OpCode::AssertCmp {
+    exit_block.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: t,
         rhs: c5,
     });
-    exit_block.push_instruction(OpCode::AssertCmp {
+    exit_block.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: i2,
         rhs: c10,
@@ -2841,20 +2699,20 @@ fn anticipated_rejects_unconstrained_call_result_in_loop() {
             .set_terminator(Terminator::Jmp(looping, vec![c0]));
         let loop_block = mf.get_block_mut(looping);
         loop_block.push_parameter(i, Type::u(32));
-        loop_block.push_instruction(OpCode::Call {
+        loop_block.push_test_instruction(OpCode::Call {
             // index 0: opaque — an unconstrained call, however stable its argument.
             results: vec![r],
             function: CallTarget::Static(helper),
             args: vec![n],
             unconstrained: true,
         });
-        loop_block.push_instruction(OpCode::BinaryArithOp {
+        loop_block.push_test_instruction(OpCode::BinaryArithOp {
             kind: BinaryArithOpKind::Add,
             result: i2,
             lhs: i,
             rhs: c1,
         });
-        loop_block.push_instruction(OpCode::Cmp {
+        loop_block.push_test_instruction(OpCode::Cmp {
             kind: CmpKind::Lt,
             result: lt,
             lhs: i2,
@@ -2862,7 +2720,7 @@ fn anticipated_rejects_unconstrained_call_result_in_loop() {
         });
         loop_block.set_terminator(Terminator::JmpIf(lt, looping, exit));
         let exit_block = mf.get_block_mut(exit);
-        exit_block.push_instruction(OpCode::AssertCmp {
+        exit_block.push_test_instruction(OpCode::AssertCmp {
             kind: CmpKind::Eq,
             lhs: r,
             rhs: c5,
@@ -2898,7 +2756,7 @@ fn anticipated_admits_accumulator_at_post_loop_block() {
         .set_terminator(Terminator::Jmp(header, vec![c0]));
     let header_block = f.get_block_mut(header);
     header_block.push_parameter(v, Type::u(32));
-    header_block.push_instruction(OpCode::Cmp {
+    header_block.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: lt,
         lhs: v,
@@ -2906,7 +2764,7 @@ fn anticipated_admits_accumulator_at_post_loop_block() {
     });
     header_block.set_terminator(Terminator::JmpIf(lt, body, after));
     let body_block = f.get_block_mut(body);
-    body_block.push_instruction(OpCode::BinaryArithOp {
+    body_block.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: v1,
         lhs: v,
@@ -2916,7 +2774,7 @@ fn anticipated_admits_accumulator_at_post_loop_block() {
     f.get_block_mut(after)
         .set_terminator(Terminator::Jmp(tail, vec![]));
     let tail_block = f.get_block_mut(tail);
-    tail_block.push_instruction(OpCode::AssertCmp {
+    tail_block.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: v,
         rhs: c10,
@@ -2968,7 +2826,7 @@ fn anticipated_admits_first_loop_value_inside_second_loop() {
         .set_terminator(Terminator::Jmp(header, vec![c0]));
     let header_block = f.get_block_mut(header);
     header_block.push_parameter(v, Type::u(32));
-    header_block.push_instruction(OpCode::Cmp {
+    header_block.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: lt,
         lhs: v,
@@ -2976,7 +2834,7 @@ fn anticipated_admits_first_loop_value_inside_second_loop() {
     });
     header_block.set_terminator(Terminator::JmpIf(lt, body, second));
     let body_block = f.get_block_mut(body);
-    body_block.push_instruction(OpCode::BinaryArithOp {
+    body_block.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: v1,
         lhs: v,
@@ -2984,7 +2842,7 @@ fn anticipated_admits_first_loop_value_inside_second_loop() {
     });
     body_block.set_terminator(Terminator::Jmp(header, vec![v1]));
     let second_block = f.get_block_mut(second);
-    second_block.push_instruction(OpCode::Cmp {
+    second_block.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: lt2,
         lhs: v,
@@ -2992,7 +2850,7 @@ fn anticipated_admits_first_loop_value_inside_second_loop() {
     });
     second_block.set_terminator(Terminator::JmpIf(lt2, second, tail));
     let tail_block = f.get_block_mut(tail);
-    tail_block.push_instruction(OpCode::AssertCmp {
+    tail_block.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: v,
         rhs: c10,
@@ -3046,7 +2904,7 @@ fn anticipated_rejects_inner_loop_value_at_outer_block() {
         .set_terminator(Terminator::Jmp(inner, vec![c0]));
     let inner_block = f.get_block_mut(inner);
     inner_block.push_parameter(w, Type::u(32));
-    inner_block.push_instruction(OpCode::Cmp {
+    inner_block.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: lt_i,
         lhs: w,
@@ -3054,7 +2912,7 @@ fn anticipated_rejects_inner_loop_value_at_outer_block() {
     });
     inner_block.set_terminator(Terminator::JmpIf(lt_i, inner_body, latch));
     let inner_body_block = f.get_block_mut(inner_body);
-    inner_body_block.push_instruction(OpCode::BinaryArithOp {
+    inner_body_block.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: w2,
         lhs: w,
@@ -3062,7 +2920,7 @@ fn anticipated_rejects_inner_loop_value_at_outer_block() {
     });
     inner_body_block.set_terminator(Terminator::Jmp(inner, vec![w2]));
     let latch_block = f.get_block_mut(latch);
-    latch_block.push_instruction(OpCode::Cmp {
+    latch_block.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: lt_o,
         lhs: w,
@@ -3070,7 +2928,7 @@ fn anticipated_rejects_inner_loop_value_at_outer_block() {
     });
     latch_block.set_terminator(Terminator::JmpIf(lt_o, outer, tail));
     let tail_block = f.get_block_mut(tail);
-    tail_block.push_instruction(OpCode::AssertCmp {
+    tail_block.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: w,
         rhs: c10,
@@ -3123,7 +2981,7 @@ fn anticipated_admits_det_call_via_congruence_tier() {
         hf.add_return_type(Type::u(32));
         let entry = hf.get_entry_mut();
         entry.push_parameter(p, Type::u(32));
-        entry.push_instruction(OpCode::BinaryArithOp {
+        entry.push_test_instruction(OpCode::BinaryArithOp {
             kind: BinaryArithOpKind::Add,
             result: q,
             lhs: p,
@@ -3137,7 +2995,7 @@ fn anticipated_admits_det_call_via_congruence_tier() {
         let exit = mf.add_block();
         let entry = mf.get_entry_mut();
         entry.push_parameter(n, Type::u(32));
-        entry.push_instruction(OpCode::Call {
+        entry.push_test_instruction(OpCode::Call {
             // The dominating witness: same callee, same argument, in an acyclic block.
             results: vec![w],
             function: CallTarget::Static(helper),
@@ -3147,20 +3005,20 @@ fn anticipated_admits_det_call_via_congruence_tier() {
         entry.set_terminator(Terminator::Jmp(looping, vec![c0]));
         let loop_block = mf.get_block_mut(looping);
         loop_block.push_parameter(i, Type::u(32));
-        loop_block.push_instruction(OpCode::Call {
+        loop_block.push_test_instruction(OpCode::Call {
             // index 0: congruent to `w` (deterministic static call, congruent arguments).
             results: vec![r],
             function: CallTarget::Static(helper),
             args: vec![n],
             unconstrained: false,
         });
-        loop_block.push_instruction(OpCode::BinaryArithOp {
+        loop_block.push_test_instruction(OpCode::BinaryArithOp {
             kind: BinaryArithOpKind::Add,
             result: i2,
             lhs: i,
             rhs: c1,
         });
-        loop_block.push_instruction(OpCode::Cmp {
+        loop_block.push_test_instruction(OpCode::Cmp {
             kind: CmpKind::Lt,
             result: lt,
             lhs: i2,
@@ -3168,7 +3026,7 @@ fn anticipated_admits_det_call_via_congruence_tier() {
         });
         loop_block.set_terminator(Terminator::JmpIf(lt, looping, exit));
         let exit_block = mf.get_block_mut(exit);
-        exit_block.push_instruction(OpCode::AssertCmp {
+        exit_block.push_test_instruction(OpCode::AssertCmp {
             kind: CmpKind::Eq,
             lhs: r,
             rhs: c5,
@@ -3219,12 +3077,13 @@ fn anticipated_admits_det_call_directly_in_loop() {
         let hf = ssa.get_function_mut(g);
         hf.add_return_type(Type::u(32));
         hf.get_entry_mut().push_parameter(a, Type::u(32));
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: a,
-            rhs: c1,
-        });
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: b,
+                lhs: a,
+                rhs: c1,
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![b]));
     }
@@ -3238,7 +3097,7 @@ fn anticipated_admits_det_call_directly_in_loop() {
         mf.get_entry_mut()
             .set_terminator(Terminator::Jmp(header, vec![]));
         let header_block = mf.get_block_mut(header);
-        header_block.push_instruction(OpCode::Call {
+        header_block.push_test_instruction(OpCode::Call {
             results: vec![r],
             function: CallTarget::Static(g),
             args: vec![w],
@@ -3247,11 +3106,12 @@ fn anticipated_admits_det_call_directly_in_loop() {
         header_block.set_terminator(Terminator::JmpIf(p, body, after));
         mf.get_block_mut(body)
             .set_terminator(Terminator::Jmp(header, vec![]));
-        mf.get_block_mut(after).push_instruction(OpCode::AssertCmp {
-            kind: CmpKind::Eq,
-            lhs: r,
-            rhs: c5,
-        });
+        mf.get_block_mut(after)
+            .push_test_instruction(OpCode::AssertCmp {
+                kind: CmpKind::Eq,
+                lhs: r,
+                rhs: c5,
+            });
         mf.get_block_mut(after)
             .set_terminator(Terminator::Return(vec![]));
         header
@@ -3296,7 +3156,7 @@ fn anticipated_rejects_det_call_over_loop_variant_arg() {
         hf.add_return_type(Type::u(32));
         let entry = hf.get_entry_mut();
         entry.push_parameter(p, Type::u(32));
-        entry.push_instruction(OpCode::BinaryArithOp {
+        entry.push_test_instruction(OpCode::BinaryArithOp {
             kind: BinaryArithOpKind::Add,
             result: q,
             lhs: p,
@@ -3313,20 +3173,20 @@ fn anticipated_rejects_det_call_over_loop_variant_arg() {
             .set_terminator(Terminator::Jmp(looping, vec![c0]));
         let loop_block = mf.get_block_mut(looping);
         loop_block.push_parameter(i, Type::u(32));
-        loop_block.push_instruction(OpCode::Call {
+        loop_block.push_test_instruction(OpCode::Call {
             // index 0: a deterministic constrained call, but over the loop-variant `i`.
             results: vec![r],
             function: CallTarget::Static(helper),
             args: vec![i],
             unconstrained: false,
         });
-        loop_block.push_instruction(OpCode::BinaryArithOp {
+        loop_block.push_test_instruction(OpCode::BinaryArithOp {
             kind: BinaryArithOpKind::Add,
             result: i2,
             lhs: i,
             rhs: c1,
         });
-        loop_block.push_instruction(OpCode::Cmp {
+        loop_block.push_test_instruction(OpCode::Cmp {
             kind: CmpKind::Lt,
             result: lt,
             lhs: i2,
@@ -3334,7 +3194,7 @@ fn anticipated_rejects_det_call_over_loop_variant_arg() {
         });
         loop_block.set_terminator(Terminator::JmpIf(lt, looping, exit));
         let exit_block = mf.get_block_mut(exit);
-        exit_block.push_instruction(OpCode::AssertCmp {
+        exit_block.push_test_instruction(OpCode::AssertCmp {
             kind: CmpKind::Eq,
             lhs: r,
             rhs: c5,
@@ -3377,13 +3237,13 @@ fn anticipated_det_call_multi_return_per_index_bits() {
         hf.add_return_type(Type::u(32));
         let entry = hf.get_entry_mut();
         entry.push_parameter(p, Type::u(32));
-        entry.push_instruction(OpCode::BinaryArithOp {
+        entry.push_test_instruction(OpCode::BinaryArithOp {
             kind: BinaryArithOpKind::Add,
             result: q,
             lhs: p,
             rhs: c1,
         });
-        entry.push_instruction(OpCode::FreshWitness {
+        entry.push_test_instruction(OpCode::FreshWitness {
             result: wit,
             result_type: Type::u(32),
         });
@@ -3399,7 +3259,7 @@ fn anticipated_det_call_multi_return_per_index_bits() {
         mf.get_entry_mut()
             .set_terminator(Terminator::Jmp(header, vec![]));
         let header_block = mf.get_block_mut(header);
-        header_block.push_instruction(OpCode::Call {
+        header_block.push_test_instruction(OpCode::Call {
             results: vec![r0, r1],
             function: CallTarget::Static(helper),
             args: vec![n],
@@ -3409,12 +3269,12 @@ fn anticipated_det_call_multi_return_per_index_bits() {
         mf.get_block_mut(body)
             .set_terminator(Terminator::Jmp(header, vec![]));
         let after_block = mf.get_block_mut(after);
-        after_block.push_instruction(OpCode::AssertCmp {
+        after_block.push_test_instruction(OpCode::AssertCmp {
             kind: CmpKind::Eq,
             lhs: r0,
             rhs: c5,
         });
-        after_block.push_instruction(OpCode::AssertCmp {
+        after_block.push_test_instruction(OpCode::AssertCmp {
             kind: CmpKind::Eq,
             lhs: r1,
             rhs: c7,
@@ -3459,7 +3319,7 @@ fn anticipated_admits_entry_param_in_cyclic_entry_block() {
         // so re-entry rebinds nothing.
         entry.set_terminator(Terminator::JmpIf(p, entry_id, exit));
         let exit_block = mf.get_block_mut(exit);
-        exit_block.push_instruction(OpCode::AssertCmp {
+        exit_block.push_test_instruction(OpCode::AssertCmp {
             kind: CmpKind::Eq,
             lhs: w,
             rhs: c5,
@@ -3508,7 +3368,7 @@ fn anticipated_admits_det_call_via_congruence_over_unstable_arg() {
         hf.add_return_type(Type::u(32));
         let entry = hf.get_entry_mut();
         entry.push_parameter(p, Type::u(32));
-        entry.push_instruction(OpCode::BinaryArithOp {
+        entry.push_test_instruction(OpCode::BinaryArithOp {
             kind: BinaryArithOpKind::Add,
             result: q,
             lhs: p,
@@ -3529,13 +3389,13 @@ fn anticipated_admits_det_call_via_congruence_over_unstable_arg() {
         // Loop 1 carries the accumulator `v`: multi-valued, hence unstable.
         let loop1_block = mf.get_block_mut(loop1);
         loop1_block.push_parameter(v, Type::u(32));
-        loop1_block.push_instruction(OpCode::BinaryArithOp {
+        loop1_block.push_test_instruction(OpCode::BinaryArithOp {
             kind: BinaryArithOpKind::Add,
             result: v2,
             lhs: v,
             rhs: c1,
         });
-        loop1_block.push_instruction(OpCode::Cmp {
+        loop1_block.push_test_instruction(OpCode::Cmp {
             kind: CmpKind::Lt,
             result: lt,
             lhs: v2,
@@ -3544,7 +3404,7 @@ fn anticipated_admits_det_call_via_congruence_over_unstable_arg() {
         loop1_block.set_terminator(Terminator::JmpIf(lt, loop1, mid));
         // `mid` is acyclic: `w` is rule-2 stable however unstable its argument.
         let mid_block = mf.get_block_mut(mid);
-        mid_block.push_instruction(OpCode::Call {
+        mid_block.push_test_instruction(OpCode::Call {
             results: vec![w],
             function: CallTarget::Static(helper),
             args: vec![v],
@@ -3552,7 +3412,7 @@ fn anticipated_admits_det_call_via_congruence_over_unstable_arg() {
         });
         mid_block.set_terminator(Terminator::Jmp(loop2, vec![]));
         let loop2_block = mf.get_block_mut(loop2);
-        loop2_block.push_instruction(OpCode::Call {
+        loop2_block.push_test_instruction(OpCode::Call {
             // index 0: congruent to `w` (same callee, same argument); `v` is unstable, so the
             // det-call form does not fire and rule 4 is the sole admitting rule.
             results: vec![r],
@@ -3564,7 +3424,7 @@ fn anticipated_admits_det_call_via_congruence_over_unstable_arg() {
         mf.get_block_mut(body2)
             .set_terminator(Terminator::Jmp(loop2, vec![]));
         let after_block = mf.get_block_mut(after);
-        after_block.push_instruction(OpCode::AssertCmp {
+        after_block.push_test_instruction(OpCode::AssertCmp {
             kind: CmpKind::Eq,
             lhs: r,
             rhs: c5,
@@ -3609,7 +3469,7 @@ fn anticipated_eq_pair_mixed_gates() {
         .set_terminator(Terminator::Jmp(header, vec![c0]));
     let header_block = f.get_block_mut(header);
     header_block.push_parameter(acc, Type::u(32));
-    header_block.push_instruction(OpCode::Cmp {
+    header_block.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: lt,
         lhs: acc,
@@ -3617,7 +3477,7 @@ fn anticipated_eq_pair_mixed_gates() {
     });
     header_block.set_terminator(Terminator::JmpIf(lt, body, after));
     let body_block = f.get_block_mut(body);
-    body_block.push_instruction(OpCode::BinaryArithOp {
+    body_block.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: acc2,
         lhs: acc,
@@ -3627,7 +3487,7 @@ fn anticipated_eq_pair_mixed_gates() {
     f.get_block_mut(after)
         .set_terminator(Terminator::Jmp(tail, vec![]));
     let tail_block = f.get_block_mut(tail);
-    tail_block.push_instruction(OpCode::AssertCmp {
+    tail_block.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: acc,
         rhs: n,
@@ -3666,25 +3526,20 @@ fn local_assert_reaches_terminator_use() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry_id = f.get_entry_id();
     f.get_entry_mut().push_parameter(x, Type::u(32));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 0
-            kind: CmpKind::Eq,
-            lhs: x,
-            rhs: c5,
-        },
-        SourceLocation::test(),
-    ));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::BinaryArithOp {
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // index 0
+        kind: CmpKind::Eq,
+        lhs: x,
+        rhs: c5,
+    });
+    f.get_entry_mut()
+        .push_test_instruction(OpCode::BinaryArithOp {
             // index 1
             kind: BinaryArithOpKind::Add,
             result: doubled,
             lhs: x,
             rhs: x,
-        },
-        SourceLocation::test(),
-    ));
+        });
     f.get_entry_mut()
         .set_terminator(Terminator::Return(vec![doubled])); // terminator: index 2
 
@@ -3726,24 +3581,18 @@ fn multiple_local_asserts_each_recovered_after_its_index() {
     let entry_id = f.get_entry_id();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(y, Type::u(32));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 0: x == 5
-            kind: CmpKind::Eq,
-            lhs: x,
-            rhs: c5,
-        },
-        SourceLocation::test(),
-    ));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 1: y == 6
-            kind: CmpKind::Eq,
-            lhs: y,
-            rhs: c6,
-        },
-        SourceLocation::test(),
-    ));
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // index 0: x == 5
+        kind: CmpKind::Eq,
+        lhs: x,
+        rhs: c5,
+    });
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // index 1: y == 6
+        kind: CmpKind::Eq,
+        lhs: y,
+        rhs: c6,
+    });
     f.get_entry_mut().set_terminator(Terminator::Return(vec![]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -3784,24 +3633,18 @@ fn contradictory_local_asserts_first_writer_wins() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry_id = f.get_entry_id();
     f.get_entry_mut().push_parameter(x, Type::u(32));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 0: x == 5
-            kind: CmpKind::Eq,
-            lhs: x,
-            rhs: c5,
-        },
-        SourceLocation::test(),
-    ));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 1: x == 7
-            kind: CmpKind::Eq,
-            lhs: x,
-            rhs: c7,
-        },
-        SourceLocation::test(),
-    ));
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // index 0: x == 5
+        kind: CmpKind::Eq,
+        lhs: x,
+        rhs: c5,
+    });
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // index 1: x == 7
+        kind: CmpKind::Eq,
+        lhs: x,
+        rhs: c7,
+    });
     f.get_entry_mut().set_terminator(Terminator::Return(vec![]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -3841,36 +3684,27 @@ fn entry_and_local_assert_facts_layer() {
     let inner = f.add_block();
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(b, Type::u(32));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // outer: a == 5
-            kind: CmpKind::Eq,
-            lhs: a,
-            rhs: c5,
-        },
-        SourceLocation::test(),
-    ));
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // outer: a == 5
+        kind: CmpKind::Eq,
+        lhs: a,
+        rhs: c5,
+    });
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(inner, vec![]));
     let inner_block = f.get_block_mut(inner);
-    inner_block.push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 0: b == 6
-            kind: CmpKind::Eq,
-            lhs: b,
-            rhs: c6,
-        },
-        SourceLocation::test(),
-    ));
-    inner_block.push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 1: a == 7 (contradicts the dominating outer assert)
-            kind: CmpKind::Eq,
-            lhs: a,
-            rhs: c7,
-        },
-        SourceLocation::test(),
-    ));
+    inner_block.push_test_instruction(OpCode::AssertCmp {
+        // index 0: b == 6
+        kind: CmpKind::Eq,
+        lhs: b,
+        rhs: c6,
+    });
+    inner_block.push_test_instruction(OpCode::AssertCmp {
+        // index 1: a == 7 (contradicts the dominating outer assert)
+        kind: CmpKind::Eq,
+        lhs: a,
+        rhs: c7,
+    });
     inner_block.set_terminator(Terminator::Return(vec![]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -3907,25 +3741,20 @@ fn local_assert_on_value_defined_earlier_in_block() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry_id = f.get_entry_id();
     f.get_entry_mut().push_parameter(p, Type::u(32));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::BinaryArithOp {
+    f.get_entry_mut()
+        .push_test_instruction(OpCode::BinaryArithOp {
             // index 0: y = p + p
             kind: BinaryArithOpKind::Add,
             result: y,
             lhs: p,
             rhs: p,
-        },
-        SourceLocation::test(),
-    ));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 1: y == 10
-            kind: CmpKind::Eq,
-            lhs: y,
-            rhs: c10,
-        },
-        SourceLocation::test(),
-    ));
+        });
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        // index 1: y == 10
+        kind: CmpKind::Eq,
+        lhs: y,
+        rhs: c10,
+    });
     f.get_entry_mut()
         .set_terminator(Terminator::Return(vec![y])); // index 2
 
@@ -3966,38 +3795,29 @@ fn local_assert_in_loop_body() {
         .set_terminator(Terminator::Jmp(header, vec![c0]));
     let header_block = f.get_block_mut(header);
     header_block.push_parameter(i, Type::u(32));
-    header_block.push_instruction(Located::with(
-        OpCode::Cmp {
-            kind: CmpKind::Lt,
-            result: lt,
-            lhs: i,
-            rhs: n,
-        },
-        SourceLocation::test(),
-    ));
+    header_block.push_test_instruction(OpCode::Cmp {
+        kind: CmpKind::Lt,
+        result: lt,
+        lhs: i,
+        rhs: n,
+    });
     header_block.set_terminator(Terminator::JmpIf(lt, body, exit));
     let body_block = f.get_block_mut(body);
     // `next = i + 1` keeps `i` loop-variant (else it would fold to the constant 0 and the assert
     // would degrade to a constant pin rather than the pure equality this test exercises).
-    body_block.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            // index 0
-            kind: BinaryArithOpKind::Add,
-            result: next,
-            lhs: i,
-            rhs: c1,
-        },
-        SourceLocation::test(),
-    ));
-    body_block.push_instruction(Located::with(
-        OpCode::AssertCmp {
-            // index 1: i == n
-            kind: CmpKind::Eq,
-            lhs: i,
-            rhs: n,
-        },
-        SourceLocation::test(),
-    ));
+    body_block.push_test_instruction(OpCode::BinaryArithOp {
+        // index 0
+        kind: BinaryArithOpKind::Add,
+        result: next,
+        lhs: i,
+        rhs: c1,
+    });
+    body_block.push_test_instruction(OpCode::AssertCmp {
+        // index 1: i == n
+        kind: CmpKind::Eq,
+        lhs: i,
+        rhs: n,
+    });
     body_block.set_terminator(Terminator::Jmp(header, vec![next]));
     f.get_block_mut(exit)
         .set_terminator(Terminator::Return(vec![]));
@@ -4033,15 +3853,12 @@ fn interproc_constant_return_folds_at_call_site() {
         let mf = ssa.get_function_mut(main_id);
         mf.add_return_type(Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r],
-                function: CallTarget::Static(helper),
-                args: vec![],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r],
+            function: CallTarget::Static(helper),
+            args: vec![],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -4076,15 +3893,12 @@ fn interproc_passthrough_seeds_param_and_result() {
         let mf = ssa.get_function_mut(main_id);
         mf.add_return_type(Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r],
-                function: CallTarget::Static(id),
-                args: vec![c7],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r],
+            function: CallTarget::Static(id),
+            args: vec![c7],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -4125,33 +3939,24 @@ fn interproc_writeback_folds_congruent_comparison_return() {
         gf.add_return_type(Type::u(1));
         gf.get_entry_mut().push_parameter(x, Type::u(32));
         let entry = gf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: a,
-                lhs: x,
-                rhs: c1,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: b,
-                lhs: x,
-                rhs: c1,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Cmp {
-                kind: CmpKind::Eq,
-                result: eq,
-                lhs: a,
-                rhs: b,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_test_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: a,
+            rhs: b,
+        });
         entry.set_terminator(Terminator::Return(vec![eq]));
     }
     {
@@ -4159,15 +3964,12 @@ fn interproc_writeback_folds_congruent_comparison_return() {
         mf.add_return_type(Type::u(1));
         mf.get_entry_mut().push_parameter(x0, Type::u(32));
         let entry = mf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r],
-                function: CallTarget::Static(g),
-                args: vec![x0],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r],
+            function: CallTarget::Static(g),
+            args: vec![x0],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -4206,33 +4008,24 @@ fn interproc_writeback_folds_congruent_comparison_in_context() {
         gf.add_return_type(Type::u(32));
         gf.get_entry_mut().push_parameter(x, Type::u(32));
         let entry = gf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: a,
-                lhs: x,
-                rhs: c1,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: b,
-                lhs: x,
-                rhs: c1,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Cmp {
-                kind: CmpKind::Eq,
-                result: eq,
-                lhs: a,
-                rhs: b,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_test_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: a,
+            rhs: b,
+        });
         entry.set_terminator(Terminator::Return(vec![x]));
     }
     {
@@ -4240,15 +4033,12 @@ fn interproc_writeback_folds_congruent_comparison_in_context() {
         mf.add_return_type(Type::u(32));
         mf.get_entry_mut().push_parameter(x0, Type::u(32));
         let entry = mf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r],
-                function: CallTarget::Static(g),
-                args: vec![x0],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r],
+            function: CallTarget::Static(g),
+            args: vec![x0],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -4288,42 +4078,30 @@ fn interproc_writeback_terminates_under_recursion() {
         gf.add_return_type(Type::u(1));
         gf.get_entry_mut().push_parameter(x, Type::u(32));
         let entry = gf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: a,
-                lhs: x,
-                rhs: c1,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: b,
-                lhs: x,
-                rhs: c1,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Cmp {
-                kind: CmpKind::Eq,
-                result: eq,
-                lhs: a,
-                rhs: b,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![t],
-                function: CallTarget::Static(g),
-                args: vec![x],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_test_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: a,
+            rhs: b,
+        });
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![t],
+            function: CallTarget::Static(g),
+            args: vec![x],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![eq]));
     }
     {
@@ -4331,15 +4109,12 @@ fn interproc_writeback_terminates_under_recursion() {
         mf.add_return_type(Type::u(1));
         mf.get_entry_mut().push_parameter(x0, Type::u(32));
         let entry = mf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r],
-                function: CallTarget::Static(g),
-                args: vec![x0],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r],
+            function: CallTarget::Static(g),
+            args: vec![x0],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -4378,15 +4153,12 @@ fn context_parameterized_conditional_queries() {
         let mf = ssa.get_function_mut(main_id);
         mf.add_return_type(Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r],
-                function: CallTarget::Static(id),
-                args: vec![c7],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r],
+            function: CallTarget::Static(id),
+            args: vec![c7],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -4420,14 +4192,11 @@ fn asserted_const_refines_per_context() {
         let after = hf.add_block();
         hf.get_entry_mut().push_parameter(x, Type::field());
         hf.get_entry_mut().push_parameter(p, Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::AssertCmp {
-                kind: CmpKind::Eq,
-                lhs: x,
-                rhs: p,
-            },
-            SourceLocation::test(),
-        ));
+        hf.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: p,
+        });
         hf.get_entry_mut()
             .set_terminator(Terminator::Jmp(after, vec![]));
         hf.get_block_mut(after)
@@ -4438,15 +4207,12 @@ fn asserted_const_refines_per_context() {
         let mf = ssa.get_function_mut(main_id);
         let entry = mf.get_entry_mut();
         entry.push_parameter(x0, Type::field());
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![],
-                function: CallTarget::Static(g),
-                args: vec![x0, c7],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![],
+            function: CallTarget::Static(g),
+            args: vec![x0, c7],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![]));
     }
 
@@ -4491,14 +4257,12 @@ fn witness_forward_in_prunes_context_dead_forward() {
         hf.get_block_mut(then_b)
             .set_terminator(Terminator::Jmp(after, vec![]));
         // The false arm establishes the forward `r → w`; it is dead once a context pins `p`.
-        hf.get_block_mut(else_b).push_instruction(Located::with(
-            OpCode::WriteWitness {
+        hf.get_block_mut(else_b)
+            .push_test_instruction(OpCode::WriteWitness {
                 result: Some(r),
                 value: w,
                 pinned: false,
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_block_mut(else_b)
             .set_terminator(Terminator::Jmp(after, vec![]));
         hf.get_block_mut(after)
@@ -4508,15 +4272,12 @@ fn witness_forward_in_prunes_context_dead_forward() {
         let mf = ssa.get_function_mut(main_id);
         let entry = mf.get_entry_mut();
         entry.push_parameter(w0, Type::u(32));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![],
-                function: CallTarget::Static(g),
-                args: vec![c_true, w0],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![],
+            function: CallTarget::Static(g),
+            args: vec![c_true, w0],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![]));
     }
 
@@ -4549,39 +4310,28 @@ fn conditional_queries_parity_under_empty_context() {
     for v in [x, a, b, d, e] {
         f.get_entry_mut().push_parameter(v, Type::u(32));
     }
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            kind: CmpKind::Eq,
-            lhs: x,
-            rhs: c5,
-        },
-        SourceLocation::test(),
-    ));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            kind: CmpKind::Eq,
-            lhs: a,
-            rhs: b,
-        },
-        SourceLocation::test(),
-    ));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::WriteWitness {
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        kind: CmpKind::Eq,
+        lhs: x,
+        rhs: c5,
+    });
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        kind: CmpKind::Eq,
+        lhs: a,
+        rhs: b,
+    });
+    f.get_entry_mut()
+        .push_test_instruction(OpCode::WriteWitness {
             result: Some(r),
             value: x,
             pinned: false,
-        },
-        SourceLocation::test(),
-    ));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: eq,
-            lhs: d,
-            rhs: e,
-        },
-        SourceLocation::test(),
-    ));
+        });
+    f.get_entry_mut().push_test_instruction(OpCode::Cmp {
+        kind: CmpKind::Eq,
+        result: eq,
+        lhs: d,
+        rhs: e,
+    });
     f.get_entry_mut()
         .set_terminator(Terminator::JmpIf(eq, then_b, else_b));
     f.get_block_mut(then_b)
@@ -4645,12 +4395,12 @@ fn anticipated_queries_parity_under_empty_context() {
     f.get_block_mut(mid)
         .set_terminator(Terminator::Jmp(tail, vec![]));
     let tail_block = f.get_block_mut(tail);
-    tail_block.push_instruction(OpCode::AssertCmp {
+    tail_block.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: x,
         rhs: c5,
     });
-    tail_block.push_instruction(OpCode::AssertCmp {
+    tail_block.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
@@ -4714,15 +4464,12 @@ fn known_unequal_in_gains_from_pruned_predecessor() {
         hf.get_entry_mut().push_parameter(p, Type::u(1));
         hf.get_entry_mut().push_parameter(d, Type::u(32));
         hf.get_entry_mut().push_parameter(e, Type::u(32));
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::Cmp {
-                kind: CmpKind::Eq,
-                result: eq,
-                lhs: d,
-                rhs: e,
-            },
-            SourceLocation::test(),
-        ));
+        hf.get_entry_mut().push_test_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: d,
+            rhs: e,
+        });
         hf.get_entry_mut()
             .set_terminator(Terminator::JmpIf(p, side, main_b));
         // `side` is `join`'s second predecessor; it dies once a context pins `p = false`.
@@ -4741,15 +4488,12 @@ fn known_unequal_in_gains_from_pruned_predecessor() {
         let entry = mf.get_entry_mut();
         entry.push_parameter(d0, Type::u(32));
         entry.push_parameter(e0, Type::u(32));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![],
-                function: CallTarget::Static(g),
-                args: vec![c_false, d0, e0],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![],
+            function: CallTarget::Static(g),
+            args: vec![c_false, d0, e0],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![]));
     }
 
@@ -4780,23 +4524,17 @@ fn asserted_const_never_aggregate() {
     f.get_entry_mut().push_parameter(x, Type::u(32).array_of(2));
     let entry = f.get_entry_mut();
     // `s` aggregate-folds to a lattice `Const(Blob)`, so the assert pins `x` to a Blob.
-    entry.push_instruction(Located::with(
-        OpCode::MkSeq {
-            result: s,
-            elems: vec![c0, c1],
-            seq_type: SequenceTargetType::Array(2),
-            elem_type: Type::u(32),
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::AssertCmp {
-            kind: CmpKind::Eq,
-            lhs: x,
-            rhs: s,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::MkSeq {
+        result: s,
+        elems: vec![c0, c1],
+        seq_type: SequenceTargetType::Array(2),
+        elem_type: Type::u(32),
+    });
+    entry.push_test_instruction(OpCode::AssertCmp {
+        kind: CmpKind::Eq,
+        lhs: x,
+        rhs: s,
+    });
     entry.set_terminator(Terminator::Jmp(after, vec![]));
     f.get_block_mut(after)
         .set_terminator(Terminator::Return(vec![]));
@@ -4831,14 +4569,11 @@ fn asserted_const_in_never_aggregate() {
             .push_parameter(a, Type::u(32).array_of(2));
         hf.get_entry_mut()
             .push_parameter(x, Type::u(32).array_of(2));
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::AssertCmp {
-                kind: CmpKind::Eq,
-                lhs: x,
-                rhs: a,
-            },
-            SourceLocation::test(),
-        ));
+        hf.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: a,
+        });
         hf.get_entry_mut()
             .set_terminator(Terminator::Jmp(after, vec![]));
         hf.get_block_mut(after)
@@ -4849,24 +4584,18 @@ fn asserted_const_in_never_aggregate() {
         let mf = ssa.get_function_mut(main_id);
         let entry = mf.get_entry_mut();
         entry.push_parameter(y, Type::u(32).array_of(2));
-        entry.push_instruction(Located::with(
-            OpCode::MkSeq {
-                result: s,
-                elems: vec![c0, c1],
-                seq_type: SequenceTargetType::Array(2),
-                elem_type: Type::u(32),
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![],
-                function: CallTarget::Static(g),
-                args: vec![s, y],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::MkSeq {
+            result: s,
+            elems: vec![c0, c1],
+            seq_type: SequenceTargetType::Array(2),
+            elem_type: Type::u(32),
+        });
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![],
+            function: CallTarget::Static(g),
+            args: vec![s, y],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![]));
     }
 
@@ -4898,14 +4627,11 @@ fn asserted_const_migrates_to_unconditional_channel() {
         let hf = ssa.get_function_mut(g);
         let after = hf.add_block();
         hf.get_entry_mut().push_parameter(x, Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::AssertCmp {
-                kind: CmpKind::Eq,
-                lhs: x,
-                rhs: c7,
-            },
-            SourceLocation::test(),
-        ));
+        hf.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c7,
+        });
         hf.get_entry_mut()
             .set_terminator(Terminator::Jmp(after, vec![]));
         hf.get_block_mut(after)
@@ -4915,15 +4641,12 @@ fn asserted_const_migrates_to_unconditional_channel() {
     {
         let mf = ssa.get_function_mut(main_id);
         let entry = mf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![],
-                function: CallTarget::Static(g),
-                args: vec![c7],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![],
+            function: CallTarget::Static(g),
+            args: vec![c7],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![]));
     }
 
@@ -4978,15 +4701,13 @@ fn context_constant_can_split_congruence() {
         let hf = ssa.get_function_mut(g);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(p, Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Mul,
                 result: m,
                 lhs: p,
                 rhs: c3,
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![m]));
     }
@@ -4998,45 +4719,35 @@ fn context_constant_can_split_congruence() {
         let after = hf.add_block();
         hf.get_entry_mut().push_parameter(a, Type::field());
         hf.get_entry_mut().push_parameter(w, Type::u(32));
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![x],
-                function: CallTarget::Static(g),
-                args: vec![a],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+        hf.get_entry_mut().push_test_instruction(OpCode::Call {
+            results: vec![x],
+            function: CallTarget::Static(g),
+            args: vec![a],
+            unconstrained: false,
+        });
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Mul,
                 result: y,
                 lhs: a,
                 rhs: c3,
-            },
-            SourceLocation::test(),
-        ));
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::Cmp {
-                kind: CmpKind::Eq,
-                result: eq,
-                lhs: x,
-                rhs: y,
-            },
-            SourceLocation::test(),
-        ));
+            });
+        hf.get_entry_mut().push_test_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: x,
+            rhs: y,
+        });
         hf.get_entry_mut()
             .set_terminator(Terminator::JmpIf(eq, then_b, else_b));
         hf.get_block_mut(then_b)
             .set_terminator(Terminator::Jmp(after, vec![]));
-        hf.get_block_mut(else_b).push_instruction(Located::with(
-            OpCode::WriteWitness {
+        hf.get_block_mut(else_b)
+            .push_test_instruction(OpCode::WriteWitness {
                 result: Some(r),
                 value: w,
                 pinned: false,
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_block_mut(else_b)
             .set_terminator(Terminator::Jmp(after, vec![]));
         hf.get_block_mut(after)
@@ -5046,15 +4757,12 @@ fn context_constant_can_split_congruence() {
         let mf = ssa.get_function_mut(main_id);
         let entry = mf.get_entry_mut();
         entry.push_parameter(w0, Type::u(32));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![],
-                function: CallTarget::Static(f),
-                args: vec![c5, w0],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![],
+            function: CallTarget::Static(f),
+            args: vec![c5, w0],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![]));
     }
 
@@ -5094,24 +4802,18 @@ fn interproc_two_call_sites_are_distinguished() {
         let mf = ssa.get_function_mut(main_id);
         mf.add_return_type(Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r5],
-                function: CallTarget::Static(id),
-                args: vec![c5],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r7],
-                function: CallTarget::Static(id),
-                args: vec![c7],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r5],
+            function: CallTarget::Static(id),
+            args: vec![c5],
+            unconstrained: false,
+        });
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r7],
+            function: CallTarget::Static(id),
+            args: vec![c7],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![r5, r7]));
     }
 
@@ -5156,24 +4858,18 @@ fn unconstrained_call_result_is_opaque() {
         mf.add_return_type(Type::field());
         mf.add_return_type(Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r1],
-                function: CallTarget::Static(helper),
-                args: vec![],
-                unconstrained: true,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r2],
-                function: CallTarget::Static(helper),
-                args: vec![],
-                unconstrained: true,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r1],
+            function: CallTarget::Static(helper),
+            args: vec![],
+            unconstrained: true,
+        });
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r2],
+            function: CallTarget::Static(helper),
+            args: vec![],
+            unconstrained: true,
+        });
         entry.set_terminator(Terminator::Return(vec![r1, r2]));
     }
 
@@ -5201,15 +4897,13 @@ fn cross_call_congruence_for_deterministic_callee() {
         let hf = ssa.get_function_mut(dbl);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(p, Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Add,
                 result: psum,
                 lhs: p,
                 rhs: p,
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![psum]));
     }
@@ -5227,51 +4921,36 @@ fn cross_call_congruence_for_deterministic_callee() {
         mf.get_entry_mut().push_parameter(y, Type::field());
         let entry = mf.get_entry_mut();
         // `a` and `b` are structurally congruent (both `x + 1`); `y` is distinct.
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: a,
-                lhs: x,
-                rhs: c1,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: b,
-                lhs: x,
-                rhs: c1,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r1],
-                function: CallTarget::Static(dbl),
-                args: vec![a],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r2],
-                function: CallTarget::Static(dbl),
-                args: vec![b],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r3],
-                function: CallTarget::Static(dbl),
-                args: vec![y],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r1],
+            function: CallTarget::Static(dbl),
+            args: vec![a],
+            unconstrained: false,
+        });
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r2],
+            function: CallTarget::Static(dbl),
+            args: vec![b],
+            unconstrained: false,
+        });
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r3],
+            function: CallTarget::Static(dbl),
+            args: vec![y],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
     }
 
@@ -5293,13 +4972,11 @@ fn cross_call_no_congruence_for_nondeterministic_callee() {
     {
         let hf = ssa.get_function_mut(rnd);
         hf.add_return_type(Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::FreshWitness {
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::FreshWitness {
                 result: w,
                 result_type: Type::field(),
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![w]));
     }
@@ -5309,24 +4986,18 @@ fn cross_call_no_congruence_for_nondeterministic_callee() {
         mf.add_return_type(Type::field());
         mf.add_return_type(Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r1],
-                function: CallTarget::Static(rnd),
-                args: vec![],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r2],
-                function: CallTarget::Static(rnd),
-                args: vec![],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r1],
+            function: CallTarget::Static(rnd),
+            args: vec![],
+            unconstrained: false,
+        });
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r2],
+            function: CallTarget::Static(rnd),
+            args: vec![],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![r1, r2]));
     }
 
@@ -5349,15 +5020,13 @@ fn cross_call_congruence_is_transitive() {
         let hf = ssa.get_function_mut(inner);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(ip, Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Add,
                 result: isum,
                 lhs: ip,
                 rhs: ip,
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![isum]));
     }
@@ -5367,15 +5036,12 @@ fn cross_call_congruence_is_transitive() {
         let hf = ssa.get_function_mut(outer);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(op, Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![ores],
-                function: CallTarget::Static(inner),
-                args: vec![op],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        hf.get_entry_mut().push_test_instruction(OpCode::Call {
+            results: vec![ores],
+            function: CallTarget::Static(inner),
+            args: vec![op],
+            unconstrained: false,
+        });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![ores]));
     }
@@ -5390,42 +5056,30 @@ fn cross_call_congruence_is_transitive() {
         mf.add_return_type(Type::field());
         mf.get_entry_mut().push_parameter(x, Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: a,
-                lhs: x,
-                rhs: c1,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: b,
-                lhs: x,
-                rhs: c1,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r1],
-                function: CallTarget::Static(outer),
-                args: vec![a],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r2],
-                function: CallTarget::Static(outer),
-                args: vec![b],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: c1,
+        });
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r1],
+            function: CallTarget::Static(outer),
+            args: vec![a],
+            unconstrained: false,
+        });
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r2],
+            function: CallTarget::Static(outer),
+            args: vec![b],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![r1, r2]));
     }
 
@@ -5452,14 +5106,11 @@ fn cross_call_congruence_for_array_returning_callee() {
         hf.add_return_type(Type::field());
         hf.get_entry_mut()
             .push_parameter(p, Type::field().array_of(1));
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::ArrayGet {
-                result: elem,
-                array: p,
-                index: c0,
-            },
-            SourceLocation::test(),
-        ));
+        hf.get_entry_mut().push_test_instruction(OpCode::ArrayGet {
+            result: elem,
+            array: p,
+            index: c0,
+        });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![elem]));
     }
@@ -5476,60 +5127,42 @@ fn cross_call_congruence_for_array_returning_callee() {
         mf.get_entry_mut().push_parameter(y, Type::field());
         let entry = mf.get_entry_mut();
         // `a` and `b` are congruent single-element arrays (`[x]`); `d` is `[y]`.
-        entry.push_instruction(Located::with(
-            OpCode::MkSeq {
-                result: a,
-                elems: vec![x],
-                seq_type: SequenceTargetType::Array(1),
-                elem_type: Type::field(),
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::MkSeq {
-                result: b,
-                elems: vec![x],
-                seq_type: SequenceTargetType::Array(1),
-                elem_type: Type::field(),
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::MkSeq {
-                result: d,
-                elems: vec![y],
-                seq_type: SequenceTargetType::Array(1),
-                elem_type: Type::field(),
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r1],
-                function: CallTarget::Static(pick),
-                args: vec![a],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r2],
-                function: CallTarget::Static(pick),
-                args: vec![b],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r3],
-                function: CallTarget::Static(pick),
-                args: vec![d],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::MkSeq {
+            result: a,
+            elems: vec![x],
+            seq_type: SequenceTargetType::Array(1),
+            elem_type: Type::field(),
+        });
+        entry.push_test_instruction(OpCode::MkSeq {
+            result: b,
+            elems: vec![x],
+            seq_type: SequenceTargetType::Array(1),
+            elem_type: Type::field(),
+        });
+        entry.push_test_instruction(OpCode::MkSeq {
+            result: d,
+            elems: vec![y],
+            seq_type: SequenceTargetType::Array(1),
+            elem_type: Type::field(),
+        });
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r1],
+            function: CallTarget::Static(pick),
+            args: vec![a],
+            unconstrained: false,
+        });
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r2],
+            function: CallTarget::Static(pick),
+            args: vec![b],
+            unconstrained: false,
+        });
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r3],
+            function: CallTarget::Static(pick),
+            args: vec![d],
+            unconstrained: false,
+        });
         entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
     }
 
@@ -5559,33 +5192,24 @@ fn cmp_eq_of_congruent_operands_folds_and_prunes_dead_edge() {
     f.get_entry_mut().push_parameter(x, Type::u(32));
     let entry = f.get_entry_mut();
     // a = x + 1 and b = x + 1 are structurally congruent but not constant.
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: a,
-            lhs: x,
-            rhs: c1,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: x,
-            rhs: c1,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: eq,
-            lhs: a,
-            rhs: b,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: a,
+        lhs: x,
+        rhs: c1,
+    });
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: b,
+        lhs: x,
+        rhs: c1,
+    });
+    entry.push_test_instruction(OpCode::Cmp {
+        kind: CmpKind::Eq,
+        result: eq,
+        lhs: a,
+        rhs: b,
+    });
     entry.set_terminator(Terminator::JmpIf(eq, then_b, else_b));
     f.get_block_mut(then_b)
         .set_terminator(Terminator::Return(vec![a]));
@@ -5629,33 +5253,24 @@ fn writeback_cascades_to_downstream_constant() {
     let merge = f.add_block();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: a,
-            lhs: x,
-            rhs: c1,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: x,
-            rhs: c1,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: eq,
-            lhs: a,
-            rhs: b,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: a,
+        lhs: x,
+        rhs: c1,
+    });
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: b,
+        lhs: x,
+        rhs: c1,
+    });
+    entry.push_test_instruction(OpCode::Cmp {
+        kind: CmpKind::Eq,
+        result: eq,
+        lhs: a,
+        rhs: b,
+    });
     entry.set_terminator(Terminator::JmpIf(eq, then_b, else_b));
     // The dead else-edge would carry a different constant, forcing the merge to ⊥ under SCCP
     // alone.
@@ -5687,15 +5302,12 @@ fn cmp_eq_of_noncongruent_operands_is_not_folded() {
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(y, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(Located::with(
-        OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: eq,
-            lhs: x,
-            rhs: y,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::Cmp {
+        kind: CmpKind::Eq,
+        result: eq,
+        lhs: x,
+        rhs: y,
+    });
     entry.set_terminator(Terminator::JmpIf(eq, then_b, else_b));
     f.get_block_mut(then_b)
         .set_terminator(Terminator::Return(vec![x]));
@@ -5720,29 +5332,20 @@ fn free_witnesses_are_not_congruent_so_comparison_not_folded() {
 
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
-    entry.push_instruction(Located::with(
-        OpCode::FreshWitness {
-            result: w1,
-            result_type: Type::field(),
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::FreshWitness {
-            result: w2,
-            result_type: Type::field(),
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: eq,
-            lhs: w1,
-            rhs: w2,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::FreshWitness {
+        result: w1,
+        result_type: Type::field(),
+    });
+    entry.push_test_instruction(OpCode::FreshWitness {
+        result: w2,
+        result_type: Type::field(),
+    });
+    entry.push_test_instruction(OpCode::Cmp {
+        kind: CmpKind::Eq,
+        result: eq,
+        lhs: w1,
+        rhs: w2,
+    });
     entry.set_terminator(Terminator::Return(vec![eq]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -5763,15 +5366,12 @@ fn writeback_is_noop_without_congruent_comparison() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
     entry.push_parameter(x, Type::u(32));
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: a,
-            lhs: x,
-            rhs: c1,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: a,
+        lhs: x,
+        rhs: c1,
+    });
     entry.set_terminator(Terminator::Return(vec![a]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -5796,33 +5396,24 @@ fn cmp_lt_of_congruent_operands_folds_false() {
     let f = ssa.get_unique_entrypoint_mut();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: a,
-            lhs: x,
-            rhs: c1,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: x,
-            rhs: c1,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::Cmp {
-            kind: CmpKind::Lt,
-            result: lt,
-            lhs: a,
-            rhs: b,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: a,
+        lhs: x,
+        rhs: c1,
+    });
+    entry.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: b,
+        lhs: x,
+        rhs: c1,
+    });
+    entry.push_test_instruction(OpCode::Cmp {
+        kind: CmpKind::Lt,
+        result: lt,
+        lhs: a,
+        rhs: b,
+    });
     entry.set_terminator(Terminator::Return(vec![lt]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -5851,25 +5442,19 @@ fn witnessed_comparison_of_congruent_operands_is_promoted() {
     entry.push_parameter(w, Type::witness_of(Type::u(32)));
     entry.push_parameter(n, Type::u(32));
     // Witnessed comparison: an operand is `WitnessOf`, so the result is `WitnessOf(u1)`.
-    entry.push_instruction(Located::with(
-        OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: ww,
-            lhs: w,
-            rhs: w,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::Cmp {
+        kind: CmpKind::Eq,
+        result: ww,
+        lhs: w,
+        rhs: w,
+    });
     // Plain comparison: result is `u1`.
-    entry.push_instruction(Located::with(
-        OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: nn,
-            lhs: n,
-            rhs: n,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::Cmp {
+        kind: CmpKind::Eq,
+        result: nn,
+        lhs: n,
+        rhs: n,
+    });
     entry.set_terminator(Terminator::Return(vec![ww, nn]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -5911,44 +5496,32 @@ fn loop_carried_congruent_comparison_folds_true() {
     let header_block = f.get_block_mut(header);
     header_block.push_parameter(i, Type::u(32));
     header_block.push_parameter(j, Type::u(32));
-    header_block.push_instruction(Located::with(
-        OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: eq,
-            lhs: i,
-            rhs: j,
-        },
-        SourceLocation::test(),
-    ));
-    header_block.push_instruction(Located::with(
-        OpCode::Cmp {
-            kind: CmpKind::Lt,
-            result: lt,
-            lhs: i,
-            rhs: c10,
-        },
-        SourceLocation::test(),
-    ));
+    header_block.push_test_instruction(OpCode::Cmp {
+        kind: CmpKind::Eq,
+        result: eq,
+        lhs: i,
+        rhs: j,
+    });
+    header_block.push_test_instruction(OpCode::Cmp {
+        kind: CmpKind::Lt,
+        result: lt,
+        lhs: i,
+        rhs: c10,
+    });
     header_block.set_terminator(Terminator::JmpIf(lt, body, exit));
     let body_block = f.get_block_mut(body);
-    body_block.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: i2,
-            lhs: i,
-            rhs: c1,
-        },
-        SourceLocation::test(),
-    ));
-    body_block.push_instruction(Located::with(
-        OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: j2,
-            lhs: j,
-            rhs: c1,
-        },
-        SourceLocation::test(),
-    ));
+    body_block.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: i2,
+        lhs: i,
+        rhs: c1,
+    });
+    body_block.push_test_instruction(OpCode::BinaryArithOp {
+        kind: BinaryArithOpKind::Add,
+        result: j2,
+        lhs: j,
+        rhs: c1,
+    });
     body_block.set_terminator(Terminator::Jmp(header, vec![i2, j2]));
     f.get_block_mut(exit)
         .set_terminator(Terminator::Return(vec![i, j]));
@@ -5976,23 +5549,17 @@ fn const_array_get_folds_to_scalar() {
     let (seq, got) = (ssa.fresh_value(), ssa.fresh_value());
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
-    entry.push_instruction(Located::with(
-        OpCode::MkSeq {
-            result: seq,
-            elems: vec![c0, c1, c2],
-            seq_type: SequenceTargetType::Array(3),
-            elem_type: Type::u(32),
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: got,
-            array: seq,
-            index: idx,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::MkSeq {
+        result: seq,
+        elems: vec![c0, c1, c2],
+        seq_type: SequenceTargetType::Array(3),
+        elem_type: Type::u(32),
+    });
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: got,
+        array: seq,
+        index: idx,
+    });
     entry.set_terminator(Terminator::Return(vec![got]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -6020,31 +5587,22 @@ fn const_repeated_array_get_and_slice_len() {
     let (seq, got, len) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
-    entry.push_instruction(Located::with(
-        OpCode::MkRepeated {
-            result: seq,
-            element: elem,
-            seq_type: SequenceTargetType::Array(4),
-            count: 4,
-            elem_type: Type::u(32),
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: got,
-            array: seq,
-            index: idx,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::SliceLen {
-            result: len,
-            slice: seq,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::MkRepeated {
+        result: seq,
+        element: elem,
+        seq_type: SequenceTargetType::Array(4),
+        count: 4,
+        elem_type: Type::u(32),
+    });
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: got,
+        array: seq,
+        index: idx,
+    });
+    entry.push_test_instruction(OpCode::SliceLen {
+        result: len,
+        slice: seq,
+    });
     entry.set_terminator(Terminator::Return(vec![got, len]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -6073,40 +5631,28 @@ fn const_array_set_then_get() {
     );
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
-    entry.push_instruction(Located::with(
-        OpCode::MkSeq {
-            result: seq,
-            elems: vec![c0, c1, c2],
-            seq_type: SequenceTargetType::Array(3),
-            elem_type: Type::u(32),
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArraySet {
-            result: seq2,
-            array: seq,
-            index: idx1,
-            value: new_val,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: at_set,
-            array: seq2,
-            index: idx1,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: at_orig,
-            array: seq2,
-            index: idx0,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::MkSeq {
+        result: seq,
+        elems: vec![c0, c1, c2],
+        seq_type: SequenceTargetType::Array(3),
+        elem_type: Type::u(32),
+    });
+    entry.push_test_instruction(OpCode::ArraySet {
+        result: seq2,
+        array: seq,
+        index: idx1,
+        value: new_val,
+    });
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: at_set,
+        array: seq2,
+        index: idx1,
+    });
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: at_orig,
+        array: seq2,
+        index: idx0,
+    });
     entry.set_terminator(Terminator::Return(vec![at_set, at_orig]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -6140,51 +5686,36 @@ fn const_slice_push_front_and_back() {
     );
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
-    entry.push_instruction(Located::with(
-        OpCode::MkSeq {
-            result: base,
-            elems: vec![mid],
-            seq_type: SequenceTargetType::Slice,
-            elem_type: Type::u(32),
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::MkSeq {
+        result: base,
+        elems: vec![mid],
+        seq_type: SequenceTargetType::Slice,
+        elem_type: Type::u(32),
+    });
     // Front: [front, mid]; element 0 is the pushed value.
-    entry.push_instruction(Located::with(
-        OpCode::SlicePush {
-            dir: SliceOpDir::Front,
-            result: pushed_front,
-            slice: base,
-            values: vec![front],
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::SlicePush {
+        dir: SliceOpDir::Front,
+        result: pushed_front,
+        slice: base,
+        values: vec![front],
+    });
     // Back: [mid, back]; element 1 is the pushed value.
-    entry.push_instruction(Located::with(
-        OpCode::SlicePush {
-            dir: SliceOpDir::Back,
-            result: pushed_back,
-            slice: base,
-            values: vec![back],
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: head,
-            array: pushed_front,
-            index: idx0,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: tail,
-            array: pushed_back,
-            index: idx1,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::SlicePush {
+        dir: SliceOpDir::Back,
+        result: pushed_back,
+        slice: base,
+        values: vec![back],
+    });
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: head,
+        array: pushed_front,
+        index: idx0,
+    });
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: tail,
+        array: pushed_back,
+        index: idx1,
+    });
     entry.set_terminator(Terminator::Return(vec![head, tail]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -6206,22 +5737,16 @@ fn const_mk_seq_of_blob_folds() {
     let (seq, got) = (ssa.fresh_value(), ssa.fresh_value());
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
-    entry.push_instruction(Located::with(
-        OpCode::MkSeqOfBlob {
-            result: seq,
-            element_type: Type::u(32),
-            blob,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: got,
-            array: seq,
-            index: idx,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::MkSeqOfBlob {
+        result: seq,
+        element_type: Type::u(32),
+        blob,
+    });
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: got,
+        array: seq,
+        index: idx,
+    });
     entry.set_terminator(Terminator::Return(vec![got]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -6258,60 +5783,42 @@ fn aggregate_folding_negative_cases() {
     f.get_entry_mut().push_parameter(p, Type::u(32));
     let entry = f.get_entry_mut();
     // Out of bounds: index 5 into a length-2 array.
-    entry.push_instruction(Located::with(
-        OpCode::MkSeq {
-            result: seq,
-            elems: vec![c0, c1],
-            seq_type: SequenceTargetType::Array(2),
-            elem_type: Type::u(32),
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: g_oob,
-            array: seq,
-            index: idx_oob,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::MkSeq {
+        result: seq,
+        elems: vec![c0, c1],
+        seq_type: SequenceTargetType::Array(2),
+        elem_type: Type::u(32),
+    });
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: g_oob,
+        array: seq,
+        index: idx_oob,
+    });
     // Non-constant element keeps the whole aggregate non-constant.
-    entry.push_instruction(Located::with(
-        OpCode::MkSeq {
-            result: seq_nc,
-            elems: vec![c0, p],
-            seq_type: SequenceTargetType::Array(2),
-            elem_type: Type::u(32),
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: g_nc,
-            array: seq_nc,
-            index: idx0,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::MkSeq {
+        result: seq_nc,
+        elems: vec![c0, p],
+        seq_type: SequenceTargetType::Array(2),
+        elem_type: Type::u(32),
+    });
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: g_nc,
+        array: seq_nc,
+        index: idx0,
+    });
     // Over-cap repeat is refused before materialising the aggregate.
-    entry.push_instruction(Located::with(
-        OpCode::MkRepeated {
-            result: big,
-            element: c0,
-            seq_type: SequenceTargetType::Array((1 << 16) + 1),
-            count: (1 << 16) + 1,
-            elem_type: Type::u(32),
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: g_big,
-            array: big,
-            index: idx0,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::MkRepeated {
+        result: big,
+        element: c0,
+        seq_type: SequenceTargetType::Array((1 << 16) + 1),
+        count: (1 << 16) + 1,
+        elem_type: Type::u(32),
+    });
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: g_big,
+        array: big,
+        index: idx0,
+    });
     entry.set_terminator(Terminator::Return(vec![g_oob, g_nc, g_big]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -6342,79 +5849,55 @@ fn aggregate_folding_refuses_oob_set_and_over_cap_constructors() {
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
 
     // Out-of-bounds `ArraySet` (index 5 into a length-2 array): refused, so the get sees Bottom.
-    entry.push_instruction(Located::with(
-        OpCode::MkSeq {
-            result: base,
-            elems: vec![c0, c1],
-            seq_type: SequenceTargetType::Array(2),
-            elem_type: Type::u(32),
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArraySet {
-            result: set_oob,
-            array: base,
-            index: idx_oob,
-            value: c0,
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: at_set_oob,
-            array: set_oob,
-            index: idx0,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::MkSeq {
+        result: base,
+        elems: vec![c0, c1],
+        seq_type: SequenceTargetType::Array(2),
+        elem_type: Type::u(32),
+    });
+    entry.push_test_instruction(OpCode::ArraySet {
+        result: set_oob,
+        array: base,
+        index: idx_oob,
+        value: c0,
+    });
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: at_set_oob,
+        array: set_oob,
+        index: idx0,
+    });
 
     // `SlicePush` whose result would exceed the cap (1 + CAP values): refused.
-    entry.push_instruction(Located::with(
-        OpCode::MkSeq {
-            result: one,
-            elems: vec![c0],
-            seq_type: SequenceTargetType::Slice,
-            elem_type: Type::u(32),
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::SlicePush {
-            dir: SliceOpDir::Back,
-            result: pushed,
-            slice: one,
-            values: vec![c0; 1 << 12],
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: at_pushed,
-            array: pushed,
-            index: idx0,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::MkSeq {
+        result: one,
+        elems: vec![c0],
+        seq_type: SequenceTargetType::Slice,
+        elem_type: Type::u(32),
+    });
+    entry.push_test_instruction(OpCode::SlicePush {
+        dir: SliceOpDir::Back,
+        result: pushed,
+        slice: one,
+        values: vec![c0; 1 << 12],
+    });
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: at_pushed,
+        array: pushed,
+        index: idx0,
+    });
 
     // Over-cap `MkSeq`: refused before materialising the aggregate.
-    entry.push_instruction(Located::with(
-        OpCode::MkSeq {
-            result: big_seq,
-            elems: vec![c0; over_cap],
-            seq_type: SequenceTargetType::Array(over_cap),
-            elem_type: Type::u(32),
-        },
-        SourceLocation::test(),
-    ));
-    entry.push_instruction(Located::with(
-        OpCode::ArrayGet {
-            result: at_big,
-            array: big_seq,
-            index: idx0,
-        },
-        SourceLocation::test(),
-    ));
+    entry.push_test_instruction(OpCode::MkSeq {
+        result: big_seq,
+        elems: vec![c0; over_cap],
+        seq_type: SequenceTargetType::Array(over_cap),
+        elem_type: Type::u(32),
+    });
+    entry.push_test_instruction(OpCode::ArrayGet {
+        result: at_big,
+        array: big_seq,
+        index: idx0,
+    });
 
     entry.set_terminator(Terminator::Return(vec![at_set_oob, at_pushed, at_big]));
 
@@ -6446,15 +5929,13 @@ fn symbolic_jump_ignores_dead_argument() {
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
         hf.get_entry_mut().push_parameter(y, Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Add,
                 result: fa,
                 lhs: x,
                 rhs: c1,
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -6477,15 +5958,12 @@ fn symbolic_jump_ignores_dead_argument() {
         mf.get_entry_mut().push_parameter(d, Type::field());
         let entry = mf.get_entry_mut();
         for (res, args) in [(r1, vec![a, c]), (r2, vec![a, d]), (r3, vec![b, c])] {
-            entry.push_instruction(Located::with(
-                OpCode::Call {
-                    results: vec![res],
-                    function: CallTarget::Static(f),
-                    args,
-                    unconstrained: false,
-                },
-                SourceLocation::test(),
-            ));
+            entry.push_test_instruction(OpCode::Call {
+                results: vec![res],
+                function: CallTarget::Static(f),
+                args,
+                unconstrained: false,
+            });
         }
         entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
     }
@@ -6513,15 +5991,13 @@ fn symbolic_jump_relates_call_to_open_expression() {
         let hf = ssa.get_function_mut(f);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Add,
                 result: fa,
                 lhs: x,
                 rhs: c5,
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -6533,33 +6009,24 @@ fn symbolic_jump_relates_call_to_open_expression() {
         mf.add_return_type(Type::field());
         mf.get_entry_mut().push_parameter(a, Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r],
-                function: CallTarget::Static(f),
-                args: vec![a],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: w,
-                lhs: a,
-                rhs: c5,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: w2,
-                lhs: a,
-                rhs: c6,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r],
+            function: CallTarget::Static(f),
+            args: vec![a],
+            unconstrained: false,
+        });
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: w,
+            lhs: a,
+            rhs: c5,
+        });
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: w2,
+            lhs: a,
+            rhs: c6,
+        });
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -6589,24 +6056,20 @@ fn symbolic_jump_depth_two_grafts_via_synthetic() {
         let hf = ssa.get_function_mut(f);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Add,
                 result: ft,
                 lhs: x,
                 rhs: c5,
-            },
-            SourceLocation::test(),
-        ));
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+            });
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Mul,
                 result: fa,
                 lhs: ft,
                 rhs: c2,
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -6618,33 +6081,24 @@ fn symbolic_jump_depth_two_grafts_via_synthetic() {
         mf.add_return_type(Type::field());
         mf.get_entry_mut().push_parameter(a, Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r],
-                function: CallTarget::Static(f),
-                args: vec![a],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: wt,
-                lhs: a,
-                rhs: c5,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Mul,
-                result: w,
-                lhs: wt,
-                rhs: c2,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r],
+            function: CallTarget::Static(f),
+            args: vec![a],
+            unconstrained: false,
+        });
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: wt,
+            lhs: a,
+            rhs: c5,
+        });
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Mul,
+            result: w,
+            lhs: wt,
+            rhs: c2,
+        });
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -6690,24 +6144,20 @@ fn symbolic_jump_dead_argument_behind_depth_two() {
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
         hf.get_entry_mut().push_parameter(y, Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Add,
                 result: ft,
                 lhs: x,
                 rhs: c5,
-            },
-            SourceLocation::test(),
-        ));
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+            });
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Mul,
                 result: fa,
                 lhs: ft,
                 rhs: c2,
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -6730,15 +6180,12 @@ fn symbolic_jump_dead_argument_behind_depth_two() {
         mf.get_entry_mut().push_parameter(d, Type::field());
         let entry = mf.get_entry_mut();
         for (res, args) in [(r1, vec![a, c]), (r2, vec![a, d]), (r3, vec![b, c])] {
-            entry.push_instruction(Located::with(
-                OpCode::Call {
-                    results: vec![res],
-                    function: CallTarget::Static(f),
-                    args,
-                    unconstrained: false,
-                },
-                SourceLocation::test(),
-            ));
+            entry.push_test_instruction(OpCode::Call {
+                results: vec![res],
+                function: CallTarget::Static(f),
+                args,
+                unconstrained: false,
+            });
         }
         entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
     }
@@ -6771,33 +6218,27 @@ fn symbolic_jump_depth_over_cap_falls_back_to_calldet() {
         let hf = ssa.get_function_mut(f);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Add,
                 result: ft,
                 lhs: x,
                 rhs: c1,
-            },
-            SourceLocation::test(),
-        ));
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+            });
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Mul,
                 result: fu,
                 lhs: ft,
                 rhs: c2,
-            },
-            SourceLocation::test(),
-        ));
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+            });
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Add,
                 result: fa,
                 lhs: fu,
                 rhs: c3,
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -6814,44 +6255,32 @@ fn symbolic_jump_depth_over_cap_falls_back_to_calldet() {
         mf.get_entry_mut().push_parameter(b, Type::field());
         let entry = mf.get_entry_mut();
         for (res, arg) in [(r1, a), (r2, a), (r3, b)] {
-            entry.push_instruction(Located::with(
-                OpCode::Call {
-                    results: vec![res],
-                    function: CallTarget::Static(f),
-                    args: vec![arg],
-                    unconstrained: false,
-                },
-                SourceLocation::test(),
-            ));
+            entry.push_test_instruction(OpCode::Call {
+                results: vec![res],
+                function: CallTarget::Static(f),
+                args: vec![arg],
+                unconstrained: false,
+            });
         }
         // The caller-local `((a + 1) * 2) + 3`.
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: wt,
-                lhs: a,
-                rhs: c1,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Mul,
-                result: wu,
-                lhs: wt,
-                rhs: c2,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: w,
-                lhs: wu,
-                rhs: c3,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: wt,
+            lhs: a,
+            rhs: c1,
+        });
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Mul,
+            result: wu,
+            lhs: wt,
+            rhs: c2,
+        });
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: w,
+            lhs: wu,
+            rhs: c3,
+        });
         entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
     }
 
@@ -6878,15 +6307,13 @@ fn symbolic_jump_nested_call_falls_back_to_calldet() {
         let hf = ssa.get_function_mut(h);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(hx, Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Add,
                 result: hr,
                 lhs: hx,
                 rhs: c1,
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![hr]));
     }
@@ -6897,24 +6324,19 @@ fn symbolic_jump_nested_call_falls_back_to_calldet() {
         let gf = ssa.get_function_mut(g);
         gf.add_return_type(Type::field());
         gf.get_entry_mut().push_parameter(gx, Type::field());
-        gf.get_entry_mut().push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![gc],
-                function: CallTarget::Static(h),
-                args: vec![gx],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
-        gf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+        gf.get_entry_mut().push_test_instruction(OpCode::Call {
+            results: vec![gc],
+            function: CallTarget::Static(h),
+            args: vec![gx],
+            unconstrained: false,
+        });
+        gf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Add,
                 result: ga,
                 lhs: gc,
                 rhs: c1,
-            },
-            SourceLocation::test(),
-        ));
+            });
         gf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![ga]));
     }
@@ -6930,15 +6352,12 @@ fn symbolic_jump_nested_call_falls_back_to_calldet() {
         mf.get_entry_mut().push_parameter(b, Type::field());
         let entry = mf.get_entry_mut();
         for (res, arg) in [(r1, a), (r2, a), (r3, b)] {
-            entry.push_instruction(Located::with(
-                OpCode::Call {
-                    results: vec![res],
-                    function: CallTarget::Static(g),
-                    args: vec![arg],
-                    unconstrained: false,
-                },
-                SourceLocation::test(),
-            ));
+            entry.push_test_instruction(OpCode::Call {
+                results: vec![res],
+                function: CallTarget::Static(g),
+                args: vec![arg],
+                unconstrained: false,
+            });
         }
         entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
     }
@@ -6964,15 +6383,13 @@ fn symbolic_jump_preserves_noncommutativity() {
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
         hf.get_entry_mut().push_parameter(y, Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Sub,
                 result: fa,
                 lhs: x,
                 rhs: y,
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -6988,15 +6405,12 @@ fn symbolic_jump_preserves_noncommutativity() {
         mf.get_entry_mut().push_parameter(b, Type::field());
         let entry = mf.get_entry_mut();
         for (res, args) in [(r1, vec![a, b]), (r2, vec![b, a]), (r3, vec![a, b])] {
-            entry.push_instruction(Located::with(
-                OpCode::Call {
-                    results: vec![res],
-                    function: CallTarget::Static(f),
-                    args,
-                    unconstrained: false,
-                },
-                SourceLocation::test(),
-            ));
+            entry.push_test_instruction(OpCode::Call {
+                results: vec![res],
+                function: CallTarget::Static(f),
+                args,
+                unconstrained: false,
+            });
         }
         entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
     }
@@ -7021,22 +6435,18 @@ fn symbolic_jump_witness_operand_is_not_grafted() {
         let hf = ssa.get_function_mut(f);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::FreshWitness {
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::FreshWitness {
                 result: wit,
                 result_type: Type::field(),
-            },
-            SourceLocation::test(),
-        ));
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+            });
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Add,
                 result: fa,
                 lhs: x,
                 rhs: wit,
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -7050,15 +6460,12 @@ fn symbolic_jump_witness_operand_is_not_grafted() {
         mf.get_entry_mut().push_parameter(a, Type::field());
         let entry = mf.get_entry_mut();
         for res in [r1, r2] {
-            entry.push_instruction(Located::with(
-                OpCode::Call {
-                    results: vec![res],
-                    function: CallTarget::Static(f),
-                    args: vec![a],
-                    unconstrained: false,
-                },
-                SourceLocation::test(),
-            ));
+            entry.push_test_instruction(OpCode::Call {
+                results: vec![res],
+                function: CallTarget::Static(f),
+                args: vec![a],
+                unconstrained: false,
+            });
         }
         entry.set_terminator(Terminator::Return(vec![r1, r2]));
     }
@@ -7106,24 +6513,20 @@ fn symbolic_jump_synthetic_does_not_collide_with_callee_only_constant() {
         let hf = ssa.get_function_mut(f);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Mul,
                 result: ft,
                 lhs: x,
                 rhs: c,
-            },
-            SourceLocation::test(),
-        ));
-        hf.get_entry_mut().push_instruction(Located::with(
-            OpCode::BinaryArithOp {
+            });
+        hf.get_entry_mut()
+            .push_test_instruction(OpCode::BinaryArithOp {
                 kind: BinaryArithOpKind::Add,
                 result: fa,
                 lhs: x,
                 rhs: ft,
-            },
-            SourceLocation::test(),
-        ));
+            });
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -7135,35 +6538,26 @@ fn symbolic_jump_synthetic_does_not_collide_with_callee_only_constant() {
         mf.get_entry_mut().push_parameter(a, Type::field());
         let entry = mf.get_entry_mut();
         // v = 2 + 3, which folds to Field(5) — the same constant class as `c`.
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: v,
-                lhs: two,
-                rhs: three,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: v,
+            lhs: two,
+            rhs: three,
+        });
         // r = f(a)
-        entry.push_instruction(Located::with(
-            OpCode::Call {
-                results: vec![r],
-                function: CallTarget::Static(f),
-                args: vec![a],
-                unconstrained: false,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Call {
+            results: vec![r],
+            function: CallTarget::Static(f),
+            args: vec![a],
+            unconstrained: false,
+        });
         // w = a + v, a genuine `a + 5`.
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Add,
-                result: w,
-                lhs: a,
-                rhs: v,
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: w,
+            lhs: a,
+            rhs: v,
+        });
         entry.set_terminator(Terminator::Return(vec![r, w]));
     }
 

--- a/compiler/src/compiler/analysis/click_cooper/test.rs
+++ b/compiler/src/compiler/analysis/click_cooper/test.rs
@@ -1860,12 +1860,14 @@ fn anticipated_const_in_gains_from_pinned_branch() {
         hf.get_entry_mut().push_parameter(x, Type::u(32));
         hf.get_entry_mut()
             .set_terminator(Terminator::JmpIf(p, then_b, else_b));
-        hf.get_block_mut(then_b)
-            .push_instruction(OpCode::AssertCmp {
+        hf.get_block_mut(then_b).push_instruction(Located::with(
+            OpCode::AssertCmp {
                 kind: CmpKind::Eq,
                 lhs: x,
                 rhs: c5,
-            });
+            },
+            SourceLocation::test(),
+        ));
         hf.get_block_mut(then_b)
             .set_terminator(Terminator::Jmp(merge, vec![]));
         hf.get_block_mut(else_b)

--- a/compiler/src/compiler/analysis/click_cooper/test.rs
+++ b/compiler/src/compiler/analysis/click_cooper/test.rs
@@ -5,7 +5,7 @@ use crate::compiler::{
         types::Types,
     },
     ssa::{
-        FunctionId, ProgramPoint, Terminator,
+        FunctionId, Located, ProgramPoint, SourceLocation, Terminator,
         hlssa::{
             BinaryArithOpKind, Blob, CallTarget, CastTarget, CmpKind, Constant, HLSSA, OpCode,
             ScalarFold, SequenceTargetType, SliceOpDir, Type,
@@ -224,18 +224,24 @@ fn equal_constants_are_congruent() {
 
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: a,
-        lhs: c2,
-        rhs: c3,
-    });
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: b,
-        lhs: c1,
-        rhs: c4,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: c2,
+            rhs: c3,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: c1,
+            rhs: c4,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![a, b]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -263,30 +269,42 @@ fn structural_congruence_is_commutative() {
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(y, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: a,
-        lhs: x,
-        rhs: y,
-    });
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: b,
-        lhs: x,
-        rhs: y,
-    });
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: c,
-        lhs: y,
-        rhs: x,
-    });
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Sub,
-        result: d,
-        lhs: x,
-        rhs: y,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: y,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: y,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: c,
+            lhs: y,
+            rhs: x,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Sub,
+            result: d,
+            lhs: x,
+            rhs: y,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![a, b, c, d]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -324,47 +342,68 @@ fn array_ops_are_value_numbered() {
     f.get_entry_mut().push_parameter(j, Type::u(32));
     let entry = f.get_entry_mut();
     // g1, g2 are arr[i]; g3 is arr[j].
-    entry.push_instruction(OpCode::ArrayGet {
-        result: g1,
-        array: arr,
-        index: i,
-    });
-    entry.push_instruction(OpCode::ArrayGet {
-        result: g2,
-        array: arr,
-        index: i,
-    });
-    entry.push_instruction(OpCode::ArrayGet {
-        result: g3,
-        array: arr,
-        index: j,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: g1,
+            array: arr,
+            index: i,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: g2,
+            array: arr,
+            index: i,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: g3,
+            array: arr,
+            index: j,
+        },
+        SourceLocation::test(),
+    ));
     // s1 and s2 are the same array `[arr[i], arr[j]]` built twice — congruent elementwise.
-    entry.push_instruction(OpCode::MkSeq {
-        result: s1,
-        elems: vec![g1, g3],
-        seq_type: SequenceTargetType::Array(2),
-        elem_type: Type::field(),
-    });
-    entry.push_instruction(OpCode::MkSeq {
-        result: s2,
-        elems: vec![g2, g3],
-        seq_type: SequenceTargetType::Array(2),
-        elem_type: Type::field(),
-    });
+    entry.push_instruction(Located::with(
+        OpCode::MkSeq {
+            result: s1,
+            elems: vec![g1, g3],
+            seq_type: SequenceTargetType::Array(2),
+            elem_type: Type::field(),
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::MkSeq {
+            result: s2,
+            elems: vec![g2, g3],
+            seq_type: SequenceTargetType::Array(2),
+            elem_type: Type::field(),
+        },
+        SourceLocation::test(),
+    ));
     // s3 differs only in sequence kind (Slice), s4 only in element type (u32): neither merges.
-    entry.push_instruction(OpCode::MkSeq {
-        result: s3,
-        elems: vec![g1, g3],
-        seq_type: SequenceTargetType::Slice,
-        elem_type: Type::field(),
-    });
-    entry.push_instruction(OpCode::MkSeq {
-        result: s4,
-        elems: vec![g1, g3],
-        seq_type: SequenceTargetType::Array(2),
-        elem_type: Type::u(32),
-    });
+    entry.push_instruction(Located::with(
+        OpCode::MkSeq {
+            result: s3,
+            elems: vec![g1, g3],
+            seq_type: SequenceTargetType::Slice,
+            elem_type: Type::field(),
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::MkSeq {
+            result: s4,
+            elems: vec![g1, g3],
+            seq_type: SequenceTargetType::Array(2),
+            elem_type: Type::u(32),
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![g1, g2, g3, s1, s2, s3, s4]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -474,26 +513,35 @@ fn loop_carried_parallel_induction_is_congruent() {
     let header_block = f.get_block_mut(header);
     header_block.push_parameter(i, Type::u(32));
     header_block.push_parameter(j, Type::u(32));
-    header_block.push_instruction(OpCode::Cmp {
-        kind: CmpKind::Lt,
-        result: lt,
-        lhs: i,
-        rhs: c10,
-    });
+    header_block.push_instruction(Located::with(
+        OpCode::Cmp {
+            kind: CmpKind::Lt,
+            result: lt,
+            lhs: i,
+            rhs: c10,
+        },
+        SourceLocation::test(),
+    ));
     header_block.set_terminator(Terminator::JmpIf(lt, body, exit));
     let body_block = f.get_block_mut(body);
-    body_block.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: i2,
-        lhs: i,
-        rhs: c1,
-    });
-    body_block.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: j2,
-        lhs: j,
-        rhs: c1,
-    });
+    body_block.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: i2,
+            lhs: i,
+            rhs: c1,
+        },
+        SourceLocation::test(),
+    ));
+    body_block.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: j2,
+            lhs: j,
+            rhs: c1,
+        },
+        SourceLocation::test(),
+    ));
     body_block.set_terminator(Terminator::Jmp(header, vec![i2, j2]));
     f.get_block_mut(exit)
         .set_terminator(Terminator::Return(vec![i, j]));
@@ -529,21 +577,27 @@ fn leader_is_dominating_definition() {
     f.get_entry_mut().push_parameter(x, Type::field());
     f.get_entry_mut().push_parameter(y, Type::field());
     // `a = x + y` in the entry, recomputed as `b = x + y` in a strictly dominated block.
-    f.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: a,
-        lhs: x,
-        rhs: y,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: y,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(next, vec![]));
     let next_block = f.get_block_mut(next);
-    next_block.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: b,
-        lhs: x,
-        rhs: y,
-    });
+    next_block.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: y,
+        },
+        SourceLocation::test(),
+    ));
     next_block.set_terminator(Terminator::Return(vec![a, b]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -568,18 +622,24 @@ fn leader_is_earlier_in_block() {
     f.get_entry_mut().push_parameter(x, Type::field());
     f.get_entry_mut().push_parameter(y, Type::field());
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: a,
-        lhs: x,
-        rhs: y,
-    });
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: b,
-        lhs: x,
-        rhs: y,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: y,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: y,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![a, b]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -615,28 +675,37 @@ fn leader_never_crosses_incomparable_branches() {
         .set_terminator(Terminator::JmpIf(cond, e1, e2));
     // `x + y` recomputed in both incomparable branches and again at the merge.
     let e1_block = f.get_block_mut(e1);
-    e1_block.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: a,
-        lhs: x,
-        rhs: y,
-    });
+    e1_block.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: y,
+        },
+        SourceLocation::test(),
+    ));
     e1_block.set_terminator(Terminator::Jmp(merge, vec![]));
     let e2_block = f.get_block_mut(e2);
-    e2_block.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: b,
-        lhs: x,
-        rhs: y,
-    });
+    e2_block.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: y,
+        },
+        SourceLocation::test(),
+    ));
     e2_block.set_terminator(Terminator::Jmp(merge, vec![]));
     let merge_block = f.get_block_mut(merge);
-    merge_block.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: c,
-        lhs: x,
-        rhs: y,
-    });
+    merge_block.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: c,
+            lhs: x,
+            rhs: y,
+        },
+        SourceLocation::test(),
+    ));
     merge_block.set_terminator(Terminator::Return(vec![a, b, c]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -663,12 +732,15 @@ fn leader_of_constant_class_is_the_interned_constant() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
     // `a = 2 + 3` folds to 5, congruent to the interned constant `c5`.
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: a,
-        lhs: c2,
-        rhs: c3,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: c2,
+            rhs: c3,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![a, c5]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -690,11 +762,14 @@ fn assert_eq_const_is_conditional_not_unconditional() {
     let entry_id = f.get_entry_id();
     let after = f.add_block();
     f.get_entry_mut().push_parameter(x, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: c5,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c5,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(after, vec![]));
     f.get_block_mut(after)
@@ -736,8 +811,10 @@ fn assert_bool_is_conditional() {
     let entry_id = f.get_entry_id();
     let after = f.add_block();
     f.get_entry_mut().push_parameter(b, Type::u(1));
-    f.get_entry_mut()
-        .push_instruction(OpCode::Assert { value: b });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::Assert { value: b },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(after, vec![]));
     f.get_block_mut(after)
@@ -776,11 +853,14 @@ fn assert_eq_pure_equality_is_conditional() {
     let after = f.add_block();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(y, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: y,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: y,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(after, vec![]));
     f.get_block_mut(after)
@@ -814,19 +894,25 @@ fn asserted_leader_picks_dominating_member() {
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(mid, vec![]));
     let mid_block = f.get_block_mut(mid);
-    mid_block.push_instruction(OpCode::BinaryArithOp {
-        // index 0: def(b) in mid, dominated by entry
-        kind: BinaryArithOpKind::Add,
-        result: b,
-        lhs: a,
-        rhs: a,
-    });
-    mid_block.push_instruction(OpCode::AssertCmp {
-        // index 1: a == b (neither constant ⇒ an equality pair)
-        kind: CmpKind::Eq,
-        lhs: a,
-        rhs: b,
-    });
+    mid_block.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            // index 0: def(b) in mid, dominated by entry
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: a,
+            rhs: a,
+        },
+        SourceLocation::test(),
+    ));
+    mid_block.push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 1: a == b (neither constant ⇒ an equality pair)
+            kind: CmpKind::Eq,
+            lhs: a,
+            rhs: b,
+        },
+        SourceLocation::test(),
+    ));
     mid_block.set_terminator(Terminator::Return(vec![])); // index 2
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -860,18 +946,24 @@ fn asserted_leader_is_transitive() {
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(b, Type::u(32));
     f.get_entry_mut().push_parameter(c, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // index 0: a == b
-        kind: CmpKind::Eq,
-        lhs: a,
-        rhs: b,
-    });
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // index 1: b == c
-        kind: CmpKind::Eq,
-        lhs: b,
-        rhs: c,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 0: a == b
+            kind: CmpKind::Eq,
+            lhs: a,
+            rhs: b,
+        },
+        SourceLocation::test(),
+    ));
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 1: b == c
+            kind: CmpKind::Eq,
+            lhs: b,
+            rhs: c,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut().set_terminator(Terminator::Return(vec![])); // index 2
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -904,12 +996,15 @@ fn asserted_leader_index_granular() {
     let after = f.add_block();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(y, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // index 0
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: y,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 0
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: y,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(after, vec![])); // index 1
     f.get_block_mut(after)
@@ -964,12 +1059,15 @@ fn asserted_leader_respects_dominance_fanout() {
     f.get_entry_mut().push_parameter(y, Type::u(32));
     f.get_entry_mut()
         .set_terminator(Terminator::JmpIf(cond, then_b, else_b));
-    f.get_block_mut(then_b).push_instruction(OpCode::AssertCmp {
-        // index 0: x == y, only on the `then` branch
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: y,
-    });
+    f.get_block_mut(then_b).push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 0: x == y, only on the `then` branch
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: y,
+        },
+        SourceLocation::test(),
+    ));
     f.get_block_mut(then_b)
         .set_terminator(Terminator::Jmp(merge, vec![]));
     f.get_block_mut(else_b)
@@ -1020,12 +1118,15 @@ fn asserted_leader_none_without_equality() {
     let entry_id = f.get_entry_id();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(z, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // index 0: x == 5 — a constant pin, not an equality pair
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: c5,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 0: x == 5 — a constant pin, not an equality pair
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c5,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut().set_terminator(Terminator::Return(vec![])); // index 1
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -1054,12 +1155,15 @@ fn asserted_leader_none_for_non_pair_value_amid_classes() {
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(b, Type::u(32));
     f.get_entry_mut().push_parameter(z, Type::u(32)); // never in any assert
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // index 0: a == b — a real equality pair, so the function has a non-empty `def_key`
-        kind: CmpKind::Eq,
-        lhs: a,
-        rhs: b,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 0: a == b — a real equality pair, so the function has a non-empty `def_key`
+            kind: CmpKind::Eq,
+            lhs: a,
+            rhs: b,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut().set_terminator(Terminator::Return(vec![])); // index 1
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -1086,18 +1190,24 @@ fn asserted_leader_multi_threshold_same_block() {
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(c, Type::u(32));
     f.get_entry_mut().push_parameter(d, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // index 0: c == d ⇒ class {c, d}, leader c
-        kind: CmpKind::Eq,
-        lhs: c,
-        rhs: d,
-    });
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // index 1: a == c ⇒ merges into {a, c, d}, leader a
-        kind: CmpKind::Eq,
-        lhs: a,
-        rhs: c,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 0: c == d ⇒ class {c, d}, leader c
+            kind: CmpKind::Eq,
+            lhs: c,
+            rhs: d,
+        },
+        SourceLocation::test(),
+    ));
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 1: a == c ⇒ merges into {a, c, d}, leader a
+            kind: CmpKind::Eq,
+            lhs: a,
+            rhs: c,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut().set_terminator(Terminator::Return(vec![])); // index 2
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -1137,26 +1247,35 @@ fn asserted_leader_local_merges_two_cross_classes() {
     f.get_entry_mut().push_parameter(b, Type::u(32));
     f.get_entry_mut().push_parameter(c, Type::u(32));
     f.get_entry_mut().push_parameter(d, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // index 0: a == b ⇒ dominating class {a, b}
-        kind: CmpKind::Eq,
-        lhs: a,
-        rhs: b,
-    });
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // index 1: c == d ⇒ dominating class {c, d}
-        kind: CmpKind::Eq,
-        lhs: c,
-        rhs: d,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 0: a == b ⇒ dominating class {a, b}
+            kind: CmpKind::Eq,
+            lhs: a,
+            rhs: b,
+        },
+        SourceLocation::test(),
+    ));
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 1: c == d ⇒ dominating class {c, d}
+            kind: CmpKind::Eq,
+            lhs: c,
+            rhs: d,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(mid, vec![])); // index 2
-    f.get_block_mut(mid).push_instruction(OpCode::AssertCmp {
-        // index 0 (in `mid`): b == c ⇒ merges the two cross classes into {a, b, c, d}
-        kind: CmpKind::Eq,
-        lhs: b,
-        rhs: c,
-    });
+    f.get_block_mut(mid).push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 0 (in `mid`): b == c ⇒ merges the two cross classes into {a, b, c, d}
+            kind: CmpKind::Eq,
+            lhs: b,
+            rhs: c,
+        },
+        SourceLocation::test(),
+    ));
     f.get_block_mut(mid)
         .set_terminator(Terminator::Return(vec![])); // index 1
 
@@ -1190,12 +1309,15 @@ fn disequality_from_false_edge() {
     let after = f.add_block();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(y, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::Cmp {
-        kind: CmpKind::Eq,
-        result: eq,
-        lhs: x,
-        rhs: y,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: x,
+            rhs: y,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut()
         .set_terminator(Terminator::JmpIf(eq, then_b, else_b));
     f.get_block_mut(then_b)
@@ -1228,21 +1350,30 @@ fn unpinned_witness_forwards_distinct_not_merged() {
     f.get_entry_mut().push_parameter(v1, Type::u(32));
     f.get_entry_mut().push_parameter(v2, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::WriteWitness {
-        result: Some(r1),
-        value: v1,
-        pinned: false,
-    });
-    entry.push_instruction(OpCode::WriteWitness {
-        result: Some(r2),
-        value: v2,
-        pinned: false,
-    });
-    entry.push_instruction(OpCode::WriteWitness {
-        result: Some(rp),
-        value: v1,
-        pinned: true,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::WriteWitness {
+            result: Some(r1),
+            value: v1,
+            pinned: false,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::WriteWitness {
+            result: Some(r2),
+            value: v2,
+            pinned: false,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::WriteWitness {
+            result: Some(rp),
+            value: v1,
+            pinned: true,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -1269,28 +1400,40 @@ fn witness_forward_unions_hint_and_value_of_reads() {
     f.get_entry_mut().push_parameter(v, Type::u(32));
     f.get_entry_mut().push_parameter(v2, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::WriteWitness {
-        result: Some(r),
-        value: v,
-        pinned: false,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::WriteWitness {
+            result: Some(r),
+            value: v,
+            pinned: false,
+        },
+        SourceLocation::test(),
+    ));
     // `value_of(r)` strips r's witness wrapper: w1, w2 are honestly equal to r. Two separate
     // reads stay distinct (ValueOf is excluded from value-numbering), so both join r's set.
-    entry.push_instruction(OpCode::Cast {
-        result: w1,
-        value: r,
-        target: CastTarget::ValueOf,
-    });
-    entry.push_instruction(OpCode::Cast {
-        result: w2,
-        value: r,
-        target: CastTarget::ValueOf,
-    });
-    entry.push_instruction(OpCode::WriteWitness {
-        result: Some(r2),
-        value: v2,
-        pinned: false,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::Cast {
+            result: w1,
+            value: r,
+            target: CastTarget::ValueOf,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::Cast {
+            result: w2,
+            value: r,
+            target: CastTarget::ValueOf,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::WriteWitness {
+            result: Some(r2),
+            value: v2,
+            pinned: false,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -1328,11 +1471,14 @@ fn post_dominance_not_propagated_at_block_granularity() {
         .set_terminator(Terminator::Jmp(mid, vec![]));
     f.get_block_mut(mid)
         .set_terminator(Terminator::Jmp(tail, vec![]));
-    f.get_block_mut(tail).push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: c5,
-    });
+    f.get_block_mut(tail).push_instruction(Located::with(
+        OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c5,
+        },
+        SourceLocation::test(),
+    ));
     f.get_block_mut(tail)
         .set_terminator(Terminator::Return(vec![]));
 
@@ -1402,32 +1548,44 @@ fn post_dominating_assert_unsound_for_loop_carried_value() {
         .set_terminator(Terminator::Jmp(header, vec![c0]));
     let header_block = f.get_block_mut(header);
     header_block.push_parameter(v, Type::u(32));
-    header_block.push_instruction(OpCode::Cmp {
-        kind: CmpKind::Lt,
-        result: lt,
-        lhs: v,
-        rhs: c10,
-    });
+    header_block.push_instruction(Located::with(
+        OpCode::Cmp {
+            kind: CmpKind::Lt,
+            result: lt,
+            lhs: v,
+            rhs: c10,
+        },
+        SourceLocation::test(),
+    ));
     header_block.set_terminator(Terminator::JmpIf(lt, body, after));
     let body_block = f.get_block_mut(body);
-    body_block.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: v1,
-        lhs: v,
-        rhs: c1,
-    });
+    body_block.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: v1,
+            lhs: v,
+            rhs: c1,
+        },
+        SourceLocation::test(),
+    ));
     body_block.set_terminator(Terminator::Jmp(header, vec![v1]));
     let after_block = f.get_block_mut(after);
-    after_block.push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: v,
-        rhs: c10,
-    });
-    after_block.push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: s,
-        rhs: c5,
-    });
+    after_block.push_instruction(Located::with(
+        OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: v,
+            rhs: c10,
+        },
+        SourceLocation::test(),
+    ));
+    after_block.push_instruction(Located::with(
+        OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: s,
+            rhs: c5,
+        },
+        SourceLocation::test(),
+    ));
     after_block.set_terminator(Terminator::Return(vec![]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -1485,11 +1643,14 @@ fn assert_on_one_branch_does_not_post_dominate() {
     f.get_entry_mut()
         .set_terminator(Terminator::JmpIf(cond, then_b, else_b));
     // The assert lives only on the `then` branch.
-    f.get_block_mut(then_b).push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: c5,
-    });
+    f.get_block_mut(then_b).push_instruction(Located::with(
+        OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c5,
+        },
+        SourceLocation::test(),
+    ));
     f.get_block_mut(then_b)
         .set_terminator(Terminator::Jmp(merge, vec![]));
     f.get_block_mut(else_b)
@@ -3503,19 +3664,25 @@ fn local_assert_reaches_terminator_use() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry_id = f.get_entry_id();
     f.get_entry_mut().push_parameter(x, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // index 0
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: c5,
-    });
-    f.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-        // index 1
-        kind: BinaryArithOpKind::Add,
-        result: doubled,
-        lhs: x,
-        rhs: x,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 0
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c5,
+        },
+        SourceLocation::test(),
+    ));
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            // index 1
+            kind: BinaryArithOpKind::Add,
+            result: doubled,
+            lhs: x,
+            rhs: x,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut()
         .set_terminator(Terminator::Return(vec![doubled])); // terminator: index 2
 
@@ -3557,18 +3724,24 @@ fn multiple_local_asserts_each_recovered_after_its_index() {
     let entry_id = f.get_entry_id();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(y, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // index 0: x == 5
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: c5,
-    });
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // index 1: y == 6
-        kind: CmpKind::Eq,
-        lhs: y,
-        rhs: c6,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 0: x == 5
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c5,
+        },
+        SourceLocation::test(),
+    ));
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 1: y == 6
+            kind: CmpKind::Eq,
+            lhs: y,
+            rhs: c6,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut().set_terminator(Terminator::Return(vec![]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -3609,18 +3782,24 @@ fn contradictory_local_asserts_first_writer_wins() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry_id = f.get_entry_id();
     f.get_entry_mut().push_parameter(x, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // index 0: x == 5
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: c5,
-    });
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // index 1: x == 7
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: c7,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 0: x == 5
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c5,
+        },
+        SourceLocation::test(),
+    ));
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 1: x == 7
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c7,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut().set_terminator(Terminator::Return(vec![]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -3660,27 +3839,36 @@ fn entry_and_local_assert_facts_layer() {
     let inner = f.add_block();
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(b, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // outer: a == 5
-        kind: CmpKind::Eq,
-        lhs: a,
-        rhs: c5,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // outer: a == 5
+            kind: CmpKind::Eq,
+            lhs: a,
+            rhs: c5,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(inner, vec![]));
     let inner_block = f.get_block_mut(inner);
-    inner_block.push_instruction(OpCode::AssertCmp {
-        // index 0: b == 6
-        kind: CmpKind::Eq,
-        lhs: b,
-        rhs: c6,
-    });
-    inner_block.push_instruction(OpCode::AssertCmp {
-        // index 1: a == 7 (contradicts the dominating outer assert)
-        kind: CmpKind::Eq,
-        lhs: a,
-        rhs: c7,
-    });
+    inner_block.push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 0: b == 6
+            kind: CmpKind::Eq,
+            lhs: b,
+            rhs: c6,
+        },
+        SourceLocation::test(),
+    ));
+    inner_block.push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 1: a == 7 (contradicts the dominating outer assert)
+            kind: CmpKind::Eq,
+            lhs: a,
+            rhs: c7,
+        },
+        SourceLocation::test(),
+    ));
     inner_block.set_terminator(Terminator::Return(vec![]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -3717,19 +3905,25 @@ fn local_assert_on_value_defined_earlier_in_block() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry_id = f.get_entry_id();
     f.get_entry_mut().push_parameter(p, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-        // index 0: y = p + p
-        kind: BinaryArithOpKind::Add,
-        result: y,
-        lhs: p,
-        rhs: p,
-    });
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        // index 1: y == 10
-        kind: CmpKind::Eq,
-        lhs: y,
-        rhs: c10,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            // index 0: y = p + p
+            kind: BinaryArithOpKind::Add,
+            result: y,
+            lhs: p,
+            rhs: p,
+        },
+        SourceLocation::test(),
+    ));
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 1: y == 10
+            kind: CmpKind::Eq,
+            lhs: y,
+            rhs: c10,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut()
         .set_terminator(Terminator::Return(vec![y])); // index 2
 
@@ -3770,29 +3964,38 @@ fn local_assert_in_loop_body() {
         .set_terminator(Terminator::Jmp(header, vec![c0]));
     let header_block = f.get_block_mut(header);
     header_block.push_parameter(i, Type::u(32));
-    header_block.push_instruction(OpCode::Cmp {
-        kind: CmpKind::Lt,
-        result: lt,
-        lhs: i,
-        rhs: n,
-    });
+    header_block.push_instruction(Located::with(
+        OpCode::Cmp {
+            kind: CmpKind::Lt,
+            result: lt,
+            lhs: i,
+            rhs: n,
+        },
+        SourceLocation::test(),
+    ));
     header_block.set_terminator(Terminator::JmpIf(lt, body, exit));
     let body_block = f.get_block_mut(body);
     // `next = i + 1` keeps `i` loop-variant (else it would fold to the constant 0 and the assert
     // would degrade to a constant pin rather than the pure equality this test exercises).
-    body_block.push_instruction(OpCode::BinaryArithOp {
-        // index 0
-        kind: BinaryArithOpKind::Add,
-        result: next,
-        lhs: i,
-        rhs: c1,
-    });
-    body_block.push_instruction(OpCode::AssertCmp {
-        // index 1: i == n
-        kind: CmpKind::Eq,
-        lhs: i,
-        rhs: n,
-    });
+    body_block.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            // index 0
+            kind: BinaryArithOpKind::Add,
+            result: next,
+            lhs: i,
+            rhs: c1,
+        },
+        SourceLocation::test(),
+    ));
+    body_block.push_instruction(Located::with(
+        OpCode::AssertCmp {
+            // index 1: i == n
+            kind: CmpKind::Eq,
+            lhs: i,
+            rhs: n,
+        },
+        SourceLocation::test(),
+    ));
     body_block.set_terminator(Terminator::Jmp(header, vec![next]));
     f.get_block_mut(exit)
         .set_terminator(Terminator::Return(vec![]));
@@ -3828,12 +4031,15 @@ fn interproc_constant_return_folds_at_call_site() {
         let mf = ssa.get_function_mut(main_id);
         mf.add_return_type(Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(OpCode::Call {
-            results: vec![r],
-            function: CallTarget::Static(helper),
-            args: vec![],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r],
+                function: CallTarget::Static(helper),
+                args: vec![],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -3868,12 +4074,15 @@ fn interproc_passthrough_seeds_param_and_result() {
         let mf = ssa.get_function_mut(main_id);
         mf.add_return_type(Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(OpCode::Call {
-            results: vec![r],
-            function: CallTarget::Static(id),
-            args: vec![c7],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r],
+                function: CallTarget::Static(id),
+                args: vec![c7],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -3914,24 +4123,33 @@ fn interproc_writeback_folds_congruent_comparison_return() {
         gf.add_return_type(Type::u(1));
         gf.get_entry_mut().push_parameter(x, Type::u(32));
         let entry = gf.get_entry_mut();
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: a,
-            lhs: x,
-            rhs: c1,
-        });
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: x,
-            rhs: c1,
-        });
-        entry.push_instruction(OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: eq,
-            lhs: a,
-            rhs: b,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: a,
+                lhs: x,
+                rhs: c1,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: b,
+                lhs: x,
+                rhs: c1,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Cmp {
+                kind: CmpKind::Eq,
+                result: eq,
+                lhs: a,
+                rhs: b,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![eq]));
     }
     {
@@ -3939,12 +4157,15 @@ fn interproc_writeback_folds_congruent_comparison_return() {
         mf.add_return_type(Type::u(1));
         mf.get_entry_mut().push_parameter(x0, Type::u(32));
         let entry = mf.get_entry_mut();
-        entry.push_instruction(OpCode::Call {
-            results: vec![r],
-            function: CallTarget::Static(g),
-            args: vec![x0],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r],
+                function: CallTarget::Static(g),
+                args: vec![x0],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -3983,24 +4204,33 @@ fn interproc_writeback_folds_congruent_comparison_in_context() {
         gf.add_return_type(Type::u(32));
         gf.get_entry_mut().push_parameter(x, Type::u(32));
         let entry = gf.get_entry_mut();
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: a,
-            lhs: x,
-            rhs: c1,
-        });
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: x,
-            rhs: c1,
-        });
-        entry.push_instruction(OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: eq,
-            lhs: a,
-            rhs: b,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: a,
+                lhs: x,
+                rhs: c1,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: b,
+                lhs: x,
+                rhs: c1,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Cmp {
+                kind: CmpKind::Eq,
+                result: eq,
+                lhs: a,
+                rhs: b,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![x]));
     }
     {
@@ -4008,12 +4238,15 @@ fn interproc_writeback_folds_congruent_comparison_in_context() {
         mf.add_return_type(Type::u(32));
         mf.get_entry_mut().push_parameter(x0, Type::u(32));
         let entry = mf.get_entry_mut();
-        entry.push_instruction(OpCode::Call {
-            results: vec![r],
-            function: CallTarget::Static(g),
-            args: vec![x0],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r],
+                function: CallTarget::Static(g),
+                args: vec![x0],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -4053,30 +4286,42 @@ fn interproc_writeback_terminates_under_recursion() {
         gf.add_return_type(Type::u(1));
         gf.get_entry_mut().push_parameter(x, Type::u(32));
         let entry = gf.get_entry_mut();
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: a,
-            lhs: x,
-            rhs: c1,
-        });
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: x,
-            rhs: c1,
-        });
-        entry.push_instruction(OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: eq,
-            lhs: a,
-            rhs: b,
-        });
-        entry.push_instruction(OpCode::Call {
-            results: vec![t],
-            function: CallTarget::Static(g),
-            args: vec![x],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: a,
+                lhs: x,
+                rhs: c1,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: b,
+                lhs: x,
+                rhs: c1,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Cmp {
+                kind: CmpKind::Eq,
+                result: eq,
+                lhs: a,
+                rhs: b,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![t],
+                function: CallTarget::Static(g),
+                args: vec![x],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![eq]));
     }
     {
@@ -4084,12 +4329,15 @@ fn interproc_writeback_terminates_under_recursion() {
         mf.add_return_type(Type::u(1));
         mf.get_entry_mut().push_parameter(x0, Type::u(32));
         let entry = mf.get_entry_mut();
-        entry.push_instruction(OpCode::Call {
-            results: vec![r],
-            function: CallTarget::Static(g),
-            args: vec![x0],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r],
+                function: CallTarget::Static(g),
+                args: vec![x0],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -4128,12 +4376,15 @@ fn context_parameterized_conditional_queries() {
         let mf = ssa.get_function_mut(main_id);
         mf.add_return_type(Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(OpCode::Call {
-            results: vec![r],
-            function: CallTarget::Static(id),
-            args: vec![c7],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r],
+                function: CallTarget::Static(id),
+                args: vec![c7],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -4167,11 +4418,14 @@ fn asserted_const_refines_per_context() {
         let after = hf.add_block();
         hf.get_entry_mut().push_parameter(x, Type::field());
         hf.get_entry_mut().push_parameter(p, Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::AssertCmp {
-            kind: CmpKind::Eq,
-            lhs: x,
-            rhs: p,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::AssertCmp {
+                kind: CmpKind::Eq,
+                lhs: x,
+                rhs: p,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Jmp(after, vec![]));
         hf.get_block_mut(after)
@@ -4182,12 +4436,15 @@ fn asserted_const_refines_per_context() {
         let mf = ssa.get_function_mut(main_id);
         let entry = mf.get_entry_mut();
         entry.push_parameter(x0, Type::field());
-        entry.push_instruction(OpCode::Call {
-            results: vec![],
-            function: CallTarget::Static(g),
-            args: vec![x0, c7],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![],
+                function: CallTarget::Static(g),
+                args: vec![x0, c7],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![]));
     }
 
@@ -4232,12 +4489,14 @@ fn witness_forward_in_prunes_context_dead_forward() {
         hf.get_block_mut(then_b)
             .set_terminator(Terminator::Jmp(after, vec![]));
         // The false arm establishes the forward `r → w`; it is dead once a context pins `p`.
-        hf.get_block_mut(else_b)
-            .push_instruction(OpCode::WriteWitness {
+        hf.get_block_mut(else_b).push_instruction(Located::with(
+            OpCode::WriteWitness {
                 result: Some(r),
                 value: w,
                 pinned: false,
-            });
+            },
+            SourceLocation::test(),
+        ));
         hf.get_block_mut(else_b)
             .set_terminator(Terminator::Jmp(after, vec![]));
         hf.get_block_mut(after)
@@ -4247,12 +4506,15 @@ fn witness_forward_in_prunes_context_dead_forward() {
         let mf = ssa.get_function_mut(main_id);
         let entry = mf.get_entry_mut();
         entry.push_parameter(w0, Type::u(32));
-        entry.push_instruction(OpCode::Call {
-            results: vec![],
-            function: CallTarget::Static(g),
-            args: vec![c_true, w0],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![],
+                function: CallTarget::Static(g),
+                args: vec![c_true, w0],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![]));
     }
 
@@ -4285,27 +4547,39 @@ fn conditional_queries_parity_under_empty_context() {
     for v in [x, a, b, d, e] {
         f.get_entry_mut().push_parameter(v, Type::u(32));
     }
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: c5,
-    });
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: a,
-        rhs: b,
-    });
-    f.get_entry_mut().push_instruction(OpCode::WriteWitness {
-        result: Some(r),
-        value: x,
-        pinned: false,
-    });
-    f.get_entry_mut().push_instruction(OpCode::Cmp {
-        kind: CmpKind::Eq,
-        result: eq,
-        lhs: d,
-        rhs: e,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c5,
+        },
+        SourceLocation::test(),
+    ));
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: a,
+            rhs: b,
+        },
+        SourceLocation::test(),
+    ));
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::WriteWitness {
+            result: Some(r),
+            value: x,
+            pinned: false,
+        },
+        SourceLocation::test(),
+    ));
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: d,
+            rhs: e,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut()
         .set_terminator(Terminator::JmpIf(eq, then_b, else_b));
     f.get_block_mut(then_b)
@@ -4438,12 +4712,15 @@ fn known_unequal_in_gains_from_pruned_predecessor() {
         hf.get_entry_mut().push_parameter(p, Type::u(1));
         hf.get_entry_mut().push_parameter(d, Type::u(32));
         hf.get_entry_mut().push_parameter(e, Type::u(32));
-        hf.get_entry_mut().push_instruction(OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: eq,
-            lhs: d,
-            rhs: e,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::Cmp {
+                kind: CmpKind::Eq,
+                result: eq,
+                lhs: d,
+                rhs: e,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::JmpIf(p, side, main_b));
         // `side` is `join`'s second predecessor; it dies once a context pins `p = false`.
@@ -4462,12 +4739,15 @@ fn known_unequal_in_gains_from_pruned_predecessor() {
         let entry = mf.get_entry_mut();
         entry.push_parameter(d0, Type::u(32));
         entry.push_parameter(e0, Type::u(32));
-        entry.push_instruction(OpCode::Call {
-            results: vec![],
-            function: CallTarget::Static(g),
-            args: vec![c_false, d0, e0],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![],
+                function: CallTarget::Static(g),
+                args: vec![c_false, d0, e0],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![]));
     }
 
@@ -4498,17 +4778,23 @@ fn asserted_const_never_aggregate() {
     f.get_entry_mut().push_parameter(x, Type::u(32).array_of(2));
     let entry = f.get_entry_mut();
     // `s` aggregate-folds to a lattice `Const(Blob)`, so the assert pins `x` to a Blob.
-    entry.push_instruction(OpCode::MkSeq {
-        result: s,
-        elems: vec![c0, c1],
-        seq_type: SequenceTargetType::Array(2),
-        elem_type: Type::u(32),
-    });
-    entry.push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: s,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::MkSeq {
+            result: s,
+            elems: vec![c0, c1],
+            seq_type: SequenceTargetType::Array(2),
+            elem_type: Type::u(32),
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: s,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Jmp(after, vec![]));
     f.get_block_mut(after)
         .set_terminator(Terminator::Return(vec![]));
@@ -4543,11 +4829,14 @@ fn asserted_const_in_never_aggregate() {
             .push_parameter(a, Type::u(32).array_of(2));
         hf.get_entry_mut()
             .push_parameter(x, Type::u(32).array_of(2));
-        hf.get_entry_mut().push_instruction(OpCode::AssertCmp {
-            kind: CmpKind::Eq,
-            lhs: x,
-            rhs: a,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::AssertCmp {
+                kind: CmpKind::Eq,
+                lhs: x,
+                rhs: a,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Jmp(after, vec![]));
         hf.get_block_mut(after)
@@ -4558,18 +4847,24 @@ fn asserted_const_in_never_aggregate() {
         let mf = ssa.get_function_mut(main_id);
         let entry = mf.get_entry_mut();
         entry.push_parameter(y, Type::u(32).array_of(2));
-        entry.push_instruction(OpCode::MkSeq {
-            result: s,
-            elems: vec![c0, c1],
-            seq_type: SequenceTargetType::Array(2),
-            elem_type: Type::u(32),
-        });
-        entry.push_instruction(OpCode::Call {
-            results: vec![],
-            function: CallTarget::Static(g),
-            args: vec![s, y],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::MkSeq {
+                result: s,
+                elems: vec![c0, c1],
+                seq_type: SequenceTargetType::Array(2),
+                elem_type: Type::u(32),
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![],
+                function: CallTarget::Static(g),
+                args: vec![s, y],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![]));
     }
 
@@ -4601,11 +4896,14 @@ fn asserted_const_migrates_to_unconditional_channel() {
         let hf = ssa.get_function_mut(g);
         let after = hf.add_block();
         hf.get_entry_mut().push_parameter(x, Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::AssertCmp {
-            kind: CmpKind::Eq,
-            lhs: x,
-            rhs: c7,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::AssertCmp {
+                kind: CmpKind::Eq,
+                lhs: x,
+                rhs: c7,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Jmp(after, vec![]));
         hf.get_block_mut(after)
@@ -4615,12 +4913,15 @@ fn asserted_const_migrates_to_unconditional_channel() {
     {
         let mf = ssa.get_function_mut(main_id);
         let entry = mf.get_entry_mut();
-        entry.push_instruction(OpCode::Call {
-            results: vec![],
-            function: CallTarget::Static(g),
-            args: vec![c7],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![],
+                function: CallTarget::Static(g),
+                args: vec![c7],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![]));
     }
 
@@ -4675,12 +4976,15 @@ fn context_constant_can_split_congruence() {
         let hf = ssa.get_function_mut(g);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(p, Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Mul,
-            result: m,
-            lhs: p,
-            rhs: c3,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Mul,
+                result: m,
+                lhs: p,
+                rhs: c3,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![m]));
     }
@@ -4692,34 +4996,45 @@ fn context_constant_can_split_congruence() {
         let after = hf.add_block();
         hf.get_entry_mut().push_parameter(a, Type::field());
         hf.get_entry_mut().push_parameter(w, Type::u(32));
-        hf.get_entry_mut().push_instruction(OpCode::Call {
-            results: vec![x],
-            function: CallTarget::Static(g),
-            args: vec![a],
-            unconstrained: false,
-        });
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Mul,
-            result: y,
-            lhs: a,
-            rhs: c3,
-        });
-        hf.get_entry_mut().push_instruction(OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: eq,
-            lhs: x,
-            rhs: y,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![x],
+                function: CallTarget::Static(g),
+                args: vec![a],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Mul,
+                result: y,
+                lhs: a,
+                rhs: c3,
+            },
+            SourceLocation::test(),
+        ));
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::Cmp {
+                kind: CmpKind::Eq,
+                result: eq,
+                lhs: x,
+                rhs: y,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::JmpIf(eq, then_b, else_b));
         hf.get_block_mut(then_b)
             .set_terminator(Terminator::Jmp(after, vec![]));
-        hf.get_block_mut(else_b)
-            .push_instruction(OpCode::WriteWitness {
+        hf.get_block_mut(else_b).push_instruction(Located::with(
+            OpCode::WriteWitness {
                 result: Some(r),
                 value: w,
                 pinned: false,
-            });
+            },
+            SourceLocation::test(),
+        ));
         hf.get_block_mut(else_b)
             .set_terminator(Terminator::Jmp(after, vec![]));
         hf.get_block_mut(after)
@@ -4729,12 +5044,15 @@ fn context_constant_can_split_congruence() {
         let mf = ssa.get_function_mut(main_id);
         let entry = mf.get_entry_mut();
         entry.push_parameter(w0, Type::u(32));
-        entry.push_instruction(OpCode::Call {
-            results: vec![],
-            function: CallTarget::Static(f),
-            args: vec![c5, w0],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![],
+                function: CallTarget::Static(f),
+                args: vec![c5, w0],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![]));
     }
 
@@ -4774,18 +5092,24 @@ fn interproc_two_call_sites_are_distinguished() {
         let mf = ssa.get_function_mut(main_id);
         mf.add_return_type(Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(OpCode::Call {
-            results: vec![r5],
-            function: CallTarget::Static(id),
-            args: vec![c5],
-            unconstrained: false,
-        });
-        entry.push_instruction(OpCode::Call {
-            results: vec![r7],
-            function: CallTarget::Static(id),
-            args: vec![c7],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r5],
+                function: CallTarget::Static(id),
+                args: vec![c5],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r7],
+                function: CallTarget::Static(id),
+                args: vec![c7],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r5, r7]));
     }
 
@@ -4830,18 +5154,24 @@ fn unconstrained_call_result_is_opaque() {
         mf.add_return_type(Type::field());
         mf.add_return_type(Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(OpCode::Call {
-            results: vec![r1],
-            function: CallTarget::Static(helper),
-            args: vec![],
-            unconstrained: true,
-        });
-        entry.push_instruction(OpCode::Call {
-            results: vec![r2],
-            function: CallTarget::Static(helper),
-            args: vec![],
-            unconstrained: true,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r1],
+                function: CallTarget::Static(helper),
+                args: vec![],
+                unconstrained: true,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r2],
+                function: CallTarget::Static(helper),
+                args: vec![],
+                unconstrained: true,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r1, r2]));
     }
 
@@ -4869,12 +5199,15 @@ fn cross_call_congruence_for_deterministic_callee() {
         let hf = ssa.get_function_mut(dbl);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(p, Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: psum,
-            lhs: p,
-            rhs: p,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: psum,
+                lhs: p,
+                rhs: p,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![psum]));
     }
@@ -4892,36 +5225,51 @@ fn cross_call_congruence_for_deterministic_callee() {
         mf.get_entry_mut().push_parameter(y, Type::field());
         let entry = mf.get_entry_mut();
         // `a` and `b` are structurally congruent (both `x + 1`); `y` is distinct.
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: a,
-            lhs: x,
-            rhs: c1,
-        });
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: x,
-            rhs: c1,
-        });
-        entry.push_instruction(OpCode::Call {
-            results: vec![r1],
-            function: CallTarget::Static(dbl),
-            args: vec![a],
-            unconstrained: false,
-        });
-        entry.push_instruction(OpCode::Call {
-            results: vec![r2],
-            function: CallTarget::Static(dbl),
-            args: vec![b],
-            unconstrained: false,
-        });
-        entry.push_instruction(OpCode::Call {
-            results: vec![r3],
-            function: CallTarget::Static(dbl),
-            args: vec![y],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: a,
+                lhs: x,
+                rhs: c1,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: b,
+                lhs: x,
+                rhs: c1,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r1],
+                function: CallTarget::Static(dbl),
+                args: vec![a],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r2],
+                function: CallTarget::Static(dbl),
+                args: vec![b],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r3],
+                function: CallTarget::Static(dbl),
+                args: vec![y],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
     }
 
@@ -4943,10 +5291,13 @@ fn cross_call_no_congruence_for_nondeterministic_callee() {
     {
         let hf = ssa.get_function_mut(rnd);
         hf.add_return_type(Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::FreshWitness {
-            result: w,
-            result_type: Type::field(),
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::FreshWitness {
+                result: w,
+                result_type: Type::field(),
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![w]));
     }
@@ -4956,18 +5307,24 @@ fn cross_call_no_congruence_for_nondeterministic_callee() {
         mf.add_return_type(Type::field());
         mf.add_return_type(Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(OpCode::Call {
-            results: vec![r1],
-            function: CallTarget::Static(rnd),
-            args: vec![],
-            unconstrained: false,
-        });
-        entry.push_instruction(OpCode::Call {
-            results: vec![r2],
-            function: CallTarget::Static(rnd),
-            args: vec![],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r1],
+                function: CallTarget::Static(rnd),
+                args: vec![],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r2],
+                function: CallTarget::Static(rnd),
+                args: vec![],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r1, r2]));
     }
 
@@ -4990,12 +5347,15 @@ fn cross_call_congruence_is_transitive() {
         let hf = ssa.get_function_mut(inner);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(ip, Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: isum,
-            lhs: ip,
-            rhs: ip,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: isum,
+                lhs: ip,
+                rhs: ip,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![isum]));
     }
@@ -5005,12 +5365,15 @@ fn cross_call_congruence_is_transitive() {
         let hf = ssa.get_function_mut(outer);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(op, Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::Call {
-            results: vec![ores],
-            function: CallTarget::Static(inner),
-            args: vec![op],
-            unconstrained: false,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![ores],
+                function: CallTarget::Static(inner),
+                args: vec![op],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![ores]));
     }
@@ -5025,30 +5388,42 @@ fn cross_call_congruence_is_transitive() {
         mf.add_return_type(Type::field());
         mf.get_entry_mut().push_parameter(x, Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: a,
-            lhs: x,
-            rhs: c1,
-        });
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: b,
-            lhs: x,
-            rhs: c1,
-        });
-        entry.push_instruction(OpCode::Call {
-            results: vec![r1],
-            function: CallTarget::Static(outer),
-            args: vec![a],
-            unconstrained: false,
-        });
-        entry.push_instruction(OpCode::Call {
-            results: vec![r2],
-            function: CallTarget::Static(outer),
-            args: vec![b],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: a,
+                lhs: x,
+                rhs: c1,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: b,
+                lhs: x,
+                rhs: c1,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r1],
+                function: CallTarget::Static(outer),
+                args: vec![a],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r2],
+                function: CallTarget::Static(outer),
+                args: vec![b],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r1, r2]));
     }
 
@@ -5075,11 +5450,14 @@ fn cross_call_congruence_for_array_returning_callee() {
         hf.add_return_type(Type::field());
         hf.get_entry_mut()
             .push_parameter(p, Type::field().array_of(1));
-        hf.get_entry_mut().push_instruction(OpCode::ArrayGet {
-            result: elem,
-            array: p,
-            index: c0,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::ArrayGet {
+                result: elem,
+                array: p,
+                index: c0,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![elem]));
     }
@@ -5096,42 +5474,60 @@ fn cross_call_congruence_for_array_returning_callee() {
         mf.get_entry_mut().push_parameter(y, Type::field());
         let entry = mf.get_entry_mut();
         // `a` and `b` are congruent single-element arrays (`[x]`); `d` is `[y]`.
-        entry.push_instruction(OpCode::MkSeq {
-            result: a,
-            elems: vec![x],
-            seq_type: SequenceTargetType::Array(1),
-            elem_type: Type::field(),
-        });
-        entry.push_instruction(OpCode::MkSeq {
-            result: b,
-            elems: vec![x],
-            seq_type: SequenceTargetType::Array(1),
-            elem_type: Type::field(),
-        });
-        entry.push_instruction(OpCode::MkSeq {
-            result: d,
-            elems: vec![y],
-            seq_type: SequenceTargetType::Array(1),
-            elem_type: Type::field(),
-        });
-        entry.push_instruction(OpCode::Call {
-            results: vec![r1],
-            function: CallTarget::Static(pick),
-            args: vec![a],
-            unconstrained: false,
-        });
-        entry.push_instruction(OpCode::Call {
-            results: vec![r2],
-            function: CallTarget::Static(pick),
-            args: vec![b],
-            unconstrained: false,
-        });
-        entry.push_instruction(OpCode::Call {
-            results: vec![r3],
-            function: CallTarget::Static(pick),
-            args: vec![d],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::MkSeq {
+                result: a,
+                elems: vec![x],
+                seq_type: SequenceTargetType::Array(1),
+                elem_type: Type::field(),
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::MkSeq {
+                result: b,
+                elems: vec![x],
+                seq_type: SequenceTargetType::Array(1),
+                elem_type: Type::field(),
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::MkSeq {
+                result: d,
+                elems: vec![y],
+                seq_type: SequenceTargetType::Array(1),
+                elem_type: Type::field(),
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r1],
+                function: CallTarget::Static(pick),
+                args: vec![a],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r2],
+                function: CallTarget::Static(pick),
+                args: vec![b],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r3],
+                function: CallTarget::Static(pick),
+                args: vec![d],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
     }
 
@@ -5161,24 +5557,33 @@ fn cmp_eq_of_congruent_operands_folds_and_prunes_dead_edge() {
     f.get_entry_mut().push_parameter(x, Type::u(32));
     let entry = f.get_entry_mut();
     // a = x + 1 and b = x + 1 are structurally congruent but not constant.
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: a,
-        lhs: x,
-        rhs: c1,
-    });
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: b,
-        lhs: x,
-        rhs: c1,
-    });
-    entry.push_instruction(OpCode::Cmp {
-        kind: CmpKind::Eq,
-        result: eq,
-        lhs: a,
-        rhs: b,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: c1,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: c1,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: a,
+            rhs: b,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::JmpIf(eq, then_b, else_b));
     f.get_block_mut(then_b)
         .set_terminator(Terminator::Return(vec![a]));
@@ -5222,24 +5627,33 @@ fn writeback_cascades_to_downstream_constant() {
     let merge = f.add_block();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: a,
-        lhs: x,
-        rhs: c1,
-    });
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: b,
-        lhs: x,
-        rhs: c1,
-    });
-    entry.push_instruction(OpCode::Cmp {
-        kind: CmpKind::Eq,
-        result: eq,
-        lhs: a,
-        rhs: b,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: c1,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: c1,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: a,
+            rhs: b,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::JmpIf(eq, then_b, else_b));
     // The dead else-edge would carry a different constant, forcing the merge to ⊥ under SCCP
     // alone.
@@ -5271,12 +5685,15 @@ fn cmp_eq_of_noncongruent_operands_is_not_folded() {
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(y, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::Cmp {
-        kind: CmpKind::Eq,
-        result: eq,
-        lhs: x,
-        rhs: y,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: x,
+            rhs: y,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::JmpIf(eq, then_b, else_b));
     f.get_block_mut(then_b)
         .set_terminator(Terminator::Return(vec![x]));
@@ -5301,20 +5718,29 @@ fn free_witnesses_are_not_congruent_so_comparison_not_folded() {
 
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::FreshWitness {
-        result: w1,
-        result_type: Type::field(),
-    });
-    entry.push_instruction(OpCode::FreshWitness {
-        result: w2,
-        result_type: Type::field(),
-    });
-    entry.push_instruction(OpCode::Cmp {
-        kind: CmpKind::Eq,
-        result: eq,
-        lhs: w1,
-        rhs: w2,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::FreshWitness {
+            result: w1,
+            result_type: Type::field(),
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::FreshWitness {
+            result: w2,
+            result_type: Type::field(),
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: w1,
+            rhs: w2,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![eq]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -5335,12 +5761,15 @@ fn writeback_is_noop_without_congruent_comparison() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
     entry.push_parameter(x, Type::u(32));
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: a,
-        lhs: x,
-        rhs: c1,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: c1,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![a]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -5365,24 +5794,33 @@ fn cmp_lt_of_congruent_operands_folds_false() {
     let f = ssa.get_unique_entrypoint_mut();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: a,
-        lhs: x,
-        rhs: c1,
-    });
-    entry.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: b,
-        lhs: x,
-        rhs: c1,
-    });
-    entry.push_instruction(OpCode::Cmp {
-        kind: CmpKind::Lt,
-        result: lt,
-        lhs: a,
-        rhs: b,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: a,
+            lhs: x,
+            rhs: c1,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: b,
+            lhs: x,
+            rhs: c1,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::Cmp {
+            kind: CmpKind::Lt,
+            result: lt,
+            lhs: a,
+            rhs: b,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![lt]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -5411,19 +5849,25 @@ fn witnessed_comparison_of_congruent_operands_is_promoted() {
     entry.push_parameter(w, Type::witness_of(Type::u(32)));
     entry.push_parameter(n, Type::u(32));
     // Witnessed comparison: an operand is `WitnessOf`, so the result is `WitnessOf(u1)`.
-    entry.push_instruction(OpCode::Cmp {
-        kind: CmpKind::Eq,
-        result: ww,
-        lhs: w,
-        rhs: w,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: ww,
+            lhs: w,
+            rhs: w,
+        },
+        SourceLocation::test(),
+    ));
     // Plain comparison: result is `u1`.
-    entry.push_instruction(OpCode::Cmp {
-        kind: CmpKind::Eq,
-        result: nn,
-        lhs: n,
-        rhs: n,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: nn,
+            lhs: n,
+            rhs: n,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![ww, nn]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -5465,32 +5909,44 @@ fn loop_carried_congruent_comparison_folds_true() {
     let header_block = f.get_block_mut(header);
     header_block.push_parameter(i, Type::u(32));
     header_block.push_parameter(j, Type::u(32));
-    header_block.push_instruction(OpCode::Cmp {
-        kind: CmpKind::Eq,
-        result: eq,
-        lhs: i,
-        rhs: j,
-    });
-    header_block.push_instruction(OpCode::Cmp {
-        kind: CmpKind::Lt,
-        result: lt,
-        lhs: i,
-        rhs: c10,
-    });
+    header_block.push_instruction(Located::with(
+        OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: i,
+            rhs: j,
+        },
+        SourceLocation::test(),
+    ));
+    header_block.push_instruction(Located::with(
+        OpCode::Cmp {
+            kind: CmpKind::Lt,
+            result: lt,
+            lhs: i,
+            rhs: c10,
+        },
+        SourceLocation::test(),
+    ));
     header_block.set_terminator(Terminator::JmpIf(lt, body, exit));
     let body_block = f.get_block_mut(body);
-    body_block.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: i2,
-        lhs: i,
-        rhs: c1,
-    });
-    body_block.push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: j2,
-        lhs: j,
-        rhs: c1,
-    });
+    body_block.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: i2,
+            lhs: i,
+            rhs: c1,
+        },
+        SourceLocation::test(),
+    ));
+    body_block.push_instruction(Located::with(
+        OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: j2,
+            lhs: j,
+            rhs: c1,
+        },
+        SourceLocation::test(),
+    ));
     body_block.set_terminator(Terminator::Jmp(header, vec![i2, j2]));
     f.get_block_mut(exit)
         .set_terminator(Terminator::Return(vec![i, j]));
@@ -5518,17 +5974,23 @@ fn const_array_get_folds_to_scalar() {
     let (seq, got) = (ssa.fresh_value(), ssa.fresh_value());
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
-    entry.push_instruction(OpCode::MkSeq {
-        result: seq,
-        elems: vec![c0, c1, c2],
-        seq_type: SequenceTargetType::Array(3),
-        elem_type: Type::u(32),
-    });
-    entry.push_instruction(OpCode::ArrayGet {
-        result: got,
-        array: seq,
-        index: idx,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::MkSeq {
+            result: seq,
+            elems: vec![c0, c1, c2],
+            seq_type: SequenceTargetType::Array(3),
+            elem_type: Type::u(32),
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: got,
+            array: seq,
+            index: idx,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![got]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -5556,22 +6018,31 @@ fn const_repeated_array_get_and_slice_len() {
     let (seq, got, len) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
-    entry.push_instruction(OpCode::MkRepeated {
-        result: seq,
-        element: elem,
-        seq_type: SequenceTargetType::Array(4),
-        count: 4,
-        elem_type: Type::u(32),
-    });
-    entry.push_instruction(OpCode::ArrayGet {
-        result: got,
-        array: seq,
-        index: idx,
-    });
-    entry.push_instruction(OpCode::SliceLen {
-        result: len,
-        slice: seq,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::MkRepeated {
+            result: seq,
+            element: elem,
+            seq_type: SequenceTargetType::Array(4),
+            count: 4,
+            elem_type: Type::u(32),
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: got,
+            array: seq,
+            index: idx,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::SliceLen {
+            result: len,
+            slice: seq,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![got, len]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -5600,28 +6071,40 @@ fn const_array_set_then_get() {
     );
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
-    entry.push_instruction(OpCode::MkSeq {
-        result: seq,
-        elems: vec![c0, c1, c2],
-        seq_type: SequenceTargetType::Array(3),
-        elem_type: Type::u(32),
-    });
-    entry.push_instruction(OpCode::ArraySet {
-        result: seq2,
-        array: seq,
-        index: idx1,
-        value: new_val,
-    });
-    entry.push_instruction(OpCode::ArrayGet {
-        result: at_set,
-        array: seq2,
-        index: idx1,
-    });
-    entry.push_instruction(OpCode::ArrayGet {
-        result: at_orig,
-        array: seq2,
-        index: idx0,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::MkSeq {
+            result: seq,
+            elems: vec![c0, c1, c2],
+            seq_type: SequenceTargetType::Array(3),
+            elem_type: Type::u(32),
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArraySet {
+            result: seq2,
+            array: seq,
+            index: idx1,
+            value: new_val,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: at_set,
+            array: seq2,
+            index: idx1,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: at_orig,
+            array: seq2,
+            index: idx0,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![at_set, at_orig]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -5655,36 +6138,51 @@ fn const_slice_push_front_and_back() {
     );
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
-    entry.push_instruction(OpCode::MkSeq {
-        result: base,
-        elems: vec![mid],
-        seq_type: SequenceTargetType::Slice,
-        elem_type: Type::u(32),
-    });
+    entry.push_instruction(Located::with(
+        OpCode::MkSeq {
+            result: base,
+            elems: vec![mid],
+            seq_type: SequenceTargetType::Slice,
+            elem_type: Type::u(32),
+        },
+        SourceLocation::test(),
+    ));
     // Front: [front, mid]; element 0 is the pushed value.
-    entry.push_instruction(OpCode::SlicePush {
-        dir: SliceOpDir::Front,
-        result: pushed_front,
-        slice: base,
-        values: vec![front],
-    });
+    entry.push_instruction(Located::with(
+        OpCode::SlicePush {
+            dir: SliceOpDir::Front,
+            result: pushed_front,
+            slice: base,
+            values: vec![front],
+        },
+        SourceLocation::test(),
+    ));
     // Back: [mid, back]; element 1 is the pushed value.
-    entry.push_instruction(OpCode::SlicePush {
-        dir: SliceOpDir::Back,
-        result: pushed_back,
-        slice: base,
-        values: vec![back],
-    });
-    entry.push_instruction(OpCode::ArrayGet {
-        result: head,
-        array: pushed_front,
-        index: idx0,
-    });
-    entry.push_instruction(OpCode::ArrayGet {
-        result: tail,
-        array: pushed_back,
-        index: idx1,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::SlicePush {
+            dir: SliceOpDir::Back,
+            result: pushed_back,
+            slice: base,
+            values: vec![back],
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: head,
+            array: pushed_front,
+            index: idx0,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: tail,
+            array: pushed_back,
+            index: idx1,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![head, tail]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -5706,16 +6204,22 @@ fn const_mk_seq_of_blob_folds() {
     let (seq, got) = (ssa.fresh_value(), ssa.fresh_value());
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
-    entry.push_instruction(OpCode::MkSeqOfBlob {
-        result: seq,
-        element_type: Type::u(32),
-        blob,
-    });
-    entry.push_instruction(OpCode::ArrayGet {
-        result: got,
-        array: seq,
-        index: idx,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::MkSeqOfBlob {
+            result: seq,
+            element_type: Type::u(32),
+            blob,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: got,
+            array: seq,
+            index: idx,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![got]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -5752,42 +6256,60 @@ fn aggregate_folding_negative_cases() {
     f.get_entry_mut().push_parameter(p, Type::u(32));
     let entry = f.get_entry_mut();
     // Out of bounds: index 5 into a length-2 array.
-    entry.push_instruction(OpCode::MkSeq {
-        result: seq,
-        elems: vec![c0, c1],
-        seq_type: SequenceTargetType::Array(2),
-        elem_type: Type::u(32),
-    });
-    entry.push_instruction(OpCode::ArrayGet {
-        result: g_oob,
-        array: seq,
-        index: idx_oob,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::MkSeq {
+            result: seq,
+            elems: vec![c0, c1],
+            seq_type: SequenceTargetType::Array(2),
+            elem_type: Type::u(32),
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: g_oob,
+            array: seq,
+            index: idx_oob,
+        },
+        SourceLocation::test(),
+    ));
     // Non-constant element keeps the whole aggregate non-constant.
-    entry.push_instruction(OpCode::MkSeq {
-        result: seq_nc,
-        elems: vec![c0, p],
-        seq_type: SequenceTargetType::Array(2),
-        elem_type: Type::u(32),
-    });
-    entry.push_instruction(OpCode::ArrayGet {
-        result: g_nc,
-        array: seq_nc,
-        index: idx0,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::MkSeq {
+            result: seq_nc,
+            elems: vec![c0, p],
+            seq_type: SequenceTargetType::Array(2),
+            elem_type: Type::u(32),
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: g_nc,
+            array: seq_nc,
+            index: idx0,
+        },
+        SourceLocation::test(),
+    ));
     // Over-cap repeat is refused before materialising the aggregate.
-    entry.push_instruction(OpCode::MkRepeated {
-        result: big,
-        element: c0,
-        seq_type: SequenceTargetType::Array((1 << 16) + 1),
-        count: (1 << 16) + 1,
-        elem_type: Type::u(32),
-    });
-    entry.push_instruction(OpCode::ArrayGet {
-        result: g_big,
-        array: big,
-        index: idx0,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::MkRepeated {
+            result: big,
+            element: c0,
+            seq_type: SequenceTargetType::Array((1 << 16) + 1),
+            count: (1 << 16) + 1,
+            elem_type: Type::u(32),
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: g_big,
+            array: big,
+            index: idx0,
+        },
+        SourceLocation::test(),
+    ));
     entry.set_terminator(Terminator::Return(vec![g_oob, g_nc, g_big]));
 
     let fid = ssa.get_unique_entrypoint_id();
@@ -5818,55 +6340,79 @@ fn aggregate_folding_refuses_oob_set_and_over_cap_constructors() {
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
 
     // Out-of-bounds `ArraySet` (index 5 into a length-2 array): refused, so the get sees Bottom.
-    entry.push_instruction(OpCode::MkSeq {
-        result: base,
-        elems: vec![c0, c1],
-        seq_type: SequenceTargetType::Array(2),
-        elem_type: Type::u(32),
-    });
-    entry.push_instruction(OpCode::ArraySet {
-        result: set_oob,
-        array: base,
-        index: idx_oob,
-        value: c0,
-    });
-    entry.push_instruction(OpCode::ArrayGet {
-        result: at_set_oob,
-        array: set_oob,
-        index: idx0,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::MkSeq {
+            result: base,
+            elems: vec![c0, c1],
+            seq_type: SequenceTargetType::Array(2),
+            elem_type: Type::u(32),
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArraySet {
+            result: set_oob,
+            array: base,
+            index: idx_oob,
+            value: c0,
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: at_set_oob,
+            array: set_oob,
+            index: idx0,
+        },
+        SourceLocation::test(),
+    ));
 
     // `SlicePush` whose result would exceed the cap (1 + CAP values): refused.
-    entry.push_instruction(OpCode::MkSeq {
-        result: one,
-        elems: vec![c0],
-        seq_type: SequenceTargetType::Slice,
-        elem_type: Type::u(32),
-    });
-    entry.push_instruction(OpCode::SlicePush {
-        dir: SliceOpDir::Back,
-        result: pushed,
-        slice: one,
-        values: vec![c0; 1 << 12],
-    });
-    entry.push_instruction(OpCode::ArrayGet {
-        result: at_pushed,
-        array: pushed,
-        index: idx0,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::MkSeq {
+            result: one,
+            elems: vec![c0],
+            seq_type: SequenceTargetType::Slice,
+            elem_type: Type::u(32),
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::SlicePush {
+            dir: SliceOpDir::Back,
+            result: pushed,
+            slice: one,
+            values: vec![c0; 1 << 12],
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: at_pushed,
+            array: pushed,
+            index: idx0,
+        },
+        SourceLocation::test(),
+    ));
 
     // Over-cap `MkSeq`: refused before materialising the aggregate.
-    entry.push_instruction(OpCode::MkSeq {
-        result: big_seq,
-        elems: vec![c0; over_cap],
-        seq_type: SequenceTargetType::Array(over_cap),
-        elem_type: Type::u(32),
-    });
-    entry.push_instruction(OpCode::ArrayGet {
-        result: at_big,
-        array: big_seq,
-        index: idx0,
-    });
+    entry.push_instruction(Located::with(
+        OpCode::MkSeq {
+            result: big_seq,
+            elems: vec![c0; over_cap],
+            seq_type: SequenceTargetType::Array(over_cap),
+            elem_type: Type::u(32),
+        },
+        SourceLocation::test(),
+    ));
+    entry.push_instruction(Located::with(
+        OpCode::ArrayGet {
+            result: at_big,
+            array: big_seq,
+            index: idx0,
+        },
+        SourceLocation::test(),
+    ));
 
     entry.set_terminator(Terminator::Return(vec![at_set_oob, at_pushed, at_big]));
 
@@ -5898,12 +6444,15 @@ fn symbolic_jump_ignores_dead_argument() {
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
         hf.get_entry_mut().push_parameter(y, Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: fa,
-            lhs: x,
-            rhs: c1,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: fa,
+                lhs: x,
+                rhs: c1,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -5926,12 +6475,15 @@ fn symbolic_jump_ignores_dead_argument() {
         mf.get_entry_mut().push_parameter(d, Type::field());
         let entry = mf.get_entry_mut();
         for (res, args) in [(r1, vec![a, c]), (r2, vec![a, d]), (r3, vec![b, c])] {
-            entry.push_instruction(OpCode::Call {
-                results: vec![res],
-                function: CallTarget::Static(f),
-                args,
-                unconstrained: false,
-            });
+            entry.push_instruction(Located::with(
+                OpCode::Call {
+                    results: vec![res],
+                    function: CallTarget::Static(f),
+                    args,
+                    unconstrained: false,
+                },
+                SourceLocation::test(),
+            ));
         }
         entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
     }
@@ -5959,12 +6511,15 @@ fn symbolic_jump_relates_call_to_open_expression() {
         let hf = ssa.get_function_mut(f);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: fa,
-            lhs: x,
-            rhs: c5,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: fa,
+                lhs: x,
+                rhs: c5,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -5976,24 +6531,33 @@ fn symbolic_jump_relates_call_to_open_expression() {
         mf.add_return_type(Type::field());
         mf.get_entry_mut().push_parameter(a, Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(OpCode::Call {
-            results: vec![r],
-            function: CallTarget::Static(f),
-            args: vec![a],
-            unconstrained: false,
-        });
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: w,
-            lhs: a,
-            rhs: c5,
-        });
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: w2,
-            lhs: a,
-            rhs: c6,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r],
+                function: CallTarget::Static(f),
+                args: vec![a],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: w,
+                lhs: a,
+                rhs: c5,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: w2,
+                lhs: a,
+                rhs: c6,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -6023,18 +6587,24 @@ fn symbolic_jump_depth_two_grafts_via_synthetic() {
         let hf = ssa.get_function_mut(f);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: ft,
-            lhs: x,
-            rhs: c5,
-        });
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Mul,
-            result: fa,
-            lhs: ft,
-            rhs: c2,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: ft,
+                lhs: x,
+                rhs: c5,
+            },
+            SourceLocation::test(),
+        ));
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Mul,
+                result: fa,
+                lhs: ft,
+                rhs: c2,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -6046,24 +6616,33 @@ fn symbolic_jump_depth_two_grafts_via_synthetic() {
         mf.add_return_type(Type::field());
         mf.get_entry_mut().push_parameter(a, Type::field());
         let entry = mf.get_entry_mut();
-        entry.push_instruction(OpCode::Call {
-            results: vec![r],
-            function: CallTarget::Static(f),
-            args: vec![a],
-            unconstrained: false,
-        });
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: wt,
-            lhs: a,
-            rhs: c5,
-        });
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Mul,
-            result: w,
-            lhs: wt,
-            rhs: c2,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r],
+                function: CallTarget::Static(f),
+                args: vec![a],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: wt,
+                lhs: a,
+                rhs: c5,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Mul,
+                result: w,
+                lhs: wt,
+                rhs: c2,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r]));
     }
 
@@ -6109,18 +6688,24 @@ fn symbolic_jump_dead_argument_behind_depth_two() {
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
         hf.get_entry_mut().push_parameter(y, Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: ft,
-            lhs: x,
-            rhs: c5,
-        });
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Mul,
-            result: fa,
-            lhs: ft,
-            rhs: c2,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: ft,
+                lhs: x,
+                rhs: c5,
+            },
+            SourceLocation::test(),
+        ));
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Mul,
+                result: fa,
+                lhs: ft,
+                rhs: c2,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -6143,12 +6728,15 @@ fn symbolic_jump_dead_argument_behind_depth_two() {
         mf.get_entry_mut().push_parameter(d, Type::field());
         let entry = mf.get_entry_mut();
         for (res, args) in [(r1, vec![a, c]), (r2, vec![a, d]), (r3, vec![b, c])] {
-            entry.push_instruction(OpCode::Call {
-                results: vec![res],
-                function: CallTarget::Static(f),
-                args,
-                unconstrained: false,
-            });
+            entry.push_instruction(Located::with(
+                OpCode::Call {
+                    results: vec![res],
+                    function: CallTarget::Static(f),
+                    args,
+                    unconstrained: false,
+                },
+                SourceLocation::test(),
+            ));
         }
         entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
     }
@@ -6181,24 +6769,33 @@ fn symbolic_jump_depth_over_cap_falls_back_to_calldet() {
         let hf = ssa.get_function_mut(f);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: ft,
-            lhs: x,
-            rhs: c1,
-        });
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Mul,
-            result: fu,
-            lhs: ft,
-            rhs: c2,
-        });
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: fa,
-            lhs: fu,
-            rhs: c3,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: ft,
+                lhs: x,
+                rhs: c1,
+            },
+            SourceLocation::test(),
+        ));
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Mul,
+                result: fu,
+                lhs: ft,
+                rhs: c2,
+            },
+            SourceLocation::test(),
+        ));
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: fa,
+                lhs: fu,
+                rhs: c3,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -6215,32 +6812,44 @@ fn symbolic_jump_depth_over_cap_falls_back_to_calldet() {
         mf.get_entry_mut().push_parameter(b, Type::field());
         let entry = mf.get_entry_mut();
         for (res, arg) in [(r1, a), (r2, a), (r3, b)] {
-            entry.push_instruction(OpCode::Call {
-                results: vec![res],
-                function: CallTarget::Static(f),
-                args: vec![arg],
-                unconstrained: false,
-            });
+            entry.push_instruction(Located::with(
+                OpCode::Call {
+                    results: vec![res],
+                    function: CallTarget::Static(f),
+                    args: vec![arg],
+                    unconstrained: false,
+                },
+                SourceLocation::test(),
+            ));
         }
         // The caller-local `((a + 1) * 2) + 3`.
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: wt,
-            lhs: a,
-            rhs: c1,
-        });
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Mul,
-            result: wu,
-            lhs: wt,
-            rhs: c2,
-        });
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: w,
-            lhs: wu,
-            rhs: c3,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: wt,
+                lhs: a,
+                rhs: c1,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Mul,
+                result: wu,
+                lhs: wt,
+                rhs: c2,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: w,
+                lhs: wu,
+                rhs: c3,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
     }
 
@@ -6267,12 +6876,15 @@ fn symbolic_jump_nested_call_falls_back_to_calldet() {
         let hf = ssa.get_function_mut(h);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(hx, Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: hr,
-            lhs: hx,
-            rhs: c1,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: hr,
+                lhs: hx,
+                rhs: c1,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![hr]));
     }
@@ -6283,18 +6895,24 @@ fn symbolic_jump_nested_call_falls_back_to_calldet() {
         let gf = ssa.get_function_mut(g);
         gf.add_return_type(Type::field());
         gf.get_entry_mut().push_parameter(gx, Type::field());
-        gf.get_entry_mut().push_instruction(OpCode::Call {
-            results: vec![gc],
-            function: CallTarget::Static(h),
-            args: vec![gx],
-            unconstrained: false,
-        });
-        gf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: ga,
-            lhs: gc,
-            rhs: c1,
-        });
+        gf.get_entry_mut().push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![gc],
+                function: CallTarget::Static(h),
+                args: vec![gx],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
+        gf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: ga,
+                lhs: gc,
+                rhs: c1,
+            },
+            SourceLocation::test(),
+        ));
         gf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![ga]));
     }
@@ -6310,12 +6928,15 @@ fn symbolic_jump_nested_call_falls_back_to_calldet() {
         mf.get_entry_mut().push_parameter(b, Type::field());
         let entry = mf.get_entry_mut();
         for (res, arg) in [(r1, a), (r2, a), (r3, b)] {
-            entry.push_instruction(OpCode::Call {
-                results: vec![res],
-                function: CallTarget::Static(g),
-                args: vec![arg],
-                unconstrained: false,
-            });
+            entry.push_instruction(Located::with(
+                OpCode::Call {
+                    results: vec![res],
+                    function: CallTarget::Static(g),
+                    args: vec![arg],
+                    unconstrained: false,
+                },
+                SourceLocation::test(),
+            ));
         }
         entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
     }
@@ -6341,12 +6962,15 @@ fn symbolic_jump_preserves_noncommutativity() {
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
         hf.get_entry_mut().push_parameter(y, Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Sub,
-            result: fa,
-            lhs: x,
-            rhs: y,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Sub,
+                result: fa,
+                lhs: x,
+                rhs: y,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -6362,12 +6986,15 @@ fn symbolic_jump_preserves_noncommutativity() {
         mf.get_entry_mut().push_parameter(b, Type::field());
         let entry = mf.get_entry_mut();
         for (res, args) in [(r1, vec![a, b]), (r2, vec![b, a]), (r3, vec![a, b])] {
-            entry.push_instruction(OpCode::Call {
-                results: vec![res],
-                function: CallTarget::Static(f),
-                args,
-                unconstrained: false,
-            });
+            entry.push_instruction(Located::with(
+                OpCode::Call {
+                    results: vec![res],
+                    function: CallTarget::Static(f),
+                    args,
+                    unconstrained: false,
+                },
+                SourceLocation::test(),
+            ));
         }
         entry.set_terminator(Terminator::Return(vec![r1, r2, r3]));
     }
@@ -6392,16 +7019,22 @@ fn symbolic_jump_witness_operand_is_not_grafted() {
         let hf = ssa.get_function_mut(f);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::FreshWitness {
-            result: wit,
-            result_type: Type::field(),
-        });
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: fa,
-            lhs: x,
-            rhs: wit,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::FreshWitness {
+                result: wit,
+                result_type: Type::field(),
+            },
+            SourceLocation::test(),
+        ));
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: fa,
+                lhs: x,
+                rhs: wit,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -6415,12 +7048,15 @@ fn symbolic_jump_witness_operand_is_not_grafted() {
         mf.get_entry_mut().push_parameter(a, Type::field());
         let entry = mf.get_entry_mut();
         for res in [r1, r2] {
-            entry.push_instruction(OpCode::Call {
-                results: vec![res],
-                function: CallTarget::Static(f),
-                args: vec![a],
-                unconstrained: false,
-            });
+            entry.push_instruction(Located::with(
+                OpCode::Call {
+                    results: vec![res],
+                    function: CallTarget::Static(f),
+                    args: vec![a],
+                    unconstrained: false,
+                },
+                SourceLocation::test(),
+            ));
         }
         entry.set_terminator(Terminator::Return(vec![r1, r2]));
     }
@@ -6468,18 +7104,24 @@ fn symbolic_jump_synthetic_does_not_collide_with_callee_only_constant() {
         let hf = ssa.get_function_mut(f);
         hf.add_return_type(Type::field());
         hf.get_entry_mut().push_parameter(x, Type::field());
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Mul,
-            result: ft,
-            lhs: x,
-            rhs: c,
-        });
-        hf.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: fa,
-            lhs: x,
-            rhs: ft,
-        });
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Mul,
+                result: ft,
+                lhs: x,
+                rhs: c,
+            },
+            SourceLocation::test(),
+        ));
+        hf.get_entry_mut().push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: fa,
+                lhs: x,
+                rhs: ft,
+            },
+            SourceLocation::test(),
+        ));
         hf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![fa]));
     }
@@ -6491,26 +7133,35 @@ fn symbolic_jump_synthetic_does_not_collide_with_callee_only_constant() {
         mf.get_entry_mut().push_parameter(a, Type::field());
         let entry = mf.get_entry_mut();
         // v = 2 + 3, which folds to Field(5) — the same constant class as `c`.
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: v,
-            lhs: two,
-            rhs: three,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: v,
+                lhs: two,
+                rhs: three,
+            },
+            SourceLocation::test(),
+        ));
         // r = f(a)
-        entry.push_instruction(OpCode::Call {
-            results: vec![r],
-            function: CallTarget::Static(f),
-            args: vec![a],
-            unconstrained: false,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Call {
+                results: vec![r],
+                function: CallTarget::Static(f),
+                args: vec![a],
+                unconstrained: false,
+            },
+            SourceLocation::test(),
+        ));
         // w = a + v, a genuine `a + 5`.
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Add,
-            result: w,
-            lhs: a,
-            rhs: v,
-        });
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Add,
+                result: w,
+                lhs: a,
+                rhs: v,
+            },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![r, w]));
     }
 

--- a/compiler/src/compiler/analysis/instrumenter.rs
+++ b/compiler/src/compiler/analysis/instrumenter.rs
@@ -2308,7 +2308,7 @@ mod tests {
         Field,
         analysis::{flow_analysis::FlowAnalysis, types::Types},
         ssa::{
-            Located, SourceLocation, Terminator,
+            Terminator,
             hlssa::{Constant, HLSSA, OpCode},
         },
     };
@@ -2331,10 +2331,7 @@ mod tests {
         let b = ssa.add_const(Constant::Field(Field::from(b)));
         let c = ssa.add_const(Constant::Field(Field::from(c)));
         let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::Constrain { a, b, c },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Constrain { a, b, c });
         entry.set_terminator(Terminator::Return(vec![]));
         ssa
     }

--- a/compiler/src/compiler/analysis/instrumenter.rs
+++ b/compiler/src/compiler/analysis/instrumenter.rs
@@ -2308,7 +2308,7 @@ mod tests {
         Field,
         analysis::{flow_analysis::FlowAnalysis, types::Types},
         ssa::{
-            Terminator,
+            Located, SourceLocation, Terminator,
             hlssa::{Constant, HLSSA, OpCode},
         },
     };
@@ -2331,7 +2331,10 @@ mod tests {
         let b = ssa.add_const(Constant::Field(Field::from(b)));
         let c = ssa.add_const(Constant::Field(Field::from(c)));
         let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
-        entry.push_instruction(OpCode::Constrain { a, b, c });
+        entry.push_instruction(Located::with(
+            OpCode::Constrain { a, b, c },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![]));
         ssa
     }

--- a/compiler/src/compiler/analysis/points_to/mod.rs
+++ b/compiler/src/compiler/analysis/points_to/mod.rs
@@ -569,9 +569,12 @@ mod tests {
     use super::*;
     use crate::compiler::{
         analysis::{flow_analysis::FlowAnalysis, types::Types},
-        ssa::hlssa::{
-            Blob, Constant, SequenceTargetType, Type,
-            builder::{HLEmitter, HLSSABuilder},
+        ssa::{
+            SourceLocation,
+            hlssa::{
+                Blob, Constant, SequenceTargetType, Type,
+                builder::{HLEmitter, HLSSABuilder},
+            },
         },
         util::test::{falloc, fr},
     };
@@ -602,7 +605,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let cond = e.add_parameter(Type::bool());
                 let ra = falloc(&mut e);
                 let rb = falloc(&mut e);
@@ -654,7 +657,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let ra = falloc(&mut e);
                 let rb = falloc(&mut e);
                 let c = e.field_const(fr(7));
@@ -683,7 +686,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let q = falloc(&mut e); // q: Ref<Field>
                 let p = e.alloc(q); // p: Ref<Ref<Field>>, init-seeded with q; the explicit store below drives the same edge, so q's object reaches *p either way
                 e.store(p, q); // *p = q
@@ -714,7 +717,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field().ref_of());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let kept = falloc(&mut e);
                 let returned = falloc(&mut e);
                 let c = e.field_const(fr(1));
@@ -756,7 +759,7 @@ mod tests {
             // reader(p: Ref<Field>): let _ = *p; return
             sb.modify_function(reader, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p = e.add_parameter(Type::field().ref_of());
                 let _v = e.load(p);
                 e.terminate_return(vec![]);
@@ -765,7 +768,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let q = falloc(&mut e);
                 let c = e.field_const(fr(3));
                 e.store(q, c);
@@ -800,7 +803,7 @@ mod tests {
             sb.modify_function(make, |b| {
                 b.function.add_return_type(Type::field().ref_of());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = falloc(&mut e);
                 e.terminate_return(vec![a]);
             });
@@ -808,7 +811,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let z = e.call(make, vec![], 1)[0];
                 let r = e.load(z);
                 e.terminate_return(vec![r]);
@@ -843,7 +846,7 @@ mod tests {
             // stash(p: Ref<Field>): global[0] = p; return
             sb.modify_function(stash, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p = e.add_parameter(Type::field().ref_of());
                 e.init_global(0, p);
                 e.terminate_return(vec![]);
@@ -851,7 +854,7 @@ mod tests {
             // main(): q = alloc; *q = 0; stash(q); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let q = falloc(&mut e);
                 let c = e.field_const(fr(0));
                 e.store(q, c);
@@ -885,7 +888,7 @@ mod tests {
             sb.modify_function(rec, |b| {
                 b.function.add_return_type(Type::field().ref_of());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p = e.add_parameter(Type::field().ref_of());
                 e.call(rec, vec![p], 1); // self-recursion (result discarded, but arity must match)
                 e.terminate_return(vec![p]);
@@ -893,7 +896,7 @@ mod tests {
             // main(): q = alloc; z = rec(q); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let q = falloc(&mut e);
                 let z = e.call(rec, vec![q], 1)[0];
                 e.terminate_return(vec![]);
@@ -924,7 +927,7 @@ mod tests {
             sb.modify_function(make, |b| {
                 b.function.add_return_type(Type::field().ref_of());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = falloc(&mut e);
                 e.terminate_return(vec![a]);
             });
@@ -932,7 +935,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let z1 = e.call(make, vec![], 1)[0];
                 let z2 = e.call(make, vec![], 1)[0];
                 let r = e.load(z1);
@@ -976,7 +979,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let ra = falloc(&mut e);
                 let rb = falloc(&mut e);
                 let arr = e.mk_seq(
@@ -1025,7 +1028,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let c0 = e.field_const(fr(7));
                 let c1 = e.field_const(fr(9));
                 let arr = e.mk_seq(vec![c0, c1], SequenceTargetType::Array(2), Type::field());
@@ -1056,7 +1059,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let n = e.add_parameter(Type::u(32)); // dynamic index
                 let ra = falloc(&mut e);
                 let rb = falloc(&mut e);
@@ -1095,7 +1098,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let cond = e.add_parameter(Type::bool());
                 let a = falloc(&mut e);
                 let bb = falloc(&mut e);
@@ -1150,7 +1153,7 @@ mod tests {
             let mut sb = HLSSABuilder::new(&mut ssa);
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let ra = falloc(&mut e);
                 let rb = falloc(&mut e);
                 let arr = e.mk_seq(
@@ -1185,7 +1188,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let c = e.field_const(fr(3));
                 let arr = e.mk_repeated(c, SequenceTargetType::Array(4), 4, Type::field());
                 let i0 = e.u_const(32, 0);
@@ -1214,7 +1217,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let r = falloc(&mut e);
                 let c = e.field_const(fr(3));
                 e.store(r, c);
@@ -1243,7 +1246,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let blob = e.emit_constant(Constant::Blob(Blob {
                     elem_type: Type::field(),
                     elements: vec![
@@ -1280,7 +1283,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let r1 = e.read_global(0, Type::field().ref_of());
                 let r2 = e.read_global(0, Type::field().ref_of());
                 let v = e.load(r1);
@@ -1314,7 +1317,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let r = e.read_global(0, Type::field().ref_of());
                 let a = falloc(&mut e);
                 let v = e.load(a);
@@ -1343,7 +1346,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let g = e.read_global(0, Type::field().ref_of().ref_of());
                 let inner = e.load(g); // Ref<Field>, points to External (load through opaque)
                 let a = falloc(&mut e);
@@ -1372,7 +1375,7 @@ mod tests {
             let mut sb = HLSSABuilder::new(&mut ssa);
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let g = e.read_global(0, Type::field().ref_of().ref_of());
                 let a = falloc(&mut e); // a: Ref<Field>
                 e.store(g, a); // *g = a — published through opaque memory
@@ -1411,7 +1414,7 @@ mod tests {
             // writer(pp: Ref<Ref<Field>>): let a = alloc; *pp = a; return
             sb.modify_function(writer, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let pp = e.add_parameter(Type::field().ref_of().ref_of());
                 let a = falloc(&mut e);
                 e.store(pp, a);
@@ -1421,7 +1424,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let seed = falloc(&mut e); // a Ref<Field> init-seeded into pp's cell; the weak-update analysis keeps it alongside what writer stores through *pp
                 let pp = e.alloc(seed);
                 e.call(writer, vec![pp], 0);
@@ -1469,7 +1472,7 @@ mod tests {
             // copy(dst: Ref<Ref<Field>>, src: Ref<Field>): *dst = src; return
             sb.modify_function(copy, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let dst = e.add_parameter(Type::field().ref_of().ref_of());
                 let src = e.add_parameter(Type::field().ref_of());
                 e.store(dst, src);
@@ -1479,7 +1482,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = falloc(&mut e);
                 let dst = e.alloc(a); // init-seeded with a; the callee also copies a through *dst, so *dst resolves to a's object either way
                 e.call(copy, vec![dst, a], 0);
@@ -1515,7 +1518,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let q = falloc(&mut e); // q: Ref<Field>
                 let p = e.alloc(q); // p: Ref<Ref<Field>>, init-seeded with q; no explicit store
                 let r = e.load(p); // r = *p (a Ref<Field>) — sees the init seed
@@ -1546,7 +1549,7 @@ mod tests {
             let mut sb = HLSSABuilder::new(&mut ssa);
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let q = falloc(&mut e); // q: Ref<Field>
                 let p = e.alloc(q); // p: Ref<Ref<Field>>, init-seeded with q; no explicit store
                 e.init_global(0, p); // p escapes ⇒ q escapes through p's cell

--- a/compiler/src/compiler/analysis/points_to/mod.rs
+++ b/compiler/src/compiler/analysis/points_to/mod.rs
@@ -569,12 +569,9 @@ mod tests {
     use super::*;
     use crate::compiler::{
         analysis::{flow_analysis::FlowAnalysis, types::Types},
-        ssa::{
-            SourceLocation,
-            hlssa::{
-                Blob, Constant, SequenceTargetType, Type,
-                builder::{HLEmitter, HLSSABuilder},
-            },
+        ssa::hlssa::{
+            Blob, Constant, SequenceTargetType, Type,
+            builder::{HLEmitter, HLSSABuilder},
         },
         util::test::{falloc, fr},
     };
@@ -605,7 +602,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let cond = e.add_parameter(Type::bool());
                 let ra = falloc(&mut e);
                 let rb = falloc(&mut e);
@@ -657,7 +654,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let ra = falloc(&mut e);
                 let rb = falloc(&mut e);
                 let c = e.field_const(fr(7));
@@ -686,7 +683,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let q = falloc(&mut e); // q: Ref<Field>
                 let p = e.alloc(q); // p: Ref<Ref<Field>>, init-seeded with q; the explicit store below drives the same edge, so q's object reaches *p either way
                 e.store(p, q); // *p = q
@@ -717,7 +714,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field().ref_of());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let kept = falloc(&mut e);
                 let returned = falloc(&mut e);
                 let c = e.field_const(fr(1));
@@ -759,7 +756,7 @@ mod tests {
             // reader(p: Ref<Field>): let _ = *p; return
             sb.modify_function(reader, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p = e.add_parameter(Type::field().ref_of());
                 let _v = e.load(p);
                 e.terminate_return(vec![]);
@@ -768,7 +765,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let q = falloc(&mut e);
                 let c = e.field_const(fr(3));
                 e.store(q, c);
@@ -803,7 +800,7 @@ mod tests {
             sb.modify_function(make, |b| {
                 b.function.add_return_type(Type::field().ref_of());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = falloc(&mut e);
                 e.terminate_return(vec![a]);
             });
@@ -811,7 +808,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let z = e.call(make, vec![], 1)[0];
                 let r = e.load(z);
                 e.terminate_return(vec![r]);
@@ -846,7 +843,7 @@ mod tests {
             // stash(p: Ref<Field>): global[0] = p; return
             sb.modify_function(stash, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p = e.add_parameter(Type::field().ref_of());
                 e.init_global(0, p);
                 e.terminate_return(vec![]);
@@ -854,7 +851,7 @@ mod tests {
             // main(): q = alloc; *q = 0; stash(q); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let q = falloc(&mut e);
                 let c = e.field_const(fr(0));
                 e.store(q, c);
@@ -888,7 +885,7 @@ mod tests {
             sb.modify_function(rec, |b| {
                 b.function.add_return_type(Type::field().ref_of());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p = e.add_parameter(Type::field().ref_of());
                 e.call(rec, vec![p], 1); // self-recursion (result discarded, but arity must match)
                 e.terminate_return(vec![p]);
@@ -896,7 +893,7 @@ mod tests {
             // main(): q = alloc; z = rec(q); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let q = falloc(&mut e);
                 let z = e.call(rec, vec![q], 1)[0];
                 e.terminate_return(vec![]);
@@ -927,7 +924,7 @@ mod tests {
             sb.modify_function(make, |b| {
                 b.function.add_return_type(Type::field().ref_of());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = falloc(&mut e);
                 e.terminate_return(vec![a]);
             });
@@ -935,7 +932,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let z1 = e.call(make, vec![], 1)[0];
                 let z2 = e.call(make, vec![], 1)[0];
                 let r = e.load(z1);
@@ -979,7 +976,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let ra = falloc(&mut e);
                 let rb = falloc(&mut e);
                 let arr = e.mk_seq(
@@ -1028,7 +1025,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let c0 = e.field_const(fr(7));
                 let c1 = e.field_const(fr(9));
                 let arr = e.mk_seq(vec![c0, c1], SequenceTargetType::Array(2), Type::field());
@@ -1059,7 +1056,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let n = e.add_parameter(Type::u(32)); // dynamic index
                 let ra = falloc(&mut e);
                 let rb = falloc(&mut e);
@@ -1098,7 +1095,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let cond = e.add_parameter(Type::bool());
                 let a = falloc(&mut e);
                 let bb = falloc(&mut e);
@@ -1153,7 +1150,7 @@ mod tests {
             let mut sb = HLSSABuilder::new(&mut ssa);
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let ra = falloc(&mut e);
                 let rb = falloc(&mut e);
                 let arr = e.mk_seq(
@@ -1188,7 +1185,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let c = e.field_const(fr(3));
                 let arr = e.mk_repeated(c, SequenceTargetType::Array(4), 4, Type::field());
                 let i0 = e.u_const(32, 0);
@@ -1217,7 +1214,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let r = falloc(&mut e);
                 let c = e.field_const(fr(3));
                 e.store(r, c);
@@ -1246,7 +1243,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let blob = e.emit_constant(Constant::Blob(Blob {
                     elem_type: Type::field(),
                     elements: vec![
@@ -1283,7 +1280,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let r1 = e.read_global(0, Type::field().ref_of());
                 let r2 = e.read_global(0, Type::field().ref_of());
                 let v = e.load(r1);
@@ -1317,7 +1314,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let r = e.read_global(0, Type::field().ref_of());
                 let a = falloc(&mut e);
                 let v = e.load(a);
@@ -1346,7 +1343,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let g = e.read_global(0, Type::field().ref_of().ref_of());
                 let inner = e.load(g); // Ref<Field>, points to External (load through opaque)
                 let a = falloc(&mut e);
@@ -1375,7 +1372,7 @@ mod tests {
             let mut sb = HLSSABuilder::new(&mut ssa);
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let g = e.read_global(0, Type::field().ref_of().ref_of());
                 let a = falloc(&mut e); // a: Ref<Field>
                 e.store(g, a); // *g = a — published through opaque memory
@@ -1414,7 +1411,7 @@ mod tests {
             // writer(pp: Ref<Ref<Field>>): let a = alloc; *pp = a; return
             sb.modify_function(writer, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let pp = e.add_parameter(Type::field().ref_of().ref_of());
                 let a = falloc(&mut e);
                 e.store(pp, a);
@@ -1424,7 +1421,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let seed = falloc(&mut e); // a Ref<Field> init-seeded into pp's cell; the weak-update analysis keeps it alongside what writer stores through *pp
                 let pp = e.alloc(seed);
                 e.call(writer, vec![pp], 0);
@@ -1472,7 +1469,7 @@ mod tests {
             // copy(dst: Ref<Ref<Field>>, src: Ref<Field>): *dst = src; return
             sb.modify_function(copy, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let dst = e.add_parameter(Type::field().ref_of().ref_of());
                 let src = e.add_parameter(Type::field().ref_of());
                 e.store(dst, src);
@@ -1482,7 +1479,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = falloc(&mut e);
                 let dst = e.alloc(a); // init-seeded with a; the callee also copies a through *dst, so *dst resolves to a's object either way
                 e.call(copy, vec![dst, a], 0);
@@ -1518,7 +1515,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let q = falloc(&mut e); // q: Ref<Field>
                 let p = e.alloc(q); // p: Ref<Ref<Field>>, init-seeded with q; no explicit store
                 let r = e.load(p); // r = *p (a Ref<Field>) — sees the init seed
@@ -1549,7 +1546,7 @@ mod tests {
             let mut sb = HLSSABuilder::new(&mut ssa);
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let q = falloc(&mut e); // q: Ref<Field>
                 let p = e.alloc(q); // p: Ref<Ref<Field>>, init-seeded with q; no explicit store
                 e.init_global(0, p); // p escapes ⇒ q escapes through p's cell

--- a/compiler/src/compiler/analysis/symbolic_executor.rs
+++ b/compiler/src/compiler/analysis/symbolic_executor.rs
@@ -10,7 +10,7 @@ use crate::{
         Field,
         analysis::types::TypeInfo,
         ssa::{
-            BlockId, FunctionId, Instruction, Terminator, ValueId,
+            BlockId, FunctionId, Instruction, SourceLocation, Terminator, ValueId,
             hlssa::{
                 BinaryArithOpKind, CallTarget, CastTarget, CmpKind, Constant, Endianness, HLSSA,
                 HLSSAConstantsSnapshot, LookupTarget, OpCode, Radix, RefCountOp,
@@ -135,6 +135,10 @@ pub trait Context<V> {
     fn on_return(&mut self, returns: &mut [V], return_types: &[Type]);
     fn on_jmp(&mut self, target: BlockId, params: &mut [V], param_types: &[&Type]);
 
+    /// Called with each instruction's source location before that instruction is interpreted.
+    /// Backends that emit residual instructions can use it to locate what they emit.
+    fn on_location(&mut self, _location: &SourceLocation) {}
+
     // TODO it looks odd that this is the only opcode implemented here.
     // This is the _new_ structure, so at some point we should migrate all other opcodes here.
     fn lookup(&mut self, _target: LookupTarget<V>, _args: Vec<V>, _flag: V) {
@@ -250,7 +254,8 @@ impl SymbolicExecutor {
         let mut current = Some(entry);
 
         while let Some(block) = current {
-            for instr in block.get_instructions() {
+            for (instr, location) in block.get_instructions_with_source_locations() {
+                ctx.on_location(location);
                 match instr {
                     OpCode::Cmp {
                         kind: cmp_kind,

--- a/compiler/src/compiler/analysis/witness_taint_inference/mod.rs
+++ b/compiler/src/compiler/analysis/witness_taint_inference/mod.rs
@@ -277,12 +277,9 @@ struct FunctionSummary {
 mod tests {
     use super::*;
     use crate::compiler::analysis::witness_info::{WitnessShape, WitnessType};
-    use crate::compiler::ssa::{
-        SourceLocation,
-        hlssa::{
-            Type,
-            builder::{HLEmitter, HLSSABuilder},
-        },
+    use crate::compiler::ssa::hlssa::{
+        Type,
+        builder::{HLEmitter, HLSSABuilder},
     };
 
     fn pure() -> WitnessShape {
@@ -353,7 +350,7 @@ mod tests {
             b.function.add_return_type(Type::field());
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let x = e.add_parameter(Type::field());
             let w = e.write_witness(x);
             e.terminate_return(vec![x, w]);
@@ -373,7 +370,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::witness_of(Type::field()));
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let _x = e.add_parameter(Type::field());
             let c = e.field_const(fr(0));
             let w = e.cast_to_witness_of(c);
@@ -395,7 +392,7 @@ mod tests {
             b.function.add_return_type(Type::field());
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let x = e.add_parameter(Type::field());
             let c = e.field_const(fr(5));
             let p = e.alloc(c); // pure init store
@@ -419,7 +416,7 @@ mod tests {
             b.function.add_return_type(Type::field());
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let x = e.add_parameter(Type::field());
             let w = e.write_witness(x);
             let a = e.add(w, x); // witness ∨ pure = witness
@@ -444,7 +441,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let x = e.add_parameter(Type::field());
             let w = e.write_witness(x);
             let cond = e.eq(w, x); // Witness condition
@@ -478,7 +475,7 @@ mod tests {
         // helper(p: Ref<Field>): *p = write_witness(7); return
         sb.modify_function(helper_id, |b| {
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let p = e.add_parameter(Type::field().ref_of());
             let c = e.field_const(fr(7));
             let w = e.write_witness(c);
@@ -489,7 +486,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let _x = e.add_parameter(Type::field());
             let c0 = e.field_const(fr(0));
             let q = e.alloc(c0);
@@ -512,7 +509,7 @@ mod tests {
         // rec(p: Ref<Field>): *p = write_witness(1); rec(p); return
         sb.modify_function(rec_id, |b| {
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let p = e.add_parameter(Type::field().ref_of());
             let c = e.field_const(fr(1));
             let w = e.write_witness(c);
@@ -523,7 +520,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let _x = e.add_parameter(Type::field());
             let c0 = e.field_const(fr(0));
             let q = e.alloc(c0);
@@ -547,7 +544,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let _x = e.add_parameter(Type::field());
             // inner: Ref<Field>, with a witness stored into its pointee.
             let c = e.field_const(fr(9));
@@ -578,7 +575,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let x = e.add_parameter(Type::field());
             let c0 = e.field_const(fr(0));
             let inner = e.alloc(c0);
@@ -623,7 +620,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let x = e.add_parameter(Type::field());
             let c0 = e.field_const(fr(0));
             let ra = e.alloc(c0);
@@ -656,7 +653,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let x = e.add_parameter(Type::field());
             let c1 = e.field_const(fr(1));
             let c2 = e.field_const(fr(2));
@@ -697,7 +694,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let x = e.add_parameter(Type::field());
             let c1 = e.field_const(fr(1));
             let c2 = e.field_const(fr(2));
@@ -737,7 +734,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let _x = e.add_parameter(Type::field());
             let c1 = e.field_const(fr(1));
             let c2 = e.field_const(fr(2));
@@ -763,7 +760,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let x = e.add_parameter(Type::field());
             let c0 = e.field_const(fr(0));
             let ra = e.alloc(c0);
@@ -791,7 +788,7 @@ mod tests {
             b.function.add_return_type(Type::field()); // the merge phi
             b.function.add_return_type(Type::field()); // load after the conditional store
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let x = e.add_parameter(Type::field());
             let w = e.write_witness(x);
             let zero = e.field_const(fr(0));
@@ -856,7 +853,7 @@ mod tests {
         sb.modify_function(helper_id, |b| {
             b.function.add_return_type(Type::field().ref_of());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let c = e.field_const(fr(17));
             let p = e.alloc(c);
             e.terminate_return(vec![p]);
@@ -865,7 +862,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let x = e.add_parameter(Type::field());
             let z = e.call(helper_id, vec![], 1)[0];
             let w = e.write_witness(x);
@@ -913,7 +910,7 @@ mod tests {
         sb.modify_function(inner_id, |b| {
             b.function.add_return_type(Type::field().ref_of());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let c = e.field_const(fr(17));
             let p = e.alloc(c);
             e.terminate_return(vec![p]);
@@ -922,14 +919,14 @@ mod tests {
         sb.modify_function(mid_id, |b| {
             b.function.add_return_type(Type::field().ref_of());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let r = e.call(inner_id, vec![], 1)[0];
             e.terminate_return(vec![r]);
         });
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let x = e.add_parameter(Type::field());
             let z = e.call(mid_id, vec![], 1)[0];
             let w = e.write_witness(x);
@@ -961,14 +958,14 @@ mod tests {
         sb.modify_function(rec_id, |b| {
             b.function.add_return_type(Type::field().ref_of());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let z = e.call(rec_id, vec![], 1)[0];
             e.terminate_return(vec![z]);
         });
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let x = e.add_parameter(Type::field());
             let z = e.call(rec_id, vec![], 1)[0];
             let w = e.write_witness(x);
@@ -999,7 +996,7 @@ mod tests {
         sb.modify_function(id_id, |b| {
             b.function.add_return_type(Type::field().ref_of());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let p = e.add_parameter(Type::field().ref_of());
             e.terminate_return(vec![p]);
         });
@@ -1007,7 +1004,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let x = e.add_parameter(Type::field());
             let c0 = e.field_const(fr(0));
             let q = e.alloc(c0);
@@ -1032,7 +1029,7 @@ mod tests {
         sb.modify_function(helper_id, |b| {
             b.function.add_return_type(Type::field().ref_of());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let c = e.field_const(fr(17));
             let p = e.alloc(c);
             e.terminate_return(vec![p]);
@@ -1040,7 +1037,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry).with_source_location(SourceLocation::test());
+            let mut e = b.test_block(entry);
             let _x = e.add_parameter(Type::field());
             let z = e.call(helper_id, vec![], 1)[0];
             let c5 = e.field_const(fr(5));

--- a/compiler/src/compiler/analysis/witness_taint_inference/mod.rs
+++ b/compiler/src/compiler/analysis/witness_taint_inference/mod.rs
@@ -277,9 +277,12 @@ struct FunctionSummary {
 mod tests {
     use super::*;
     use crate::compiler::analysis::witness_info::{WitnessShape, WitnessType};
-    use crate::compiler::ssa::hlssa::{
-        Type,
-        builder::{HLEmitter, HLSSABuilder},
+    use crate::compiler::ssa::{
+        SourceLocation,
+        hlssa::{
+            Type,
+            builder::{HLEmitter, HLSSABuilder},
+        },
     };
 
     fn pure() -> WitnessShape {
@@ -350,7 +353,7 @@ mod tests {
             b.function.add_return_type(Type::field());
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let x = e.add_parameter(Type::field());
             let w = e.write_witness(x);
             e.terminate_return(vec![x, w]);
@@ -370,7 +373,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::witness_of(Type::field()));
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let _x = e.add_parameter(Type::field());
             let c = e.field_const(fr(0));
             let w = e.cast_to_witness_of(c);
@@ -392,7 +395,7 @@ mod tests {
             b.function.add_return_type(Type::field());
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let x = e.add_parameter(Type::field());
             let c = e.field_const(fr(5));
             let p = e.alloc(c); // pure init store
@@ -416,7 +419,7 @@ mod tests {
             b.function.add_return_type(Type::field());
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let x = e.add_parameter(Type::field());
             let w = e.write_witness(x);
             let a = e.add(w, x); // witness ∨ pure = witness
@@ -441,7 +444,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let x = e.add_parameter(Type::field());
             let w = e.write_witness(x);
             let cond = e.eq(w, x); // Witness condition
@@ -475,7 +478,7 @@ mod tests {
         // helper(p: Ref<Field>): *p = write_witness(7); return
         sb.modify_function(helper_id, |b| {
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let p = e.add_parameter(Type::field().ref_of());
             let c = e.field_const(fr(7));
             let w = e.write_witness(c);
@@ -486,7 +489,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let _x = e.add_parameter(Type::field());
             let c0 = e.field_const(fr(0));
             let q = e.alloc(c0);
@@ -509,7 +512,7 @@ mod tests {
         // rec(p: Ref<Field>): *p = write_witness(1); rec(p); return
         sb.modify_function(rec_id, |b| {
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let p = e.add_parameter(Type::field().ref_of());
             let c = e.field_const(fr(1));
             let w = e.write_witness(c);
@@ -520,7 +523,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let _x = e.add_parameter(Type::field());
             let c0 = e.field_const(fr(0));
             let q = e.alloc(c0);
@@ -544,7 +547,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let _x = e.add_parameter(Type::field());
             // inner: Ref<Field>, with a witness stored into its pointee.
             let c = e.field_const(fr(9));
@@ -575,7 +578,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let x = e.add_parameter(Type::field());
             let c0 = e.field_const(fr(0));
             let inner = e.alloc(c0);
@@ -620,7 +623,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let x = e.add_parameter(Type::field());
             let c0 = e.field_const(fr(0));
             let ra = e.alloc(c0);
@@ -653,7 +656,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let x = e.add_parameter(Type::field());
             let c1 = e.field_const(fr(1));
             let c2 = e.field_const(fr(2));
@@ -694,7 +697,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let x = e.add_parameter(Type::field());
             let c1 = e.field_const(fr(1));
             let c2 = e.field_const(fr(2));
@@ -734,7 +737,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let _x = e.add_parameter(Type::field());
             let c1 = e.field_const(fr(1));
             let c2 = e.field_const(fr(2));
@@ -760,7 +763,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let x = e.add_parameter(Type::field());
             let c0 = e.field_const(fr(0));
             let ra = e.alloc(c0);
@@ -788,7 +791,7 @@ mod tests {
             b.function.add_return_type(Type::field()); // the merge phi
             b.function.add_return_type(Type::field()); // load after the conditional store
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let x = e.add_parameter(Type::field());
             let w = e.write_witness(x);
             let zero = e.field_const(fr(0));
@@ -853,7 +856,7 @@ mod tests {
         sb.modify_function(helper_id, |b| {
             b.function.add_return_type(Type::field().ref_of());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let c = e.field_const(fr(17));
             let p = e.alloc(c);
             e.terminate_return(vec![p]);
@@ -862,7 +865,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let x = e.add_parameter(Type::field());
             let z = e.call(helper_id, vec![], 1)[0];
             let w = e.write_witness(x);
@@ -910,7 +913,7 @@ mod tests {
         sb.modify_function(inner_id, |b| {
             b.function.add_return_type(Type::field().ref_of());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let c = e.field_const(fr(17));
             let p = e.alloc(c);
             e.terminate_return(vec![p]);
@@ -919,14 +922,14 @@ mod tests {
         sb.modify_function(mid_id, |b| {
             b.function.add_return_type(Type::field().ref_of());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let r = e.call(inner_id, vec![], 1)[0];
             e.terminate_return(vec![r]);
         });
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let x = e.add_parameter(Type::field());
             let z = e.call(mid_id, vec![], 1)[0];
             let w = e.write_witness(x);
@@ -958,14 +961,14 @@ mod tests {
         sb.modify_function(rec_id, |b| {
             b.function.add_return_type(Type::field().ref_of());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let z = e.call(rec_id, vec![], 1)[0];
             e.terminate_return(vec![z]);
         });
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let x = e.add_parameter(Type::field());
             let z = e.call(rec_id, vec![], 1)[0];
             let w = e.write_witness(x);
@@ -996,7 +999,7 @@ mod tests {
         sb.modify_function(id_id, |b| {
             b.function.add_return_type(Type::field().ref_of());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let p = e.add_parameter(Type::field().ref_of());
             e.terminate_return(vec![p]);
         });
@@ -1004,7 +1007,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let x = e.add_parameter(Type::field());
             let c0 = e.field_const(fr(0));
             let q = e.alloc(c0);
@@ -1029,7 +1032,7 @@ mod tests {
         sb.modify_function(helper_id, |b| {
             b.function.add_return_type(Type::field().ref_of());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let c = e.field_const(fr(17));
             let p = e.alloc(c);
             e.terminate_return(vec![p]);
@@ -1037,7 +1040,7 @@ mod tests {
         sb.modify_function(main_id, |b| {
             b.function.add_return_type(Type::field());
             let entry = b.function.get_entry_id();
-            let mut e = b.block(entry);
+            let mut e = b.block(entry).with_source_location(SourceLocation::test());
             let _x = e.add_parameter(Type::field());
             let z = e.call(helper_id, vec![], 1)[0];
             let c5 = e.field_const(fr(5));

--- a/compiler/src/compiler/located.rs
+++ b/compiler/src/compiler/located.rs
@@ -112,6 +112,17 @@ impl SourceLocation {
         )
     }
 
+    /// The location for compiler-synthesized code with no user-source anchor, such as generated
+    /// helper functions and dispatch stubs. `origin` names the generator, e.g. a pass or helper
+    /// name, and becomes the synthetic source identifier `<origin>`.
+    pub fn synthetic(origin: impl AsRef<str>) -> Self {
+        Self::new(
+            format!("<{}>", origin.as_ref()),
+            SourcePosition::new(1, 1),
+            SourcePosition::new(1, 1),
+        )
+    }
+
     pub fn new(file: impl Into<Arc<str>>, start: SourcePosition, end: SourcePosition) -> Self {
         Self {
             file: file.into(),

--- a/compiler/src/compiler/located.rs
+++ b/compiler/src/compiler/located.rs
@@ -100,9 +100,9 @@ impl SourceLocation {
         )
     }
 
-    /// The location for compiler-synthesized code with no user-source anchor, such as generated
-    /// helper functions and dispatch stubs. `origin` names the generator, e.g. a pass or helper
-    /// name, and becomes the synthetic source identifier `<origin>`.
+    /// The location for code with no user-source anchor, such as generated helper functions,
+    /// dispatch stubs, or last-resort handling for unlocated compiler input. `origin` names the
+    /// generator/context and becomes the synthetic source identifier `<origin>`.
     pub fn synthetic(origin: impl AsRef<str>) -> Self {
         Self::new(
             format!("<{}>", origin.as_ref()),

--- a/compiler/src/compiler/located.rs
+++ b/compiler/src/compiler/located.rs
@@ -6,48 +6,44 @@ use std::{
 
 use fm::{FileId, FileMap};
 
-/// A value bundled with its optional source location.
+/// A value bundled with its source location.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Located<T> {
     payload: T,
-    location: Location,
+    location: SourceLocation,
 }
 
 impl<T> Located<T> {
-    pub fn new(payload: T, location: Location) -> Self {
+    pub fn new(payload: T, location: SourceLocation) -> Self {
         Self { payload, location }
     }
 
-    pub fn without(payload: T) -> Self {
-        Self::new(payload, None)
-    }
-
     pub fn with(payload: T, location: SourceLocation) -> Self {
-        Self::new(payload, Some(location))
+        Self::new(payload, location)
     }
 
     pub fn payload(self) -> T {
         self.payload
     }
 
-    pub fn take(self) -> (T, Location) {
+    pub fn take(self) -> (T, SourceLocation) {
         (self.payload, self.location)
     }
 
-    pub fn location(&self) -> &Location {
+    pub fn location(&self) -> &SourceLocation {
         &self.location
     }
 
-    pub fn location_mut(&mut self) -> &mut Location {
+    pub fn location_mut(&mut self) -> &mut SourceLocation {
         &mut self.location
     }
 
-    pub fn get_location(&self) -> Option<&SourceLocation> {
-        self.location().as_ref()
+    pub fn get_location(&self) -> &SourceLocation {
+        self.location()
     }
 
-    pub fn get_location_mut(&mut self) -> Option<&mut SourceLocation> {
-        self.location_mut().as_mut()
+    pub fn get_location_mut(&mut self) -> &mut SourceLocation {
+        self.location_mut()
     }
 
     pub fn to_ref(&self) -> Located<&T> {
@@ -75,21 +71,11 @@ impl<T> AsRef<T> for Located<T> {
     }
 }
 
-impl<T> From<T> for Located<T> {
-    // TODO: Remove this once source locations become non-optional and callers must pass Located<T>.
-    fn from(value: T) -> Self {
-        Located::without(value)
-    }
-}
-
 impl<T: Display> Display for Located<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.payload.fmt(f)
     }
 }
-
-// TODO: Remove this alias once locations become non-optional and this can be `SourceLocation`.
-pub type Location = Option<SourceLocation>;
 
 /// Lines and columns, when available, are expected to be 1-based.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -110,13 +96,22 @@ pub struct SourceLocation {
     /// The user-facing source identifier.
     ///
     /// This should be an absolute filesystem path when the source is backed by a file, but remains
-    /// a string so compiler-generated and other synthetic sources can also be represented.
+    /// a string so synthetic source names can also be represented.
     pub file: Arc<str>,
     pub start: SourcePosition,
     pub end: SourcePosition,
 }
 
 impl SourceLocation {
+    #[cfg(test)]
+    pub fn test() -> Self {
+        Self::new(
+            "<test>",
+            SourcePosition::new(1, 1),
+            SourcePosition::new(1, 1),
+        )
+    }
+
     pub fn new(file: impl Into<Arc<str>>, start: SourcePosition, end: SourcePosition) -> Self {
         Self {
             file: file.into(),
@@ -199,17 +194,17 @@ mod tests {
         let mut location = test_location();
         let mut located = Located::with(1, location.clone());
 
-        assert_eq!(located.location(), &Some(location.clone()));
-        assert_eq!(located.get_location(), Some(&location));
-        located.get_location_mut().unwrap().start.line = 5;
+        assert_eq!(located.location(), &location);
+        assert_eq!(located.get_location(), &location);
+        located.get_location_mut().start.line = 5;
         location.start.line = 5;
         assert_eq!(AsRef::<i32>::as_ref(&located), &1);
 
         let located_ref = located.to_ref();
         assert_eq!(*located_ref, &1);
-        assert_eq!(located_ref.get_location(), Some(&location));
+        assert_eq!(located_ref.get_location(), &location);
 
-        assert_eq!(located.take(), (1, Some(location)));
+        assert_eq!(located.take(), (1, location));
     }
 
     #[test]

--- a/compiler/src/compiler/located.rs
+++ b/compiler/src/compiler/located.rs
@@ -18,10 +18,6 @@ impl<T> Located<T> {
         Self { payload, location }
     }
 
-    pub fn with(payload: T, location: SourceLocation) -> Self {
-        Self::new(payload, location)
-    }
-
     pub fn payload(self) -> T {
         self.payload
     }
@@ -36,14 +32,6 @@ impl<T> Located<T> {
 
     pub fn location_mut(&mut self) -> &mut SourceLocation {
         &mut self.location
-    }
-
-    pub fn get_location(&self) -> &SourceLocation {
-        self.location()
-    }
-
-    pub fn get_location_mut(&mut self) -> &mut SourceLocation {
-        self.location_mut()
     }
 
     pub fn to_ref(&self) -> Located<&T> {
@@ -203,24 +191,24 @@ mod tests {
     #[test]
     fn located_exposes_location_ref_and_take() {
         let mut location = test_location();
-        let mut located = Located::with(1, location.clone());
+        let mut located = Located::new(1, location.clone());
 
         assert_eq!(located.location(), &location);
-        assert_eq!(located.get_location(), &location);
-        located.get_location_mut().start.line = 5;
+        assert_eq!(located.location(), &location);
+        located.location_mut().start.line = 5;
         location.start.line = 5;
         assert_eq!(AsRef::<i32>::as_ref(&located), &1);
 
         let located_ref = located.to_ref();
         assert_eq!(*located_ref, &1);
-        assert_eq!(located_ref.get_location(), &location);
+        assert_eq!(located_ref.location(), &location);
 
         assert_eq!(located.take(), (1, location));
     }
 
     #[test]
     fn located_can_return_just_payload() {
-        let located = Located::with(1, test_location());
+        let located = Located::new(1, test_location());
 
         assert_eq!(located.payload(), 1);
     }

--- a/compiler/src/compiler/located.rs
+++ b/compiler/src/compiler/located.rs
@@ -188,12 +188,20 @@ mod tests {
         )
     }
 
+    /// The synthetic source identifier is the user-visible marker for compiler-generated code;
+    /// diagnostics rely on the `<origin>` spelling.
+    #[test]
+    fn synthetic_location_names_its_origin() {
+        let location = SourceLocation::synthetic("my_pass");
+        assert_eq!(&*location.file, "<my_pass>");
+        assert_eq!(location.to_string(), "<my_pass>:1:1");
+    }
+
     #[test]
     fn located_exposes_location_ref_and_take() {
         let mut location = test_location();
         let mut located = Located::new(1, location.clone());
 
-        assert_eq!(located.location(), &location);
         assert_eq!(located.location(), &location);
         located.location_mut().start.line = 5;
         location.start.line = 5;

--- a/compiler/src/compiler/lowering/expression_converter.rs
+++ b/compiler/src/compiler/lowering/expression_converter.rs
@@ -76,6 +76,11 @@ pub struct ExpressionConverter<'a> {
 
     /// Memoized user-facing source paths keyed by Noir file id.
     source_files: RefCell<HashMap<FileId, Arc<str>>>,
+
+    /// The most recently resolved source location, used as the location for emitted instructions
+    /// that have no Noir location of their own (e.g. the loop-index increment a `continue`
+    /// desugars to).
+    last_location: RefCell<Option<SourceLocation>>,
 }
 
 impl<'a> ExpressionConverter<'a> {
@@ -101,6 +106,7 @@ impl<'a> ExpressionConverter<'a> {
             current_block: entry_block,
             file_manager,
             source_files: RefCell::new(HashMap::default()),
+            last_location: RefCell::new(None),
         }
     }
 
@@ -115,10 +121,27 @@ impl<'a> ExpressionConverter<'a> {
         emit: impl FnOnce(&mut HLBlockEmitter<'_>) -> R,
     ) -> R {
         let mut e = b.block(self.current_block);
+        let source_location = self.resolve_location(location);
+        e.emit_with_location(source_location, emit)
+    }
+
+    /// Turn an optional Noir location into a definite `SourceLocation`.
+    ///
+    /// Locationless desugared instructions (loop-index increments, unit tuples, …) inherit the
+    /// most recently resolved location, which is the enclosing expression in practice; if nothing
+    /// has been resolved yet, they get a synthetic lowering location.
+    fn resolve_location(&self, location: Option<NoirLocation>) -> SourceLocation {
         let source_location = location
             .and_then(|location| self.source_location(location))
-            .expect("ICE: emitted SSA instruction without a source location");
-        e.emit_with_location(source_location, emit)
+            .or_else(|| self.last_location.borrow().clone())
+            .unwrap_or_else(|| SourceLocation::synthetic("lowering"));
+        *self.last_location.borrow_mut() = Some(source_location.clone());
+        source_location
+    }
+
+    /// The definite source location of `expr`, for callers that emit on the converter's behalf.
+    pub(super) fn expression_source_location(&self, expr: &Expression) -> SourceLocation {
+        self.resolve_location(Self::expression_location(expr))
     }
 
     fn source_location(&self, location: NoirLocation) -> Option<SourceLocation> {
@@ -222,8 +245,9 @@ impl<'a> ExpressionConverter<'a> {
         local_id: LocalId,
         value_id: ValueId,
         b: &mut HLFunctionBuilder<'_>,
+        location: SourceLocation,
     ) {
-        let mut e = b.block(self.current_block);
+        let mut e = b.block(self.current_block).with_source_location(location);
         let ptr = e.alloc(value_id);
         drop(e);
         self.bindings.insert(local_id, ptr);
@@ -599,7 +623,8 @@ impl<'a> ExpressionConverter<'a> {
 
         // Build header: parameter, condition, branch
         let loop_index = {
-            let mut header = b.block(loop_header);
+            let header_location = self.resolve_location(Some(for_expr.end_range_location));
+            let mut header = b.block(loop_header).with_source_location(header_location);
             let loop_index = header.add_parameter(index_type);
             let cond = header.lt(loop_index, end);
             header.terminate_jmp_if(cond, loop_body, exit_block);
@@ -1585,10 +1610,9 @@ impl<'a> ExpressionConverter<'a> {
             "vector_push_back" => {
                 let slice = self.convert_expression(&call.arguments[0], b).unwrap();
                 let elem = self.convert_expression(&call.arguments[1], b).unwrap();
-                Some(
-                    b.block(self.current_block)
-                        .slice_push(slice, vec![elem], SliceOpDir::Back),
-                )
+                Some(self.emit_located(b, Some(call.location), |e| {
+                    e.slice_push(slice, vec![elem], SliceOpDir::Back)
+                }))
             }
             _ => todo!("Builtin function '{}' not yet supported", name),
         }

--- a/compiler/src/compiler/lowering/expression_converter.rs
+++ b/compiler/src/compiler/lowering/expression_converter.rs
@@ -80,7 +80,7 @@ pub struct ExpressionConverter<'a> {
     /// The most recently resolved source location, used as the location for emitted instructions
     /// that have no Noir location of their own (e.g. the loop-index increment a `continue`
     /// desugars to).
-    last_location: RefCell<Option<SourceLocation>>,
+    last_location: Option<SourceLocation>,
 }
 
 impl<'a> ExpressionConverter<'a> {
@@ -106,7 +106,7 @@ impl<'a> ExpressionConverter<'a> {
             current_block: entry_block,
             file_manager,
             source_files: RefCell::new(HashMap::default()),
-            last_location: RefCell::new(None),
+            last_location: None,
         }
     }
 
@@ -115,14 +115,14 @@ impl<'a> ExpressionConverter<'a> {
     /// `emit` runs against the current block's emitter and returns the instruction's result; every
     /// instruction it pushes that does not already carry a location is annotated with `location`.
     fn emit_located<R>(
-        &self,
+        &mut self,
         b: &mut HLFunctionBuilder<'_>,
         location: Option<NoirLocation>,
         emit: impl FnOnce(&mut HLBlockEmitter<'_>) -> R,
     ) -> R {
-        let mut e = b.block(self.current_block);
         let source_location = self.resolve_location(location);
-        e.emit_with_location(source_location, emit)
+        b.block(self.current_block)
+            .emit_with_location(source_location, emit)
     }
 
     /// Turn an optional Noir location into a definite `SourceLocation`.
@@ -130,17 +130,17 @@ impl<'a> ExpressionConverter<'a> {
     /// Locationless desugared instructions (loop-index increments, unit tuples, …) inherit the
     /// most recently resolved location, which is the enclosing expression in practice; if nothing
     /// has been resolved yet, they get a synthetic lowering location.
-    fn resolve_location(&self, location: Option<NoirLocation>) -> SourceLocation {
+    fn resolve_location(&mut self, location: Option<NoirLocation>) -> SourceLocation {
         let source_location = location
             .and_then(|location| self.source_location(location))
-            .or_else(|| self.last_location.borrow().clone())
+            .or_else(|| self.last_location.clone())
             .unwrap_or_else(|| SourceLocation::synthetic("lowering"));
-        *self.last_location.borrow_mut() = Some(source_location.clone());
+        self.last_location = Some(source_location.clone());
         source_location
     }
 
     /// The definite source location of `expr`, for callers that emit on the converter's behalf.
-    pub(super) fn expression_source_location(&self, expr: &Expression) -> SourceLocation {
+    pub(super) fn expression_source_location(&mut self, expr: &Expression) -> SourceLocation {
         self.resolve_location(Self::expression_location(expr))
     }
 

--- a/compiler/src/compiler/lowering/expression_converter.rs
+++ b/compiler/src/compiler/lowering/expression_converter.rs
@@ -79,9 +79,9 @@ pub struct ExpressionConverter<'a> {
     /// Memoized user-facing source paths keyed by Noir file id.
     source_files: RefCell<HashMap<FileId, Arc<str>>>,
 
-    /// Source anchor inherited by locationless child expressions. This starts as a synthetic
-    /// last-resort fallback, but normally gets replaced by the nearest enclosing expression's
-    /// real source location while lowering.
+    /// Source anchor inherited by locationless child expressions. This starts at the Noir-internal
+    /// fallback, but normally gets replaced by the nearest enclosing expression's real source
+    /// location while lowering.
     current_source_location: SourceLocation,
 }
 
@@ -108,7 +108,7 @@ impl<'a> ExpressionConverter<'a> {
             current_block: entry_block,
             file_manager,
             source_files: RefCell::new(HashMap::default()),
-            current_source_location: SourceLocation::synthetic("lowering"),
+            current_source_location: SourceLocation::synthetic("Noir internal"),
         }
     }
 

--- a/compiler/src/compiler/lowering/expression_converter.rs
+++ b/compiler/src/compiler/lowering/expression_converter.rs
@@ -115,7 +115,9 @@ impl<'a> ExpressionConverter<'a> {
         emit: impl FnOnce(&mut HLBlockEmitter<'_>) -> R,
     ) -> R {
         let mut e = b.block(self.current_block);
-        let source_location = location.and_then(|location| self.source_location(location));
+        let source_location = location
+            .and_then(|location| self.source_location(location))
+            .expect("ICE: emitted SSA instruction without a source location");
         e.emit_with_location(source_location, emit)
     }
 

--- a/compiler/src/compiler/lowering/expression_converter.rs
+++ b/compiler/src/compiler/lowering/expression_converter.rs
@@ -31,7 +31,8 @@ use crate::{
 struct LoopContext {
     loop_header: BlockId,
     exit_block: BlockId,
-    source_location: SourceLocation,
+    /// Source anchor for desugared instructions emitted on behalf of the loop body.
+    body_source_location: SourceLocation,
     /// Only for `for` loops — (index_value, bit_size), used by Continue to increment.
     for_loop_index: Option<(ValueId, usize)>,
 }
@@ -78,9 +79,10 @@ pub struct ExpressionConverter<'a> {
     /// Memoized user-facing source paths keyed by Noir file id.
     source_files: RefCell<HashMap<FileId, Arc<str>>>,
 
-    /// Fallback location for expressions with no resolvable Noir location, built once so the
-    /// per-expression fallback path does not re-allocate it.
-    synthetic_location: SourceLocation,
+    /// Source anchor inherited by locationless child expressions. This starts as a synthetic
+    /// last-resort fallback, but normally gets replaced by the nearest enclosing expression's
+    /// real source location while lowering.
+    current_source_location: SourceLocation,
 }
 
 impl<'a> ExpressionConverter<'a> {
@@ -106,7 +108,7 @@ impl<'a> ExpressionConverter<'a> {
             current_block: entry_block,
             file_manager,
             source_files: RefCell::new(HashMap::default()),
-            synthetic_location: SourceLocation::synthetic("lowering"),
+            current_source_location: SourceLocation::synthetic("lowering"),
         }
     }
 
@@ -140,7 +142,7 @@ impl<'a> ExpressionConverter<'a> {
     fn resolve_location(&self, location: Option<NoirLocation>) -> SourceLocation {
         location
             .and_then(|location| self.source_location(location))
-            .unwrap_or_else(|| self.synthetic_location.clone())
+            .unwrap_or_else(|| self.current_source_location.clone())
     }
 
     /// The definite source location of `expr`, for callers that emit on the converter's behalf.
@@ -273,6 +275,19 @@ impl<'a> ExpressionConverter<'a> {
         expr: &Expression,
         b: &mut HLFunctionBuilder<'_>,
     ) -> Option<ValueId> {
+        let source_location = self.resolve_location(Self::expression_location(expr));
+        let previous_source_location =
+            std::mem::replace(&mut self.current_source_location, source_location);
+        let result = self.convert_expression_inner(expr, b);
+        self.current_source_location = previous_source_location;
+        result
+    }
+
+    fn convert_expression_inner(
+        &mut self,
+        expr: &Expression,
+        b: &mut HLFunctionBuilder<'_>,
+    ) -> Option<ValueId> {
         match expr {
             Expression::Ident(ident) => self.convert_ident(ident, b),
             Expression::Binary(binary) => self.convert_binary(binary, b),
@@ -311,19 +326,20 @@ impl<'a> ExpressionConverter<'a> {
                 None
             }
             Expression::Continue => {
-                let (loop_header, for_loop_index, source_location) = {
+                let (loop_header, for_loop_index, body_source_location) = {
                     let ctx = self.loop_stack.last().expect("continue outside of loop");
                     (
                         ctx.loop_header,
                         ctx.for_loop_index,
-                        ctx.source_location.clone(),
+                        ctx.body_source_location.clone(),
                     )
                 };
                 if let Some((loop_index, index_bit_size)) = for_loop_index {
                     // For loop: increment index and jump back to header
                     let one = b.emit_const(Constant::U(index_bit_size, 1));
-                    let next_index = self
-                        .emit_at_source_location(b, source_location, |e| e.add(loop_index, one));
+                    let next_index = self.emit_at_source_location(b, body_source_location, |e| {
+                        e.add(loop_index, one)
+                    });
                     b.block(self.current_block)
                         .terminate_jmp(loop_header, vec![next_index]);
                 } else {
@@ -610,7 +626,7 @@ impl<'a> ExpressionConverter<'a> {
     }
 
     fn convert_for(&mut self, for_expr: &For, b: &mut HLFunctionBuilder<'_>) -> Option<ValueId> {
-        let loop_location = self.resolve_location(Some(for_expr.start_range_location));
+        let body_source_location = self.expression_source_location(&for_expr.block);
 
         // Evaluate start and end range in the current block
         let start = self.convert_expression(&for_expr.start_range, b).unwrap();
@@ -660,7 +676,7 @@ impl<'a> ExpressionConverter<'a> {
         self.loop_stack.push(LoopContext {
             loop_header,
             exit_block,
-            source_location: loop_location,
+            body_source_location,
             for_loop_index: Some((loop_index, index_bit_size)),
         });
 
@@ -692,7 +708,7 @@ impl<'a> ExpressionConverter<'a> {
         while_expr: &While,
         b: &mut HLFunctionBuilder<'_>,
     ) -> Option<ValueId> {
-        let loop_location = self.expression_source_location(&while_expr.condition);
+        let body_source_location = self.expression_source_location(&while_expr.body);
 
         // Create blocks: loop_header evaluates condition, loop_body runs body, exit_block continues
         let loop_header = b.add_block(|_| {});
@@ -714,7 +730,7 @@ impl<'a> ExpressionConverter<'a> {
         self.loop_stack.push(LoopContext {
             loop_header,
             exit_block,
-            source_location: loop_location,
+            body_source_location,
             for_loop_index: None,
         });
 
@@ -740,7 +756,7 @@ impl<'a> ExpressionConverter<'a> {
         body: &Expression,
         b: &mut HLFunctionBuilder<'_>,
     ) -> Option<ValueId> {
-        let loop_location = self.expression_source_location(body);
+        let body_source_location = self.expression_source_location(body);
 
         // loop { body } — only exits via break
         let loop_block = b.add_block(|_| {});
@@ -755,7 +771,7 @@ impl<'a> ExpressionConverter<'a> {
         self.loop_stack.push(LoopContext {
             loop_header: loop_block,
             exit_block,
-            source_location: loop_location,
+            body_source_location,
             for_loop_index: None,
         });
 
@@ -1173,7 +1189,7 @@ impl<'a> ExpressionConverter<'a> {
                 let elem_type = Type::u(8);
                 let elems = s.bytes().map(|byte| Constant::U(8, byte as u128)).collect();
                 let blob = b.emit_const(Constant::Blob(Blob::new(elem_type.clone(), elems)));
-                let location = SourceLocation::synthetic("str_literal");
+                let location = self.current_source_location.clone();
                 let arr = self
                     .emit_at_source_location(b, location, |e| e.mk_seq_of_blob(elem_type, blob));
                 Some(arr)
@@ -1372,7 +1388,7 @@ impl<'a> ExpressionConverter<'a> {
             // Empty struct/tuple — still a value (e.g. A {})
             return Some(self.emit_at_source_location(
                 b,
-                SourceLocation::synthetic("empty_tuple"),
+                self.current_source_location.clone(),
                 |e| e.mk_tuple(vec![], vec![]),
             ));
         }

--- a/compiler/src/compiler/lowering/expression_converter.rs
+++ b/compiler/src/compiler/lowering/expression_converter.rs
@@ -77,6 +77,10 @@ pub struct ExpressionConverter<'a> {
 
     /// Memoized user-facing source paths keyed by Noir file id.
     source_files: RefCell<HashMap<FileId, Arc<str>>>,
+
+    /// Fallback location for expressions with no resolvable Noir location, built once so the
+    /// per-expression fallback path does not re-allocate it.
+    synthetic_location: SourceLocation,
 }
 
 impl<'a> ExpressionConverter<'a> {
@@ -102,6 +106,7 @@ impl<'a> ExpressionConverter<'a> {
             current_block: entry_block,
             file_manager,
             source_files: RefCell::new(HashMap::default()),
+            synthetic_location: SourceLocation::synthetic("lowering"),
         }
     }
 
@@ -116,8 +121,7 @@ impl<'a> ExpressionConverter<'a> {
         emit: impl FnOnce(&mut HLBlockEmitter<'_>) -> R,
     ) -> R {
         let source_location = self.resolve_location(location);
-        b.block(self.current_block)
-            .emit_with_location(source_location, emit)
+        self.emit_at_source_location(b, source_location, emit)
     }
 
     fn emit_at_source_location<R>(
@@ -126,23 +130,17 @@ impl<'a> ExpressionConverter<'a> {
         source_location: SourceLocation,
         emit: impl FnOnce(&mut HLBlockEmitter<'_>) -> R,
     ) -> R {
-        b.block(self.current_block)
-            .emit_with_location(source_location, emit)
+        let mut e = b
+            .block(self.current_block)
+            .with_source_location(source_location);
+        emit(&mut e)
     }
 
     /// Turn an optional Noir location into a definite `SourceLocation`.
     fn resolve_location(&self, location: Option<NoirLocation>) -> SourceLocation {
-        self.source_location_or_synthetic(location, "lowering")
-    }
-
-    fn source_location_or_synthetic(
-        &self,
-        location: Option<NoirLocation>,
-        synthetic_origin: impl AsRef<str>,
-    ) -> SourceLocation {
         location
             .and_then(|location| self.source_location(location))
-            .unwrap_or_else(|| SourceLocation::synthetic(synthetic_origin))
+            .unwrap_or_else(|| self.synthetic_location.clone())
     }
 
     /// The definite source location of `expr`, for callers that emit on the converter's behalf.

--- a/compiler/src/compiler/lowering/expression_converter.rs
+++ b/compiler/src/compiler/lowering/expression_converter.rs
@@ -31,6 +31,7 @@ use crate::{
 struct LoopContext {
     loop_header: BlockId,
     exit_block: BlockId,
+    source_location: SourceLocation,
     /// Only for `for` loops — (index_value, bit_size), used by Continue to increment.
     for_loop_index: Option<(ValueId, usize)>,
 }
@@ -76,11 +77,6 @@ pub struct ExpressionConverter<'a> {
 
     /// Memoized user-facing source paths keyed by Noir file id.
     source_files: RefCell<HashMap<FileId, Arc<str>>>,
-
-    /// The most recently resolved source location, used as the location for emitted instructions
-    /// that have no Noir location of their own (e.g. the loop-index increment a `continue`
-    /// desugars to).
-    last_location: Option<SourceLocation>,
 }
 
 impl<'a> ExpressionConverter<'a> {
@@ -106,7 +102,6 @@ impl<'a> ExpressionConverter<'a> {
             current_block: entry_block,
             file_manager,
             source_files: RefCell::new(HashMap::default()),
-            last_location: None,
         }
     }
 
@@ -125,22 +120,33 @@ impl<'a> ExpressionConverter<'a> {
             .emit_with_location(source_location, emit)
     }
 
+    fn emit_at_source_location<R>(
+        &mut self,
+        b: &mut HLFunctionBuilder<'_>,
+        source_location: SourceLocation,
+        emit: impl FnOnce(&mut HLBlockEmitter<'_>) -> R,
+    ) -> R {
+        b.block(self.current_block)
+            .emit_with_location(source_location, emit)
+    }
+
     /// Turn an optional Noir location into a definite `SourceLocation`.
-    ///
-    /// Locationless desugared instructions (loop-index increments, unit tuples, …) inherit the
-    /// most recently resolved location, which is the enclosing expression in practice; if nothing
-    /// has been resolved yet, they get a synthetic lowering location.
-    fn resolve_location(&mut self, location: Option<NoirLocation>) -> SourceLocation {
-        let source_location = location
+    fn resolve_location(&self, location: Option<NoirLocation>) -> SourceLocation {
+        self.source_location_or_synthetic(location, "lowering")
+    }
+
+    fn source_location_or_synthetic(
+        &self,
+        location: Option<NoirLocation>,
+        synthetic_origin: impl AsRef<str>,
+    ) -> SourceLocation {
+        location
             .and_then(|location| self.source_location(location))
-            .or_else(|| self.last_location.clone())
-            .unwrap_or_else(|| SourceLocation::synthetic("lowering"));
-        self.last_location = Some(source_location.clone());
-        source_location
+            .unwrap_or_else(|| SourceLocation::synthetic(synthetic_origin))
     }
 
     /// The definite source location of `expr`, for callers that emit on the converter's behalf.
-    pub(super) fn expression_source_location(&mut self, expr: &Expression) -> SourceLocation {
+    pub(super) fn expression_source_location(&self, expr: &Expression) -> SourceLocation {
         self.resolve_location(Self::expression_location(expr))
     }
 
@@ -307,13 +313,19 @@ impl<'a> ExpressionConverter<'a> {
                 None
             }
             Expression::Continue => {
-                let ctx = self.loop_stack.last().expect("continue outside of loop");
-                let loop_header = ctx.loop_header;
-                let for_loop_index = ctx.for_loop_index;
+                let (loop_header, for_loop_index, source_location) = {
+                    let ctx = self.loop_stack.last().expect("continue outside of loop");
+                    (
+                        ctx.loop_header,
+                        ctx.for_loop_index,
+                        ctx.source_location.clone(),
+                    )
+                };
                 if let Some((loop_index, index_bit_size)) = for_loop_index {
                     // For loop: increment index and jump back to header
                     let one = b.emit_const(Constant::U(index_bit_size, 1));
-                    let next_index = self.emit_located(b, None, |e| e.add(loop_index, one));
+                    let next_index = self
+                        .emit_at_source_location(b, source_location, |e| e.add(loop_index, one));
                     b.block(self.current_block)
                         .terminate_jmp(loop_header, vec![next_index]);
                 } else {
@@ -600,6 +612,8 @@ impl<'a> ExpressionConverter<'a> {
     }
 
     fn convert_for(&mut self, for_expr: &For, b: &mut HLFunctionBuilder<'_>) -> Option<ValueId> {
+        let loop_location = self.resolve_location(Some(for_expr.start_range_location));
+
         // Evaluate start and end range in the current block
         let start = self.convert_expression(&for_expr.start_range, b).unwrap();
         let end_raw = self.convert_expression(&for_expr.end_range, b).unwrap();
@@ -648,6 +662,7 @@ impl<'a> ExpressionConverter<'a> {
         self.loop_stack.push(LoopContext {
             loop_header,
             exit_block,
+            source_location: loop_location,
             for_loop_index: Some((loop_index, index_bit_size)),
         });
 
@@ -679,6 +694,8 @@ impl<'a> ExpressionConverter<'a> {
         while_expr: &While,
         b: &mut HLFunctionBuilder<'_>,
     ) -> Option<ValueId> {
+        let loop_location = self.expression_source_location(&while_expr.condition);
+
         // Create blocks: loop_header evaluates condition, loop_body runs body, exit_block continues
         let loop_header = b.add_block(|_| {});
         let loop_body = b.add_block(|_| {});
@@ -699,6 +716,7 @@ impl<'a> ExpressionConverter<'a> {
         self.loop_stack.push(LoopContext {
             loop_header,
             exit_block,
+            source_location: loop_location,
             for_loop_index: None,
         });
 
@@ -724,6 +742,8 @@ impl<'a> ExpressionConverter<'a> {
         body: &Expression,
         b: &mut HLFunctionBuilder<'_>,
     ) -> Option<ValueId> {
+        let loop_location = self.expression_source_location(body);
+
         // loop { body } — only exits via break
         let loop_block = b.add_block(|_| {});
         let exit_block = b.add_block(|_| {});
@@ -737,6 +757,7 @@ impl<'a> ExpressionConverter<'a> {
         self.loop_stack.push(LoopContext {
             loop_header: loop_block,
             exit_block,
+            source_location: loop_location,
             for_loop_index: None,
         });
 
@@ -1154,7 +1175,9 @@ impl<'a> ExpressionConverter<'a> {
                 let elem_type = Type::u(8);
                 let elems = s.bytes().map(|byte| Constant::U(8, byte as u128)).collect();
                 let blob = b.emit_const(Constant::Blob(Blob::new(elem_type.clone(), elems)));
-                let arr = self.emit_located(b, None, |e| e.mk_seq_of_blob(elem_type, blob));
+                let location = SourceLocation::synthetic("str_literal");
+                let arr = self
+                    .emit_at_source_location(b, location, |e| e.mk_seq_of_blob(elem_type, blob));
                 Some(arr)
             }
             Literal::FmtStr(fragments, _count, captures) => {
@@ -1349,7 +1372,11 @@ impl<'a> ExpressionConverter<'a> {
     ) -> Option<ValueId> {
         if exprs.is_empty() {
             // Empty struct/tuple — still a value (e.g. A {})
-            return Some(self.emit_located(b, None, |e| e.mk_tuple(vec![], vec![])));
+            return Some(self.emit_at_source_location(
+                b,
+                SourceLocation::synthetic("empty_tuple"),
+                |e| e.mk_tuple(vec![], vec![]),
+            ));
         }
 
         // Convert each element to a single materialized value

--- a/compiler/src/compiler/lowering/mod.rs
+++ b/compiler/src/compiler/lowering/mod.rs
@@ -13,7 +13,7 @@ use noirc_frontend::monomorphization::ast::{
 use crate::{
     collections::{HashMap, HashSet},
     compiler::ssa::{
-        FunctionId,
+        FunctionId, SourceLocation,
         hlssa::{
             HLFunction, HLSSA,
             builder::{HLEmitter, HLFunctionBuilder, HLSSABuilder},
@@ -298,7 +298,10 @@ impl SSAConverter {
                 let value = expr_converter.convert_expression(init_expr, b).unwrap();
                 current_block = expr_converter.current_block();
                 let idx = self.global_slots[gid];
-                b.block(current_block).init_global(idx, value);
+                let location = expr_converter.expression_source_location(init_expr);
+                b.block(current_block)
+                    .with_source_location(location)
+                    .init_global(idx, value);
                 if b.ssa.is_const(value) {
                     self.global_constants.insert(*gid, value);
                 }
@@ -311,9 +314,12 @@ impl SSAConverter {
         let deinit_fn_id = sb.ssa().add_function("globals_deinit".to_string());
         sb.modify_function(deinit_fn_id, |b| {
             let entry = b.function.get_entry_id();
+            let location = SourceLocation::synthetic("globals_deinit");
             for (i, typ) in global_types.iter().enumerate() {
                 if typ.is_heap_allocated() {
-                    b.block(entry).drop_global(i);
+                    b.block(entry)
+                        .with_source_location(location.clone())
+                        .drop_global(i);
                 }
             }
             b.block(entry).terminate_return(vec![]);
@@ -369,8 +375,10 @@ impl SSAConverter {
             let value_id = b.block(entry_block).add_parameter(converted_type);
 
             if *mutable {
-                // For mutable parameters, allocate a pointer and store the value
-                expr_converter.bind_local_mut(*local_id, value_id, &mut b);
+                // For mutable parameters, allocate a pointer and store the value. The alloc is
+                // attributed to the function body, the closest source anchor a parameter has.
+                let location = expr_converter.expression_source_location(&ast_func.body);
+                expr_converter.bind_local_mut(*local_id, value_id, &mut b, location);
             } else {
                 expr_converter.bind_local(*local_id, value_id);
             }

--- a/compiler/src/compiler/passes/arg_promotion.rs
+++ b/compiler/src/compiler/passes/arg_promotion.rs
@@ -609,9 +609,8 @@ fn rewrite_callee(func: &mut HLFunction, cp: &CalleePlan) {
         let lvs = &cp.return_loads[&bid];
         let block = func.get_block_mut(bid);
         let location = block
-            .get_instructions_with_source_locations()
-            .next_back()
-            .map(|(_, location)| location.clone())
+            .last_location()
+            .cloned()
             .unwrap_or_else(|| SourceLocation::synthetic("arg_promotion"));
         for (k, pp) in in_out.iter().enumerate() {
             block.push_instruction(
@@ -720,12 +719,9 @@ mod tests {
     use crate::compiler::{
         analysis::{flow_analysis::FlowAnalysis, types::Types},
         passes::mem2reg::Mem2Reg,
-        ssa::{
-            SourceLocation,
-            hlssa::{
-                SequenceTargetType,
-                builder::{HLEmitter, HLSSABuilder},
-            },
+        ssa::hlssa::{
+            SequenceTargetType,
+            builder::{HLEmitter, HLSSABuilder},
         },
         util::test::{falloc, fr},
     };
@@ -794,7 +790,7 @@ mod tests {
             // g(p: Ref<Field>): *p = *p + 1; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p = e.add_parameter(Type::field().ref_of());
                 let v = e.load(p);
                 let one = e.field_const(fr(1));
@@ -806,7 +802,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));
                 e.store(a, c);
@@ -851,7 +847,7 @@ mod tests {
                 let arr_ty = arr_ty.clone();
                 move |b| {
                     let entry = b.function.get_entry_id();
-                    let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                    let mut e = b.test_block(entry);
                     let p = e.add_parameter(arr_ty.ref_of());
                     let arr = e.load(p);
                     let i0 = e.u_const(32, 0);
@@ -864,7 +860,7 @@ mod tests {
             // main(): a = alloc; *a = [1,2,3]; g(a); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let c1 = e.field_const(fr(1));
                 let c2 = e.field_const(fr(2));
                 let c3 = e.field_const(fr(3));
@@ -901,7 +897,7 @@ mod tests {
             sb.modify_function(g, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p = e.add_parameter(Type::field().ref_of());
                 let v = e.load(p);
                 e.terminate_return(vec![v]);
@@ -910,7 +906,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));
                 e.store(a, c);
@@ -942,7 +938,7 @@ mod tests {
             // g(p0: Ref<F>, p1: Ref<F>): *p0 = *p0 + *p1; *p1 = 0; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p0 = e.add_parameter(Type::field().ref_of());
                 let p1 = e.add_parameter(Type::field().ref_of());
                 let v0 = e.load(p0);
@@ -957,7 +953,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = falloc(&mut e);
                 let bb = falloc(&mut e);
                 let c1 = e.field_const(fr(1));
@@ -1000,7 +996,7 @@ mod tests {
             // g(p: Ref<Field>): *p = *p + 1; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p = e.add_parameter(Type::field().ref_of());
                 let v = e.load(p);
                 let one = e.field_const(fr(1));
@@ -1011,7 +1007,7 @@ mod tests {
             // h(): c = alloc; *c = 9; g(c); return
             sb.modify_function(h, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let c = falloc(&mut e);
                 let nine = e.field_const(fr(9));
                 e.store(c, nine);
@@ -1021,7 +1017,7 @@ mod tests {
             // main(): a = alloc; *a = 5; g(a); h(); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = falloc(&mut e);
                 let five = e.field_const(fr(5));
                 e.store(a, five);
@@ -1053,7 +1049,7 @@ mod tests {
             // g(p: Ref<Field>): let q = alloc; *q = *p; g(q); *p = *q; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p = e.add_parameter(Type::field().ref_of());
                 let v = e.load(p);
                 let q = falloc(&mut e);
@@ -1066,7 +1062,7 @@ mod tests {
             // main(): a = alloc; *a = 0; g(a); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = falloc(&mut e);
                 let z = e.field_const(fr(0));
                 e.store(a, z);
@@ -1102,7 +1098,7 @@ mod tests {
             // g(p: Ref<Field>): global[0] = p; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p = e.add_parameter(Type::field().ref_of());
                 e.init_global(0, p);
                 e.terminate_return(vec![]);
@@ -1110,7 +1106,7 @@ mod tests {
             // main(): a = alloc; *a = 5; g(a); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));
                 e.store(a, c);
@@ -1138,7 +1134,7 @@ mod tests {
             // g(p0: Ref<F>, p1: Ref<F>): *p0 = *p0 + *p1; *p1 = 0; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p0 = e.add_parameter(Type::field().ref_of());
                 let p1 = e.add_parameter(Type::field().ref_of());
                 let v0 = e.load(p0);
@@ -1152,7 +1148,7 @@ mod tests {
             // main(): a = alloc; *a = 5; g(a, a); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));
                 e.store(a, c);
@@ -1180,7 +1176,7 @@ mod tests {
             // g(p0: Ref<F>, pp: Ref<Ref<F>>): *p0 = *p0 + 1; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p0 = e.add_parameter(Type::field().ref_of());
                 let _pp = e.add_parameter(Type::field().ref_of().ref_of());
                 let v = e.load(p0);
@@ -1192,7 +1188,7 @@ mod tests {
             // main(): a = alloc F; *a = 5; rr = alloc Ref<F>; *rr = a; g(a, rr); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));
                 e.store(a, c);
@@ -1224,7 +1220,7 @@ mod tests {
             // sink(p: Ref<Field>): global[0] = p; return  (leaks, so not itself promotable)
             sb.modify_function(sink, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p = e.add_parameter(Type::field().ref_of());
                 e.init_global(0, p);
                 e.terminate_return(vec![]);
@@ -1232,7 +1228,7 @@ mod tests {
             // g(p: Ref<Field>): sink(p); return  (forwards its ref param onward)
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p = e.add_parameter(Type::field().ref_of());
                 e.call(sink, vec![p], 0);
                 e.terminate_return(vec![]);
@@ -1240,7 +1236,7 @@ mod tests {
             // main(): a = alloc; *a = 5; g(a); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));
                 e.store(a, c);
@@ -1273,7 +1269,7 @@ mod tests {
             // g(p: Ref<Field>): *p = *p + 1; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p = e.add_parameter(Type::field().ref_of());
                 let v = e.load(p);
                 let one = e.field_const(fr(1));
@@ -1284,7 +1280,7 @@ mod tests {
             // main(): take g's address, then call it normally.
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let _fp = e.emit_constant(Constant::FnPtr(g));
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));

--- a/compiler/src/compiler/passes/arg_promotion.rs
+++ b/compiler/src/compiler/passes/arg_promotion.rs
@@ -575,7 +575,8 @@ fn rewrite_callee(func: &mut HLFunction, cp: &CalleePlan) {
         let old_instrs = entry.take_instructions();
         let entry_location = old_instrs
             .first()
-            .and_then(|instruction| instruction.location().clone());
+            .map(|instruction| instruction.location().clone())
+            .expect("ICE: promoted callee entry has no instruction source location");
         let mut new_instrs = Vec::with_capacity(old_instrs.len() + cp.params.len() * 2);
         for pp in &cp.params {
             // The alloc carries its initial value, so seed it directly from the by-value parameter
@@ -607,11 +608,19 @@ fn rewrite_callee(func: &mut HLFunction, cp: &CalleePlan) {
     for bid in return_blocks {
         let lvs = &cp.return_loads[&bid];
         let block = func.get_block_mut(bid);
+        let location = block
+            .get_instructions_with_source_locations()
+            .next_back()
+            .map(|(_, location)| location.clone())
+            .expect("ICE: promoted return block has no instruction source location");
         for (k, pp) in in_out.iter().enumerate() {
-            block.push_instruction(OpCode::Load {
-                result: lvs[k],
-                ptr: pp.alloc,
-            });
+            block.push_instruction(
+                OpCode::Load {
+                    result: lvs[k],
+                    ptr: pp.alloc,
+                }
+                .locate(location.clone()),
+            );
         }
         match block.get_terminator_mut() {
             Terminator::Return(vals) => vals.extend(lvs.iter().copied()),
@@ -711,9 +720,12 @@ mod tests {
     use crate::compiler::{
         analysis::{flow_analysis::FlowAnalysis, types::Types},
         passes::mem2reg::Mem2Reg,
-        ssa::hlssa::{
-            SequenceTargetType,
-            builder::{HLEmitter, HLSSABuilder},
+        ssa::{
+            SourceLocation,
+            hlssa::{
+                SequenceTargetType,
+                builder::{HLEmitter, HLSSABuilder},
+            },
         },
         util::test::{falloc, fr},
     };
@@ -782,7 +794,7 @@ mod tests {
             // g(p: Ref<Field>): *p = *p + 1; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p = e.add_parameter(Type::field().ref_of());
                 let v = e.load(p);
                 let one = e.field_const(fr(1));
@@ -794,7 +806,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));
                 e.store(a, c);
@@ -839,7 +851,7 @@ mod tests {
                 let arr_ty = arr_ty.clone();
                 move |b| {
                     let entry = b.function.get_entry_id();
-                    let mut e = b.block(entry);
+                    let mut e = b.block(entry).with_source_location(SourceLocation::test());
                     let p = e.add_parameter(arr_ty.ref_of());
                     let arr = e.load(p);
                     let i0 = e.u_const(32, 0);
@@ -852,7 +864,7 @@ mod tests {
             // main(): a = alloc; *a = [1,2,3]; g(a); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let c1 = e.field_const(fr(1));
                 let c2 = e.field_const(fr(2));
                 let c3 = e.field_const(fr(3));
@@ -889,7 +901,7 @@ mod tests {
             sb.modify_function(g, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p = e.add_parameter(Type::field().ref_of());
                 let v = e.load(p);
                 e.terminate_return(vec![v]);
@@ -898,7 +910,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));
                 e.store(a, c);
@@ -930,7 +942,7 @@ mod tests {
             // g(p0: Ref<F>, p1: Ref<F>): *p0 = *p0 + *p1; *p1 = 0; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p0 = e.add_parameter(Type::field().ref_of());
                 let p1 = e.add_parameter(Type::field().ref_of());
                 let v0 = e.load(p0);
@@ -945,7 +957,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = falloc(&mut e);
                 let bb = falloc(&mut e);
                 let c1 = e.field_const(fr(1));
@@ -988,7 +1000,7 @@ mod tests {
             // g(p: Ref<Field>): *p = *p + 1; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p = e.add_parameter(Type::field().ref_of());
                 let v = e.load(p);
                 let one = e.field_const(fr(1));
@@ -999,7 +1011,7 @@ mod tests {
             // h(): c = alloc; *c = 9; g(c); return
             sb.modify_function(h, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let c = falloc(&mut e);
                 let nine = e.field_const(fr(9));
                 e.store(c, nine);
@@ -1009,7 +1021,7 @@ mod tests {
             // main(): a = alloc; *a = 5; g(a); h(); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = falloc(&mut e);
                 let five = e.field_const(fr(5));
                 e.store(a, five);
@@ -1041,7 +1053,7 @@ mod tests {
             // g(p: Ref<Field>): let q = alloc; *q = *p; g(q); *p = *q; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p = e.add_parameter(Type::field().ref_of());
                 let v = e.load(p);
                 let q = falloc(&mut e);
@@ -1054,7 +1066,7 @@ mod tests {
             // main(): a = alloc; *a = 0; g(a); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = falloc(&mut e);
                 let z = e.field_const(fr(0));
                 e.store(a, z);
@@ -1090,7 +1102,7 @@ mod tests {
             // g(p: Ref<Field>): global[0] = p; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p = e.add_parameter(Type::field().ref_of());
                 e.init_global(0, p);
                 e.terminate_return(vec![]);
@@ -1098,7 +1110,7 @@ mod tests {
             // main(): a = alloc; *a = 5; g(a); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));
                 e.store(a, c);
@@ -1126,7 +1138,7 @@ mod tests {
             // g(p0: Ref<F>, p1: Ref<F>): *p0 = *p0 + *p1; *p1 = 0; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p0 = e.add_parameter(Type::field().ref_of());
                 let p1 = e.add_parameter(Type::field().ref_of());
                 let v0 = e.load(p0);
@@ -1140,7 +1152,7 @@ mod tests {
             // main(): a = alloc; *a = 5; g(a, a); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));
                 e.store(a, c);
@@ -1168,7 +1180,7 @@ mod tests {
             // g(p0: Ref<F>, pp: Ref<Ref<F>>): *p0 = *p0 + 1; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p0 = e.add_parameter(Type::field().ref_of());
                 let _pp = e.add_parameter(Type::field().ref_of().ref_of());
                 let v = e.load(p0);
@@ -1180,7 +1192,7 @@ mod tests {
             // main(): a = alloc F; *a = 5; rr = alloc Ref<F>; *rr = a; g(a, rr); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));
                 e.store(a, c);
@@ -1212,7 +1224,7 @@ mod tests {
             // sink(p: Ref<Field>): global[0] = p; return  (leaks, so not itself promotable)
             sb.modify_function(sink, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p = e.add_parameter(Type::field().ref_of());
                 e.init_global(0, p);
                 e.terminate_return(vec![]);
@@ -1220,7 +1232,7 @@ mod tests {
             // g(p: Ref<Field>): sink(p); return  (forwards its ref param onward)
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p = e.add_parameter(Type::field().ref_of());
                 e.call(sink, vec![p], 0);
                 e.terminate_return(vec![]);
@@ -1228,7 +1240,7 @@ mod tests {
             // main(): a = alloc; *a = 5; g(a); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));
                 e.store(a, c);
@@ -1261,7 +1273,7 @@ mod tests {
             // g(p: Ref<Field>): *p = *p + 1; return
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p = e.add_parameter(Type::field().ref_of());
                 let v = e.load(p);
                 let one = e.field_const(fr(1));
@@ -1272,7 +1284,7 @@ mod tests {
             // main(): take g's address, then call it normally.
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let _fp = e.emit_constant(Constant::FnPtr(g));
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));

--- a/compiler/src/compiler/passes/arg_promotion.rs
+++ b/compiler/src/compiler/passes/arg_promotion.rs
@@ -93,7 +93,7 @@ use crate::{
         pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
         passes::shared::value_replacements::{ReplaceScope, ValueReplacements},
         ssa::{
-            BlockId, FunctionId, Terminator, ValueId,
+            BlockId, FunctionId, SourceLocation, Terminator, ValueId,
             hlssa::{CallTarget, Constant, HLFunction, HLSSA, OpCode, Type, TypeExpr},
         },
     },
@@ -576,7 +576,7 @@ fn rewrite_callee(func: &mut HLFunction, cp: &CalleePlan) {
         let entry_location = old_instrs
             .first()
             .map(|instruction| instruction.location().clone())
-            .expect("ICE: promoted callee entry has no instruction source location");
+            .unwrap_or_else(|| SourceLocation::synthetic("arg_promotion"));
         let mut new_instrs = Vec::with_capacity(old_instrs.len() + cp.params.len() * 2);
         for pp in &cp.params {
             // The alloc carries its initial value, so seed it directly from the by-value parameter
@@ -612,7 +612,7 @@ fn rewrite_callee(func: &mut HLFunction, cp: &CalleePlan) {
             .get_instructions_with_source_locations()
             .next_back()
             .map(|(_, location)| location.clone())
-            .expect("ICE: promoted return block has no instruction source location");
+            .unwrap_or_else(|| SourceLocation::synthetic("arg_promotion"));
         for (k, pp) in in_out.iter().enumerate() {
             block.push_instruction(
                 OpCode::Load {

--- a/compiler/src/compiler/passes/array_boundary_expansion.rs
+++ b/compiler/src/compiler/passes/array_boundary_expansion.rs
@@ -582,9 +582,8 @@ fn rewrite_callee(func: &mut HLFunction, cp: &CalleePlan, index_consts: &[ValueI
         let entry_id = func.get_entry_id();
         let entry = func.get_block_mut(entry_id);
         let entry_location = entry
-            .get_instructions_with_source_locations()
-            .next()
-            .map(|(_, location)| location.clone())
+            .first_location()
+            .cloned()
             .unwrap_or_else(|| SourceLocation::synthetic("array_boundary_expansion"));
         let old_params = entry.take_parameters();
         let mut new_params = Vec::with_capacity(old_params.len());
@@ -632,9 +631,8 @@ fn rewrite_callee(func: &mut HLFunction, cp: &CalleePlan, index_consts: &[ValueI
             // Emit per-cell `ArrayGet`s from each expanded returned array (defined earlier in the
             // block, so it is in scope here at the end of the body).
             let location = block
-                .get_instructions_with_source_locations()
-                .next_back()
-                .map(|(_, location)| location.clone())
+                .last_location()
+                .cloned()
                 .unwrap_or_else(|| SourceLocation::synthetic("array_boundary_expansion"));
             for (pos_idx, re) in cp.returns.iter().enumerate() {
                 let arr = values[re.position];
@@ -803,10 +801,7 @@ mod tests {
             dead_code_elimination::{Config, DCE},
             mem2reg::Mem2Reg,
         },
-        ssa::{
-            SourceLocation,
-            hlssa::builder::{HLEmitter, HLSSABuilder},
-        },
+        ssa::hlssa::builder::{HLEmitter, HLSSABuilder},
     };
 
     fn fr(n: u64) -> ark_bn254::Fr {
@@ -889,7 +884,7 @@ mod tests {
             sb.modify_function(sink, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = e.add_parameter(Type::field().array_of(2));
                 let i0 = e.u_const(32, 0);
                 let i1 = e.u_const(32, 1);
@@ -902,7 +897,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let c3 = e.field_const(fr(3));
                 let c4 = e.field_const(fr(4));
                 let arr = e.mk_seq(vec![c3, c4], SequenceTargetType::Array(2), Type::field());
@@ -949,7 +944,7 @@ mod tests {
             sb.modify_function(make, |b| {
                 b.function.add_return_type(Type::field().array_of(2));
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let c7 = e.field_const(fr(7));
                 let c9 = e.field_const(fr(9));
                 let arr = e.mk_seq(vec![c7, c9], SequenceTargetType::Array(2), Type::field());
@@ -959,7 +954,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = e.call(make, vec![], 1)[0];
                 let i0 = e.u_const(32, 0);
                 let i1 = e.u_const(32, 1);
@@ -1004,7 +999,7 @@ mod tests {
             sb.modify_function(sink, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = e.add_parameter(Type::field().array_of(2));
                 let i0 = e.u_const(32, 0);
                 let x = e.array_get(a, i0);
@@ -1013,7 +1008,7 @@ mod tests {
             // main(): arr = [3, 4]; global[0] = sink(arr); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let c3 = e.field_const(fr(3));
                 let c4 = e.field_const(fr(4));
                 let arr = e.mk_seq(vec![c3, c4], SequenceTargetType::Array(2), Type::field());
@@ -1053,7 +1048,7 @@ mod tests {
             sb.modify_function(sink, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = e.add_parameter(Type::field().array_of(2));
                 let i = e.add_parameter(Type::u(32));
                 let x = e.array_get(a, i);
@@ -1063,7 +1058,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let c3 = e.field_const(fr(3));
                 let c4 = e.field_const(fr(4));
                 let arr = e.mk_seq(vec![c3, c4], SequenceTargetType::Array(2), Type::field());
@@ -1094,7 +1089,7 @@ mod tests {
             // sink(a: Array<Field,2>): global[0] = a; return   (leaks ⇒ not itself expandable)
             sb.modify_function(sink, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = e.add_parameter(Type::field().array_of(2));
                 e.init_global(0, a);
                 e.terminate_return(vec![]);
@@ -1102,7 +1097,7 @@ mod tests {
             // g(a: Array<Field,2>): sink(a); return   (forwards its array param onward)
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = e.add_parameter(Type::field().array_of(2));
                 e.call(sink, vec![a], 0);
                 e.terminate_return(vec![]);
@@ -1110,7 +1105,7 @@ mod tests {
             // main(): arr = [3, 4]; g(arr); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let c3 = e.field_const(fr(3));
                 let c4 = e.field_const(fr(4));
                 let arr = e.mk_seq(vec![c3, c4], SequenceTargetType::Array(2), Type::field());

--- a/compiler/src/compiler/passes/array_boundary_expansion.rs
+++ b/compiler/src/compiler/passes/array_boundary_expansion.rs
@@ -584,7 +584,8 @@ fn rewrite_callee(func: &mut HLFunction, cp: &CalleePlan, index_consts: &[ValueI
         let entry_location = entry
             .get_instructions_with_source_locations()
             .next()
-            .and_then(|(_, location)| location.cloned());
+            .map(|(_, location)| location.clone())
+            .expect("ICE: expanded callee entry has no instruction source location");
         let old_params = entry.take_parameters();
         let mut new_params = Vec::with_capacity(old_params.len());
         let mut reconstructs: Vec<LocatedOpCode> = Vec::with_capacity(cp.params.len());
@@ -630,15 +631,23 @@ fn rewrite_callee(func: &mut HLFunction, cp: &CalleePlan, index_consts: &[ValueI
 
             // Emit per-cell `ArrayGet`s from each expanded returned array (defined earlier in the
             // block, so it is in scope here at the end of the body).
+            let location = block
+                .get_instructions_with_source_locations()
+                .next_back()
+                .map(|(_, location)| location.clone())
+                .expect("ICE: expanded return block has no instruction source location");
             for (pos_idx, re) in cp.returns.iter().enumerate() {
                 let arr = values[re.position];
                 let cells = &cells_per_pos[pos_idx];
                 for k in 0..re.n {
-                    block.push_instruction(OpCode::ArrayGet {
-                        result: cells[k],
-                        array: arr,
-                        index: index_consts[k],
-                    });
+                    block.push_instruction(
+                        OpCode::ArrayGet {
+                            result: cells[k],
+                            array: arr,
+                            index: index_consts[k],
+                        }
+                        .locate(location.clone()),
+                    );
                 }
             }
 
@@ -794,7 +803,10 @@ mod tests {
             dead_code_elimination::{Config, DCE},
             mem2reg::Mem2Reg,
         },
-        ssa::hlssa::builder::{HLEmitter, HLSSABuilder},
+        ssa::{
+            SourceLocation,
+            hlssa::builder::{HLEmitter, HLSSABuilder},
+        },
     };
 
     fn fr(n: u64) -> ark_bn254::Fr {
@@ -877,7 +889,7 @@ mod tests {
             sb.modify_function(sink, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = e.add_parameter(Type::field().array_of(2));
                 let i0 = e.u_const(32, 0);
                 let i1 = e.u_const(32, 1);
@@ -890,7 +902,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let c3 = e.field_const(fr(3));
                 let c4 = e.field_const(fr(4));
                 let arr = e.mk_seq(vec![c3, c4], SequenceTargetType::Array(2), Type::field());
@@ -937,7 +949,7 @@ mod tests {
             sb.modify_function(make, |b| {
                 b.function.add_return_type(Type::field().array_of(2));
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let c7 = e.field_const(fr(7));
                 let c9 = e.field_const(fr(9));
                 let arr = e.mk_seq(vec![c7, c9], SequenceTargetType::Array(2), Type::field());
@@ -947,7 +959,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = e.call(make, vec![], 1)[0];
                 let i0 = e.u_const(32, 0);
                 let i1 = e.u_const(32, 1);
@@ -992,7 +1004,7 @@ mod tests {
             sb.modify_function(sink, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = e.add_parameter(Type::field().array_of(2));
                 let i0 = e.u_const(32, 0);
                 let x = e.array_get(a, i0);
@@ -1001,7 +1013,7 @@ mod tests {
             // main(): arr = [3, 4]; global[0] = sink(arr); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let c3 = e.field_const(fr(3));
                 let c4 = e.field_const(fr(4));
                 let arr = e.mk_seq(vec![c3, c4], SequenceTargetType::Array(2), Type::field());
@@ -1041,7 +1053,7 @@ mod tests {
             sb.modify_function(sink, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = e.add_parameter(Type::field().array_of(2));
                 let i = e.add_parameter(Type::u(32));
                 let x = e.array_get(a, i);
@@ -1051,7 +1063,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let c3 = e.field_const(fr(3));
                 let c4 = e.field_const(fr(4));
                 let arr = e.mk_seq(vec![c3, c4], SequenceTargetType::Array(2), Type::field());
@@ -1082,7 +1094,7 @@ mod tests {
             // sink(a: Array<Field,2>): global[0] = a; return   (leaks ⇒ not itself expandable)
             sb.modify_function(sink, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = e.add_parameter(Type::field().array_of(2));
                 e.init_global(0, a);
                 e.terminate_return(vec![]);
@@ -1090,7 +1102,7 @@ mod tests {
             // g(a: Array<Field,2>): sink(a); return   (forwards its array param onward)
             sb.modify_function(g, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = e.add_parameter(Type::field().array_of(2));
                 e.call(sink, vec![a], 0);
                 e.terminate_return(vec![]);
@@ -1098,7 +1110,7 @@ mod tests {
             // main(): arr = [3, 4]; g(arr); return
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let c3 = e.field_const(fr(3));
                 let c4 = e.field_const(fr(4));
                 let arr = e.mk_seq(vec![c3, c4], SequenceTargetType::Array(2), Type::field());

--- a/compiler/src/compiler/passes/array_boundary_expansion.rs
+++ b/compiler/src/compiler/passes/array_boundary_expansion.rs
@@ -90,7 +90,7 @@ use crate::{
         analysis::{points_to::PointsTo, types::TypeInfo},
         pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
         ssa::{
-            BlockId, FunctionId, Terminator, ValueId,
+            BlockId, FunctionId, SourceLocation, Terminator, ValueId,
             hlssa::{
                 CallTarget, Constant, HLFunction, HLSSA, LocatedOpCode, OpCode, SequenceTargetType,
                 Type, TypeExpr,
@@ -585,7 +585,7 @@ fn rewrite_callee(func: &mut HLFunction, cp: &CalleePlan, index_consts: &[ValueI
             .get_instructions_with_source_locations()
             .next()
             .map(|(_, location)| location.clone())
-            .expect("ICE: expanded callee entry has no instruction source location");
+            .unwrap_or_else(|| SourceLocation::synthetic("array_boundary_expansion"));
         let old_params = entry.take_parameters();
         let mut new_params = Vec::with_capacity(old_params.len());
         let mut reconstructs: Vec<LocatedOpCode> = Vec::with_capacity(cp.params.len());
@@ -635,7 +635,7 @@ fn rewrite_callee(func: &mut HLFunction, cp: &CalleePlan, index_consts: &[ValueI
                 .get_instructions_with_source_locations()
                 .next_back()
                 .map(|(_, location)| location.clone())
-                .expect("ICE: expanded return block has no instruction source location");
+                .unwrap_or_else(|| SourceLocation::synthetic("array_boundary_expansion"));
             for (pos_idx, re) in cp.returns.iter().enumerate() {
                 let arr = values[re.position];
                 let cells = &cells_per_pos[pos_idx];

--- a/compiler/src/compiler/passes/array_sroa.rs
+++ b/compiler/src/compiler/passes/array_sroa.rs
@@ -507,9 +507,12 @@ mod tests {
     use crate::compiler::{
         analysis::types::Types,
         passes::mem2reg::Mem2Reg,
-        ssa::hlssa::{
-            Blob, CastTarget, SequenceTargetType,
-            builder::{HLEmitter, HLSSABuilder},
+        ssa::{
+            SourceLocation,
+            hlssa::{
+                Blob, CastTarget, SequenceTargetType,
+                builder::{HLEmitter, HLSSABuilder},
+            },
         },
     };
 
@@ -601,7 +604,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let x = e.field_const(fr(7));
                 let y = e.field_const(fr(9));
                 let arr = e.mk_seq(vec![x, y], SequenceTargetType::Array(2), Type::field());
@@ -629,7 +632,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let x = e.field_const(fr(1));
                 let y = e.field_const(fr(2));
                 let z = e.field_const(fr(3));
@@ -661,7 +664,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let cond = e.add_parameter(Type::bool());
                 let a = e.field_const(fr(1));
                 let bb = e.field_const(fr(2));
@@ -703,7 +706,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let n = e.add_parameter(Type::u(32)); // dynamic index
                 let x = e.field_const(fr(7));
                 let y = e.field_const(fr(9));
@@ -729,7 +732,7 @@ mod tests {
             let mut sb = HLSSABuilder::new(&mut ssa);
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let x = e.field_const(fr(1));
                 let y = e.field_const(fr(2));
                 let z = e.field_const(fr(3));
@@ -757,7 +760,7 @@ mod tests {
             sb.modify_function(sink, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = e.add_parameter(arr2(Type::field()));
                 let i0 = e.u_const(32, 0);
                 let got = e.array_get(a, i0);
@@ -767,7 +770,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let x = e.field_const(fr(7));
                 let y = e.field_const(fr(9));
                 let arr = e.mk_seq(vec![x, y], SequenceTargetType::Array(2), Type::field());
@@ -793,7 +796,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let blob = e.emit_constant(Constant::Blob(Blob {
                     elem_type: Type::field(),
                     elements: vec![
@@ -825,7 +828,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let ra = falloc(&mut e);
                 let rb = falloc(&mut e);
                 let c1 = e.field_const(fr(3));
@@ -870,7 +873,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let x = e.field_const(fr(5));
                 let y = e.field_const(fr(6));
                 let arr = e.mk_seq(vec![x, y], SequenceTargetType::Array(2), Type::field());
@@ -903,7 +906,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let zero = e.field_const(fr(0));
                 let arr = e.mk_repeated(zero, SequenceTargetType::Array(4), 4, Type::field()); // [0;4]
                 let x = e.field_const(fr(7));
@@ -934,7 +937,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let r = falloc(&mut e);
                 let c = e.field_const(fr(5));
                 e.store(r, c);
@@ -965,7 +968,7 @@ mod tests {
             let mut sb = HLSSABuilder::new(&mut ssa);
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let cond = e.add_parameter(Type::bool());
                 let a = e.field_const(fr(1));
                 let bb = e.field_const(fr(2));
@@ -1000,7 +1003,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let x = e.field_const(fr(7));
                 let y = e.field_const(fr(9));
                 let arr = e.mk_seq(vec![x, y], SequenceTargetType::Array(2), Type::field());

--- a/compiler/src/compiler/passes/array_sroa.rs
+++ b/compiler/src/compiler/passes/array_sroa.rs
@@ -507,12 +507,9 @@ mod tests {
     use crate::compiler::{
         analysis::types::Types,
         passes::mem2reg::Mem2Reg,
-        ssa::{
-            SourceLocation,
-            hlssa::{
-                Blob, CastTarget, SequenceTargetType,
-                builder::{HLEmitter, HLSSABuilder},
-            },
+        ssa::hlssa::{
+            Blob, CastTarget, SequenceTargetType,
+            builder::{HLEmitter, HLSSABuilder},
         },
     };
 
@@ -604,7 +601,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let x = e.field_const(fr(7));
                 let y = e.field_const(fr(9));
                 let arr = e.mk_seq(vec![x, y], SequenceTargetType::Array(2), Type::field());
@@ -632,7 +629,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let x = e.field_const(fr(1));
                 let y = e.field_const(fr(2));
                 let z = e.field_const(fr(3));
@@ -664,7 +661,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let cond = e.add_parameter(Type::bool());
                 let a = e.field_const(fr(1));
                 let bb = e.field_const(fr(2));
@@ -706,7 +703,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let n = e.add_parameter(Type::u(32)); // dynamic index
                 let x = e.field_const(fr(7));
                 let y = e.field_const(fr(9));
@@ -732,7 +729,7 @@ mod tests {
             let mut sb = HLSSABuilder::new(&mut ssa);
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let x = e.field_const(fr(1));
                 let y = e.field_const(fr(2));
                 let z = e.field_const(fr(3));
@@ -760,7 +757,7 @@ mod tests {
             sb.modify_function(sink, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = e.add_parameter(arr2(Type::field()));
                 let i0 = e.u_const(32, 0);
                 let got = e.array_get(a, i0);
@@ -770,7 +767,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let x = e.field_const(fr(7));
                 let y = e.field_const(fr(9));
                 let arr = e.mk_seq(vec![x, y], SequenceTargetType::Array(2), Type::field());
@@ -796,7 +793,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let blob = e.emit_constant(Constant::Blob(Blob {
                     elem_type: Type::field(),
                     elements: vec![
@@ -828,7 +825,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let ra = falloc(&mut e);
                 let rb = falloc(&mut e);
                 let c1 = e.field_const(fr(3));
@@ -873,7 +870,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let x = e.field_const(fr(5));
                 let y = e.field_const(fr(6));
                 let arr = e.mk_seq(vec![x, y], SequenceTargetType::Array(2), Type::field());
@@ -906,7 +903,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let zero = e.field_const(fr(0));
                 let arr = e.mk_repeated(zero, SequenceTargetType::Array(4), 4, Type::field()); // [0;4]
                 let x = e.field_const(fr(7));
@@ -937,7 +934,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let r = falloc(&mut e);
                 let c = e.field_const(fr(5));
                 e.store(r, c);
@@ -968,7 +965,7 @@ mod tests {
             let mut sb = HLSSABuilder::new(&mut ssa);
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let cond = e.add_parameter(Type::bool());
                 let a = e.field_const(fr(1));
                 let bb = e.field_const(fr(2));
@@ -1003,7 +1000,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let x = e.field_const(fr(7));
                 let y = e.field_const(fr(9));
                 let arr = e.mk_seq(vec![x, y], SequenceTargetType::Array(2), Type::field());

--- a/compiler/src/compiler/passes/defunctionalize.rs
+++ b/compiler/src/compiler/passes/defunctionalize.rs
@@ -684,3 +684,31 @@ fn replace_function_types_in_instruction(instr: &mut OpCode) {
         _ => {}
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Dispatch stubs have no user-source anchor: every instruction they contain must carry the
+    /// synthetic location named after the generated function.
+    #[test]
+    fn dispatch_function_is_located_at_its_synthetic_source() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let f = ssa.add_function("f".to_string());
+        let g = ssa.add_function("g".to_string());
+
+        let dispatch_id =
+            build_dispatch_function(&mut ssa, 7, &[Type::field()], &[Type::field()], &[f, g]);
+
+        let dispatch = ssa.get_function(dispatch_id);
+        let expected = SourceLocation::synthetic("apply_dispatch@7");
+        let mut located_instructions = 0;
+        for (_, block) in dispatch.get_blocks() {
+            for (_, location) in block.get_instructions_with_source_locations() {
+                assert_eq!(location, &expected);
+                located_instructions += 1;
+            }
+        }
+        assert!(located_instructions > 0);
+    }
+}

--- a/compiler/src/compiler/passes/defunctionalize.rs
+++ b/compiler/src/compiler/passes/defunctionalize.rs
@@ -559,8 +559,9 @@ fn build_dispatch_function(
     return_types: &[Type],
     variants: &[FunctionId],
 ) -> FunctionId {
-    let dispatch_fn_id = ssa.add_function(format!("apply_dispatch@{}", counter));
-    let location = SourceLocation::synthetic(format!("apply_dispatch@{}", counter));
+    let name = format!("apply_dispatch@{counter}");
+    let location = SourceLocation::synthetic(&name);
+    let dispatch_fn_id = ssa.add_function(name);
     let mut sb = HLSSABuilder::new(ssa);
     sb.modify_function(dispatch_fn_id, |b| {
         for ret_type in return_types {

--- a/compiler/src/compiler/passes/defunctionalize.rs
+++ b/compiler/src/compiler/passes/defunctionalize.rs
@@ -15,7 +15,7 @@ use crate::{
         pass_manager::{AnalysisStore, Pass},
         passes::shared::value_replacements::ValueReplacements,
         ssa::{
-            BlockId, FunctionId, Located, Terminator, ValueId,
+            BlockId, FunctionId, Located, SourceLocation, Terminator, ValueId,
             hlssa::{
                 CallTarget, Constant, HLSSA, OpCode, Type, TypeExpr,
                 builder::{HLEmitter, HLSSABuilder},
@@ -560,6 +560,7 @@ fn build_dispatch_function(
     variants: &[FunctionId],
 ) -> FunctionId {
     let dispatch_fn_id = ssa.add_function(format!("apply_dispatch@{}", counter));
+    let location = SourceLocation::synthetic(format!("apply_dispatch@{}", counter));
     let mut sb = HLSSABuilder::new(ssa);
     sb.modify_function(dispatch_fn_id, |b| {
         for ret_type in return_types {
@@ -590,7 +591,9 @@ fn build_dispatch_function(
 
         if variants.len() == 1 {
             let variant_id = variants[0];
-            let mut cb = b.block(current_block);
+            let mut cb = b
+                .block(current_block)
+                .with_source_location(location.clone());
             let const_val = cb.u_const(32, variant_id.0 as u128);
             cb.assert_eq(fn_id_param, const_val);
             let call_results = cb.call(variant_id, forwarded_params.clone(), return_types.len());
@@ -600,7 +603,9 @@ fn build_dispatch_function(
                 let is_last = i == variants.len() - 1;
 
                 if is_last {
-                    let mut cb = b.block(current_block);
+                    let mut cb = b
+                        .block(current_block)
+                        .with_source_location(location.clone());
                     let const_val = cb.u_const(32, variant_id.0 as u128);
                     cb.assert_eq(fn_id_param, const_val);
                     let call_results =
@@ -611,14 +616,16 @@ fn build_dispatch_function(
                     let next_check_block = b.add_block(|_| {});
 
                     {
-                        let mut cb = b.block(current_block);
+                        let mut cb = b
+                            .block(current_block)
+                            .with_source_location(location.clone());
                         let const_val = cb.u_const(32, variant_id.0 as u128);
                         let eq_result = cb.eq(fn_id_param, const_val);
                         cb.terminate_jmp_if(eq_result, call_block, next_check_block);
                     }
 
                     {
-                        let mut cb = b.block(call_block);
+                        let mut cb = b.block(call_block).with_source_location(location.clone());
                         let call_results =
                             cb.call(variant_id, forwarded_params.clone(), return_types.len());
                         cb.terminate_jmp(merge_block, call_results);

--- a/compiler/src/compiler/passes/instruction_lowering/mod.rs
+++ b/compiler/src/compiler/passes/instruction_lowering/mod.rs
@@ -184,7 +184,7 @@ impl InstructionLowering {
                 }) {
                     changed = true;
                 } else {
-                    b.emit(instruction);
+                    b.emit_located(instruction);
                 }
             }
             if let Some(terminator) = terminator {

--- a/compiler/src/compiler/passes/instruction_lowering/mod.rs
+++ b/compiler/src/compiler/passes/instruction_lowering/mod.rs
@@ -176,7 +176,11 @@ impl InstructionLowering {
                 (instructions, terminator)
             };
 
-            let mut b = fb.block(block_id);
+            // Every lowered instruction scopes its own location below; emitting outside a scope
+            // is an ICE.
+            let mut b = fb
+                .block(block_id)
+                .with_scoped_source_locations("instruction_lowering");
             for instruction in instructions {
                 let location = instruction.location().clone();
                 if b.emit_with_location(location, |b| {

--- a/compiler/src/compiler/passes/lookup_spilling.rs
+++ b/compiler/src/compiler/passes/lookup_spilling.rs
@@ -10,7 +10,7 @@ use crate::compiler::{
     },
     pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
     ssa::{
-        FunctionId, ValueId,
+        FunctionId, SourceLocation, ValueId,
         hlssa::{
             CastTarget, Constant, HLSSA, HLSSAConstantsSnapshot, LookupTarget,
             MAX_SUPPORTED_UNSIGNED_BITS, OpCode, Type,
@@ -140,9 +140,10 @@ impl LookupSpilling {
             HelperKind::Rangecheck => format!("__rangecheck_spill_{}_{index}", key.width),
             HelperKind::Spread => format!("__spread_spill_{}_{index}", key.width),
         };
+        let location = SourceLocation::synthetic(&name);
         let (id, ()) = sb.add_function(name, |fb| {
             let entry = fb.function().get_entry_id();
-            let mut e = fb.block(entry);
+            let mut e = fb.block(entry).with_source_location(location);
             match key.kind {
                 HelperKind::Rangecheck => {
                     let value = e.add_parameter(key.value_type.clone());
@@ -316,7 +317,11 @@ impl Pass for LookupSpilling {
                     };
                     let mut e = fb.block(block_id);
                     for instr in instructions {
-                        if !self.rewrite_lookup(&mut e, &instr, fti, sizing, &consts, &cache) {
+                        let location = instr.location().clone();
+                        let rewritten = e.emit_with_location(location, |e| {
+                            self.rewrite_lookup(e, &instr, fti, sizing, &consts, &cache)
+                        });
+                        if !rewritten {
                             e.emit_located(instr);
                         }
                     }

--- a/compiler/src/compiler/passes/lookup_spilling.rs
+++ b/compiler/src/compiler/passes/lookup_spilling.rs
@@ -317,7 +317,7 @@ impl Pass for LookupSpilling {
                     let mut e = fb.block(block_id);
                     for instr in instructions {
                         if !self.rewrite_lookup(&mut e, &instr, fti, sizing, &consts, &cache) {
-                            e.emit(instr);
+                            e.emit_located(instr);
                         }
                     }
                     if let Some(terminator) = terminator {

--- a/compiler/src/compiler/passes/lookup_spilling.rs
+++ b/compiler/src/compiler/passes/lookup_spilling.rs
@@ -315,7 +315,11 @@ impl Pass for LookupSpilling {
                         fb.function.put_block(block_id, block);
                         (instructions, terminator)
                     };
-                    let mut e = fb.block(block_id);
+                    // Every rewritten lookup scopes its own location below; emitting outside a
+                    // scope is an ICE.
+                    let mut e = fb
+                        .block(block_id)
+                        .with_scoped_source_locations("lookup_spilling");
                     for instr in instructions {
                         let location = instr.location().clone();
                         let rewritten = e.emit_with_location(location, |e| {

--- a/compiler/src/compiler/passes/lower_map_casts.rs
+++ b/compiler/src/compiler/passes/lower_map_casts.rs
@@ -57,7 +57,11 @@ impl LowerMapCasts {
                     let terminator = fb.function.get_block_mut(bid).take_terminator();
                     let instructions = fb.function.get_block_mut(bid).take_instructions();
 
-                    let mut emitter = fb.block(bid);
+                    // Every instruction scopes its own location below; emitting outside a scope
+                    // is an ICE.
+                    let mut emitter = fb
+                        .block(bid)
+                        .with_scoped_source_locations("lower_map_casts");
                     for instruction in instructions {
                         let location = instruction.location().clone();
                         emitter.emit_with_location(location, |emitter| {

--- a/compiler/src/compiler/passes/lowering_pass.rs
+++ b/compiler/src/compiler/passes/lowering_pass.rs
@@ -122,7 +122,9 @@ fn run_on_function<T: LoweringPass + ?Sized>(
             (instructions, terminator)
         };
 
-        let mut b = fb.block(block_id);
+        // Every rewritten instruction scopes its own location below; emitting outside a scope
+        // is an ICE.
+        let mut b = fb.block(block_id).with_scoped_source_locations(T::NAME);
         for instruction in instructions {
             let location = instruction.location().clone();
             b.emit_with_location(location, |b| {

--- a/compiler/src/compiler/passes/mem2reg.rs
+++ b/compiler/src/compiler/passes/mem2reg.rs
@@ -598,10 +598,7 @@ mod tests {
     use super::*;
     use crate::compiler::{
         analysis::types::Types,
-        ssa::{
-            SourceLocation,
-            hlssa::{Type, builder::HLEmitter},
-        },
+        ssa::hlssa::{Type, builder::HLEmitter},
         util::test::{falloc, fr},
     };
 
@@ -641,7 +638,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field().ref_of());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let kept = falloc(&mut e);
                 let returned = falloc(&mut e);
                 let c = e.field_const(fr(1));
@@ -667,7 +664,7 @@ mod tests {
             // reader(p): let _ = *p; return
             sb.modify_function(reader, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p = e.add_parameter(Type::field().ref_of());
                 let _ = e.load(p);
                 e.terminate_return(vec![]);
@@ -677,7 +674,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let other = falloc(&mut e);
                 let c = e.field_const(fr(2));
                 e.store(other, c);
@@ -708,7 +705,7 @@ mod tests {
             sb.modify_function(f, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let p = e.add_parameter(Type::field().ref_of());
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));
@@ -719,7 +716,7 @@ mod tests {
             });
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 e.terminate_return(vec![]);
             });
         }
@@ -739,7 +736,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let cond = e.add_parameter(Type::bool());
                 let ra = falloc(&mut e);
                 let rb = falloc(&mut e);
@@ -772,7 +769,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let cond = e.add_parameter(Type::bool());
                 let a = falloc(&mut e);
                 let c0 = e.field_const(fr(7));
@@ -806,7 +803,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = falloc(&mut e);
                 let pp = e.alloc(a); // Ref<Ref<Field>>, ref pointee, seeded with `a`
                 e.store(pp, a); // *pp = a — `a`'s ref is consumed as a value
@@ -835,7 +832,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let a = falloc(&mut e); // cell seeded with its init value, never stored to
                 let v = e.load(a); // reads the alloc's initial value
                 e.terminate_return(vec![v]);
@@ -860,7 +857,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(arr_ty.clone());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry).with_source_location(SourceLocation::test());
+                let mut e = b.test_block(entry);
                 let cond = e.add_parameter(Type::bool());
                 let arr0 = e.add_parameter(arr_ty.clone());
                 let arr1 = e.add_parameter(arr_ty.clone());

--- a/compiler/src/compiler/passes/mem2reg.rs
+++ b/compiler/src/compiler/passes/mem2reg.rs
@@ -598,7 +598,10 @@ mod tests {
     use super::*;
     use crate::compiler::{
         analysis::types::Types,
-        ssa::hlssa::{Type, builder::HLEmitter},
+        ssa::{
+            SourceLocation,
+            hlssa::{Type, builder::HLEmitter},
+        },
         util::test::{falloc, fr},
     };
 
@@ -638,7 +641,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field().ref_of());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let kept = falloc(&mut e);
                 let returned = falloc(&mut e);
                 let c = e.field_const(fr(1));
@@ -664,7 +667,7 @@ mod tests {
             // reader(p): let _ = *p; return
             sb.modify_function(reader, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p = e.add_parameter(Type::field().ref_of());
                 let _ = e.load(p);
                 e.terminate_return(vec![]);
@@ -674,7 +677,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let other = falloc(&mut e);
                 let c = e.field_const(fr(2));
                 e.store(other, c);
@@ -705,7 +708,7 @@ mod tests {
             sb.modify_function(f, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let p = e.add_parameter(Type::field().ref_of());
                 let a = falloc(&mut e);
                 let c = e.field_const(fr(5));
@@ -716,7 +719,7 @@ mod tests {
             });
             sb.modify_function(main_id, |b| {
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 e.terminate_return(vec![]);
             });
         }
@@ -736,7 +739,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let cond = e.add_parameter(Type::bool());
                 let ra = falloc(&mut e);
                 let rb = falloc(&mut e);
@@ -769,7 +772,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let cond = e.add_parameter(Type::bool());
                 let a = falloc(&mut e);
                 let c0 = e.field_const(fr(7));
@@ -803,7 +806,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = falloc(&mut e);
                 let pp = e.alloc(a); // Ref<Ref<Field>>, ref pointee, seeded with `a`
                 e.store(pp, a); // *pp = a — `a`'s ref is consumed as a value
@@ -832,7 +835,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(Type::field());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let a = falloc(&mut e); // cell seeded with its init value, never stored to
                 let v = e.load(a); // reads the alloc's initial value
                 e.terminate_return(vec![v]);
@@ -857,7 +860,7 @@ mod tests {
             sb.modify_function(main_id, |b| {
                 b.function.add_return_type(arr_ty.clone());
                 let entry = b.function.get_entry_id();
-                let mut e = b.block(entry);
+                let mut e = b.block(entry).with_source_location(SourceLocation::test());
                 let cond = e.add_parameter(Type::bool());
                 let arr0 = e.add_parameter(arr_ty.clone());
                 let arr1 = e.add_parameter(arr_ty.clone());

--- a/compiler/src/compiler/passes/normalize_asserts.rs
+++ b/compiler/src/compiler/passes/normalize_asserts.rs
@@ -66,7 +66,7 @@ mod tests {
     use crate::compiler::{
         analysis::types::Types,
         ssa::{
-            Located, SourceLocation, Terminator, ValueId,
+            Terminator, ValueId,
             hlssa::{BinaryArithOpKind, Type},
         },
     };
@@ -120,28 +120,19 @@ mod tests {
         let entry = f.get_entry_mut();
         // A `Field` multiply feeding the equality: `SimplifyAsserts` would turn this into `AssertR1C`,
         // but `NormalizeAsserts` must not.
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Mul,
-                result: mul,
-                lhs: a,
-                rhs: b,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Cmp {
-                kind: CmpKind::Eq,
-                result: eq,
-                lhs: mul,
-                rhs: c,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Assert { value: eq },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Mul,
+            result: mul,
+            lhs: a,
+            rhs: b,
+        });
+        entry.push_test_instruction(OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: eq,
+            lhs: mul,
+            rhs: c,
+        });
+        entry.push_test_instruction(OpCode::Assert { value: eq });
         entry.set_terminator(Terminator::Return(vec![]));
 
         normalize(&mut ssa);
@@ -160,19 +151,13 @@ mod tests {
         f.get_entry_mut().push_parameter(a, Type::field());
         f.get_entry_mut().push_parameter(b, Type::field());
         let entry = f.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::Cmp {
-                kind: CmpKind::Lt,
-                result: lt,
-                lhs: a,
-                rhs: b,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Assert { value: lt },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Cmp {
+            kind: CmpKind::Lt,
+            result: lt,
+            lhs: a,
+            rhs: b,
+        });
+        entry.push_test_instruction(OpCode::Assert { value: lt });
         entry.set_terminator(Terminator::Return(vec![]));
 
         normalize(&mut ssa);
@@ -190,19 +175,13 @@ mod tests {
         f.get_entry_mut().push_parameter(l, Type::u(1));
         f.get_entry_mut().push_parameter(r, Type::u(1));
         let entry = f.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::And,
-                result: and,
-                lhs: l,
-                rhs: r,
-            },
-            SourceLocation::test(),
-        ));
-        entry.push_instruction(Located::with(
-            OpCode::Assert { value: and },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::And,
+            result: and,
+            lhs: l,
+            rhs: r,
+        });
+        entry.push_test_instruction(OpCode::Assert { value: and });
         entry.set_terminator(Terminator::Return(vec![]));
 
         normalize(&mut ssa);
@@ -228,10 +207,7 @@ mod tests {
         let f = ssa.get_unique_entrypoint_mut();
         f.get_entry_mut().push_parameter(w, Type::u(1));
         let entry = f.get_entry_mut();
-        entry.push_instruction(Located::with(
-            OpCode::Assert { value: w },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Assert { value: w });
         entry.set_terminator(Terminator::Return(vec![]));
 
         normalize(&mut ssa);

--- a/compiler/src/compiler/passes/normalize_asserts.rs
+++ b/compiler/src/compiler/passes/normalize_asserts.rs
@@ -66,7 +66,7 @@ mod tests {
     use crate::compiler::{
         analysis::types::Types,
         ssa::{
-            Terminator, ValueId,
+            Located, SourceLocation, Terminator, ValueId,
             hlssa::{BinaryArithOpKind, Type},
         },
     };
@@ -120,19 +120,28 @@ mod tests {
         let entry = f.get_entry_mut();
         // A `Field` multiply feeding the equality: `SimplifyAsserts` would turn this into `AssertR1C`,
         // but `NormalizeAsserts` must not.
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::Mul,
-            result: mul,
-            lhs: a,
-            rhs: b,
-        });
-        entry.push_instruction(OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: eq,
-            lhs: mul,
-            rhs: c,
-        });
-        entry.push_instruction(OpCode::Assert { value: eq });
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::Mul,
+                result: mul,
+                lhs: a,
+                rhs: b,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Cmp {
+                kind: CmpKind::Eq,
+                result: eq,
+                lhs: mul,
+                rhs: c,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Assert { value: eq },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![]));
 
         normalize(&mut ssa);
@@ -151,13 +160,19 @@ mod tests {
         f.get_entry_mut().push_parameter(a, Type::field());
         f.get_entry_mut().push_parameter(b, Type::field());
         let entry = f.get_entry_mut();
-        entry.push_instruction(OpCode::Cmp {
-            kind: CmpKind::Lt,
-            result: lt,
-            lhs: a,
-            rhs: b,
-        });
-        entry.push_instruction(OpCode::Assert { value: lt });
+        entry.push_instruction(Located::with(
+            OpCode::Cmp {
+                kind: CmpKind::Lt,
+                result: lt,
+                lhs: a,
+                rhs: b,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Assert { value: lt },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![]));
 
         normalize(&mut ssa);
@@ -175,13 +190,19 @@ mod tests {
         f.get_entry_mut().push_parameter(l, Type::u(1));
         f.get_entry_mut().push_parameter(r, Type::u(1));
         let entry = f.get_entry_mut();
-        entry.push_instruction(OpCode::BinaryArithOp {
-            kind: BinaryArithOpKind::And,
-            result: and,
-            lhs: l,
-            rhs: r,
-        });
-        entry.push_instruction(OpCode::Assert { value: and });
+        entry.push_instruction(Located::with(
+            OpCode::BinaryArithOp {
+                kind: BinaryArithOpKind::And,
+                result: and,
+                lhs: l,
+                rhs: r,
+            },
+            SourceLocation::test(),
+        ));
+        entry.push_instruction(Located::with(
+            OpCode::Assert { value: and },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![]));
 
         normalize(&mut ssa);
@@ -207,7 +228,10 @@ mod tests {
         let f = ssa.get_unique_entrypoint_mut();
         f.get_entry_mut().push_parameter(w, Type::u(1));
         let entry = f.get_entry_mut();
-        entry.push_instruction(OpCode::Assert { value: w });
+        entry.push_instruction(Located::with(
+            OpCode::Assert { value: w },
+            SourceLocation::test(),
+        ));
         entry.set_terminator(Terminator::Return(vec![]));
 
         normalize(&mut ssa);

--- a/compiler/src/compiler/passes/partial_redundancy_elimination/insert.rs
+++ b/compiler/src/compiler/passes/partial_redundancy_elimination/insert.rs
@@ -152,7 +152,7 @@ use crate::{
             shared::value_replacements::{ReplaceScope, ValueReplacements},
         },
         ssa::{
-            BlockId, FunctionId, Instruction, Located, Location, Terminator, ValueId,
+            BlockId, FunctionId, Instruction, Located, SourceLocation, Terminator, ValueId,
             hlssa::{HLFunction, HLSSA, OpCode, Type},
         },
     },
@@ -286,7 +286,7 @@ struct Occurrence {
 
     /// The original instruction's source location, carried onto every materialized copy so a
     /// moved evaluation still attributes its traps.
-    location: Location,
+    location: SourceLocation,
 }
 
 impl Occurrence {
@@ -536,7 +536,7 @@ impl FunctionMotionState {
                     order,
                     result,
                     template: instruction.clone(),
-                    location: location.cloned(),
+                    location: location.clone(),
                 });
                 order += 1;
                 state.gen_keys.entry(block_id).or_default().insert(node);

--- a/compiler/src/compiler/passes/partial_redundancy_elimination/test.rs
+++ b/compiler/src/compiler/passes/partial_redundancy_elimination/test.rs
@@ -1401,17 +1401,17 @@ fn pre_untaint_config_dedups_without_structural_change() {
     let e = f.add_block();
     let m = f.add_block();
     let entry = f.get_entry_mut();
-    entry.push_instruction(add(r1, a, b));
+    entry.push_test_instruction(add(r1, a, b));
     entry.set_terminator(Terminator::JmpIf(cond, t, e));
     f.get_block_mut(t)
         .set_terminator(Terminator::Jmp(m, vec![]));
     f.get_block_mut(e)
         .set_terminator(Terminator::Jmp(m, vec![]));
     let mb = f.get_block_mut(m);
-    mb.push_instruction(add(r2, a, b));
+    mb.push_test_instruction(add(r2, a, b));
     // The always-live anchor observing the redirect (the entrypoint's return slots are not
     // seeded live in this harness, so a `Return` operand cannot be the witness).
-    mb.push_instruction(OpCode::Rangecheck {
+    mb.push_test_instruction(OpCode::Rangecheck {
         value: r2,
         max_bits: 32,
     });
@@ -1684,7 +1684,7 @@ fn outer_body_operand_shape(
 
     let ohb = f.get_block_mut(oh);
     ohb.push_parameter(j, Type::u(32));
-    ohb.push_instruction(OpCode::Cmp {
+    ohb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: jc,
         lhs: j,
@@ -1694,12 +1694,12 @@ fn outer_body_operand_shape(
 
     // `x` is recomputed every outer iteration, always to the same value.
     let obb = f.get_block_mut(obody);
-    obb.push_instruction(mul(x, a, b));
+    obb.push_test_instruction(mul(x, a, b));
     obb.set_terminator(Terminator::Jmp(ih, vec![c0]));
 
     let ihb = f.get_block_mut(ih);
     ihb.push_parameter(k, Type::u(32));
-    ihb.push_instruction(OpCode::Cmp {
+    ihb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: kc,
         lhs: k,
@@ -1708,25 +1708,25 @@ fn outer_body_operand_shape(
     ihb.set_terminator(Terminator::JmpIf(kc, ibody, iafter));
 
     let ibb = f.get_block_mut(ibody);
-    ibb.push_instruction(mul(m1, x, c2));
+    ibb.push_test_instruction(mul(m1, x, c2));
     if !wrapping {
-        ibb.push_instruction(OpCode::Rangecheck {
+        ibb.push_test_instruction(OpCode::Rangecheck {
             value: m1,
             max_bits: 32,
         });
     }
-    ibb.push_instruction(add(k2, k, c1));
+    ibb.push_test_instruction(add(k2, k, c1));
     ibb.set_terminator(Terminator::Jmp(ih, vec![k2]));
 
     let iab = f.get_block_mut(iafter);
     if down_safe {
-        iab.push_instruction(mul(m2, x, c2));
-        iab.push_instruction(OpCode::Rangecheck {
+        iab.push_test_instruction(mul(m2, x, c2));
+        iab.push_test_instruction(OpCode::Rangecheck {
             value: m2,
             max_bits: 32,
         });
     }
-    iab.push_instruction(add(j2, j, c1));
+    iab.push_test_instruction(add(j2, j, c1));
     iab.set_terminator(Terminator::Jmp(oh, vec![j2]));
 
     f.get_block_mut(oexit)
@@ -1847,7 +1847,7 @@ fn call_result_operand_shape(
         let gf = ssa.get_function_mut(g);
         gf.add_return_type(Type::field());
         gf.get_entry_mut().push_parameter(p, Type::field());
-        gf.get_entry_mut().push_instruction(add(r, p, p));
+        gf.get_entry_mut().push_test_instruction(add(r, p, p));
         gf.get_entry_mut()
             .set_terminator(Terminator::Return(vec![r]));
     }
@@ -1866,7 +1866,7 @@ fn call_result_operand_shape(
 
     let ohb = f.get_block_mut(oh);
     ohb.push_parameter(j, Type::u(32));
-    ohb.push_instruction(OpCode::Cmp {
+    ohb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: jc,
         lhs: j,
@@ -1875,7 +1875,7 @@ fn call_result_operand_shape(
     ohb.set_terminator(Terminator::JmpIf(jc, obody, oexit));
 
     let obb = f.get_block_mut(obody);
-    obb.push_instruction(OpCode::Call {
+    obb.push_test_instruction(OpCode::Call {
         results: vec![x],
         function: CallTarget::Static(g),
         args: vec![a],
@@ -1885,7 +1885,7 @@ fn call_result_operand_shape(
 
     let ihb = f.get_block_mut(ih);
     ihb.push_parameter(k, Type::u(32));
-    ihb.push_instruction(OpCode::Cmp {
+    ihb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: kc,
         lhs: k,
@@ -1894,21 +1894,21 @@ fn call_result_operand_shape(
     ihb.set_terminator(Terminator::JmpIf(kc, ibody, iafter));
 
     let ibb = f.get_block_mut(ibody);
-    ibb.push_instruction(mul(m1, x, c2f));
-    ibb.push_instruction(OpCode::Rangecheck {
+    ibb.push_test_instruction(mul(m1, x, c2f));
+    ibb.push_test_instruction(OpCode::Rangecheck {
         value: m1,
         max_bits: 32,
     });
-    ibb.push_instruction(add(k2, k, c1));
+    ibb.push_test_instruction(add(k2, k, c1));
     ibb.set_terminator(Terminator::Jmp(ih, vec![k2]));
 
     let iab = f.get_block_mut(iafter);
-    iab.push_instruction(mul(m2, x, c2f));
-    iab.push_instruction(OpCode::Rangecheck {
+    iab.push_test_instruction(mul(m2, x, c2f));
+    iab.push_test_instruction(OpCode::Rangecheck {
         value: m2,
         max_bits: 32,
     });
-    iab.push_instruction(add(j2, j, c1));
+    iab.push_test_instruction(add(j2, j, c1));
     iab.set_terminator(Terminator::Jmp(oh, vec![j2]));
 
     f.get_block_mut(oexit)
@@ -2000,7 +2000,7 @@ fn aggregate_const_phi_operand_hoists_via_congruence_tier() {
 
     let entry = f.get_entry_mut();
     entry.push_parameter(idx, Type::u(32));
-    entry.push_instruction(OpCode::MkSeq {
+    entry.push_test_instruction(OpCode::MkSeq {
         result: arr0,
         elems: vec![ce1, ce2],
         seq_type: SequenceTargetType::Array(2),
@@ -2011,7 +2011,7 @@ fn aggregate_const_phi_operand_hoists_via_congruence_tier() {
     let ohb = f.get_block_mut(oh);
     ohb.push_parameter(j, Type::u(32));
     ohb.push_parameter(arr, Type::field().array_of(2));
-    ohb.push_instruction(OpCode::Cmp {
+    ohb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: jc,
         lhs: j,
@@ -2024,7 +2024,7 @@ fn aggregate_const_phi_operand_hoists_via_congruence_tier() {
 
     let ihb = f.get_block_mut(ih);
     ihb.push_parameter(k, Type::u(32));
-    ihb.push_instruction(OpCode::Cmp {
+    ihb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: kc,
         lhs: k,
@@ -2033,29 +2033,29 @@ fn aggregate_const_phi_operand_hoists_via_congruence_tier() {
     ihb.set_terminator(Terminator::JmpIf(kc, ibody, iafter));
 
     let ibb = f.get_block_mut(ibody);
-    ibb.push_instruction(OpCode::ArrayGet {
+    ibb.push_test_instruction(OpCode::ArrayGet {
         result: x1,
         array: arr,
         index: idx,
     });
-    ibb.push_instruction(OpCode::Rangecheck {
+    ibb.push_test_instruction(OpCode::Rangecheck {
         value: x1,
         max_bits: 32,
     });
-    ibb.push_instruction(add(k2, k, c1));
+    ibb.push_test_instruction(add(k2, k, c1));
     ibb.set_terminator(Terminator::Jmp(ih, vec![k2]));
 
     let iab = f.get_block_mut(iafter);
-    iab.push_instruction(OpCode::ArrayGet {
+    iab.push_test_instruction(OpCode::ArrayGet {
         result: x2,
         array: arr,
         index: idx,
     });
-    iab.push_instruction(OpCode::Rangecheck {
+    iab.push_test_instruction(OpCode::Rangecheck {
         value: x2,
         max_bits: 32,
     });
-    iab.push_instruction(add(j2, j, c1));
+    iab.push_test_instruction(add(j2, j, c1));
     iab.set_terminator(Terminator::Jmp(oh, vec![j2, arr0]));
 
     f.get_block_mut(oexit)

--- a/compiler/src/compiler/passes/partial_redundancy_elimination/test.rs
+++ b/compiler/src/compiler/passes/partial_redundancy_elimination/test.rs
@@ -369,7 +369,7 @@ fn division_discharged_by_disequality_branch() {
     let entry = f.get_entry_mut();
     entry.push_parameter(x, Type::u(32));
     entry.push_parameter(d, Type::u(32));
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: eq,
         lhs: d,
@@ -409,7 +409,7 @@ fn signed_64_bit_division_minus_one_hazard() {
     let entry = f.get_entry_mut();
     entry.push_parameter(x, Type::i(64));
     entry.push_parameter(d, Type::i(64));
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: eq,
         lhs: d,
@@ -709,8 +709,8 @@ fn same_block_duplicate_is_redirected() {
     let (r1, r2) = (ssa.fresh_value(), ssa.fresh_value());
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
-    entry.push_instruction(add(r1, a, b));
-    entry.push_instruction(add(r2, a, b));
+    entry.push_test_instruction(add(r1, a, b));
+    entry.push_test_instruction(add(r2, a, b));
     entry.set_terminator(Terminator::Return(vec![r2]));
 
     eliminate(&mut ssa);
@@ -725,8 +725,8 @@ fn commutative_operands_match() {
     let (r1, r2) = (ssa.fresh_value(), ssa.fresh_value());
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
-    entry.push_instruction(add(r1, a, b));
-    entry.push_instruction(add(r2, b, a));
+    entry.push_test_instruction(add(r1, a, b));
+    entry.push_test_instruction(add(r2, b, a));
     entry.set_terminator(Terminator::Return(vec![r2]));
 
     eliminate(&mut ssa);
@@ -742,10 +742,10 @@ fn dominated_block_reuses_dominating_definition() {
     let f = ssa.get_unique_entrypoint_mut();
     let next = f.add_block();
     let entry = f.get_entry_mut();
-    entry.push_instruction(add(r1, a, b));
+    entry.push_test_instruction(add(r1, a, b));
     entry.set_terminator(Terminator::Jmp(next, vec![]));
     let next_block = f.get_block_mut(next);
-    next_block.push_instruction(add(r2, a, b));
+    next_block.push_test_instruction(add(r2, a, b));
     next_block.set_terminator(Terminator::Return(vec![r2]));
 
     eliminate(&mut ssa);
@@ -767,10 +767,10 @@ fn sibling_arms_are_not_deduplicated() {
     f.get_entry_mut()
         .set_terminator(Terminator::JmpIf(cond, t, e));
     let tb = f.get_block_mut(t);
-    tb.push_instruction(add(r1, a, b));
+    tb.push_test_instruction(add(r1, a, b));
     tb.set_terminator(Terminator::Jmp(m, vec![r1]));
     let eb = f.get_block_mut(e);
-    eb.push_instruction(add(r2, a, b));
+    eb.push_test_instruction(add(r2, a, b));
     eb.set_terminator(Terminator::Jmp(m, vec![r2]));
     let mb = f.get_block_mut(m);
     mb.push_parameter(p, Type::field());
@@ -803,10 +803,10 @@ fn reassociated_chains_deduplicate() {
     );
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
-    entry.push_instruction(add(t1, a, b));
-    entry.push_instruction(add(t2, t1, c));
-    entry.push_instruction(add(s1, b, c));
-    entry.push_instruction(add(s2, a, s1));
+    entry.push_test_instruction(add(t1, a, b));
+    entry.push_test_instruction(add(t2, t1, c));
+    entry.push_test_instruction(add(s1, b, c));
+    entry.push_test_instruction(add(s2, a, s1));
     entry.set_terminator(Terminator::Return(vec![t2, s2]));
 
     eliminate(&mut ssa);
@@ -822,13 +822,13 @@ fn mul_const_unifies_with_mul() {
     let (m1, m2) = (ssa.fresh_value(), ssa.fresh_value());
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Mul,
         result: m1,
         lhs: a,
         rhs: c2,
     });
-    entry.push_instruction(OpCode::MulConst {
+    entry.push_test_instruction(OpCode::MulConst {
         result: m2,
         const_val: c2,
         var: a,
@@ -864,7 +864,7 @@ fn loop_carried_congruent_increments_redirect() {
     let hb = f.get_block_mut(header);
     hb.push_parameter(i, Type::u(32));
     hb.push_parameter(j, Type::u(32));
-    hb.push_instruction(OpCode::Cmp {
+    hb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: cond,
         lhs: i,
@@ -872,8 +872,8 @@ fn loop_carried_congruent_increments_redirect() {
     });
     hb.set_terminator(Terminator::JmpIf(cond, body, exit));
     let bb = f.get_block_mut(body);
-    bb.push_instruction(add(i2, i, c1));
-    bb.push_instruction(add(j2, j, c1));
+    bb.push_test_instruction(add(i2, i, c1));
+    bb.push_test_instruction(add(j2, j, c1));
     bb.set_terminator(Terminator::Jmp(header, vec![i2, j2]));
     f.get_block_mut(exit)
         .set_terminator(Terminator::Return(vec![i, j]));
@@ -894,15 +894,15 @@ fn rangecheck_duplicates_are_dropped() {
     let v = vals[0];
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::Rangecheck {
+    entry.push_test_instruction(OpCode::Rangecheck {
         value: v,
         max_bits: 32,
     });
-    entry.push_instruction(OpCode::Rangecheck {
+    entry.push_test_instruction(OpCode::Rangecheck {
         value: v,
         max_bits: 32,
     });
-    entry.push_instruction(OpCode::Rangecheck {
+    entry.push_test_instruction(OpCode::Rangecheck {
         value: v,
         max_bits: 16,
     });
@@ -923,13 +923,13 @@ fn rangecheck_over_congruent_values_deduplicates() {
     let (x, y) = (ssa.fresh_value(), ssa.fresh_value());
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
-    entry.push_instruction(add(x, a, b));
-    entry.push_instruction(add(y, a, b));
-    entry.push_instruction(OpCode::Rangecheck {
+    entry.push_test_instruction(add(x, a, b));
+    entry.push_test_instruction(add(y, a, b));
+    entry.push_test_instruction(OpCode::Rangecheck {
         value: x,
         max_bits: 32,
     });
-    entry.push_instruction(OpCode::Rangecheck {
+    entry.push_test_instruction(OpCode::Rangecheck {
         value: y,
         max_bits: 32,
     });
@@ -952,7 +952,7 @@ fn lookup_dedup_respects_config() {
         let f = ssa.get_unique_entrypoint_mut();
         let entry = f.get_entry_mut();
         for _ in 0..2 {
-            entry.push_instruction(OpCode::Lookup {
+            entry.push_test_instruction(OpCode::Lookup {
                 target: LookupTarget::Rangecheck(8),
                 args: vec![v],
                 flag,
@@ -999,7 +999,7 @@ fn unpinned_write_witness_shares_slot_pinned_does_not() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
     for (result, pinned) in [(r1, false), (r2, false), (p1, true), (p2, true)] {
-        entry.push_instruction(OpCode::WriteWitness {
+        entry.push_test_instruction(OpCode::WriteWitness {
             result: Some(result),
             value: v,
             pinned,
@@ -1020,7 +1020,7 @@ fn to_bits_deduplicates() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
     for result in [r1, r2] {
-        entry.push_instruction(OpCode::ToBits {
+        entry.push_test_instruction(OpCode::ToBits {
             result,
             value: v,
             endianness: Endianness::Little,
@@ -1049,7 +1049,7 @@ fn to_radix_bytes_deduplicates_dyn_does_not() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
     for result in [r1, r2] {
-        entry.push_instruction(OpCode::ToRadix {
+        entry.push_test_instruction(OpCode::ToRadix {
             result,
             value: v,
             radix: Radix::Bytes,
@@ -1058,7 +1058,7 @@ fn to_radix_bytes_deduplicates_dyn_does_not() {
         });
     }
     for result in [d1, d2] {
-        entry.push_instruction(OpCode::ToRadix {
+        entry.push_test_instruction(OpCode::ToRadix {
             result,
             value: v,
             radix: Radix::Dyn(d),
@@ -1087,18 +1087,18 @@ fn witness_cast_and_dependent_expression_dedup_in_one_run() {
     );
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::Cast {
+    entry.push_test_instruction(OpCode::Cast {
         result: c1,
         value: a,
         target: CastTarget::WitnessOf,
     });
-    entry.push_instruction(OpCode::Cast {
+    entry.push_test_instruction(OpCode::Cast {
         result: c2,
         value: a,
         target: CastTarget::WitnessOf,
     });
-    entry.push_instruction(add(s1, c1, c1));
-    entry.push_instruction(add(s2, c2, c2));
+    entry.push_test_instruction(add(s1, c1, c1));
+    entry.push_test_instruction(add(s2, c2, c2));
     entry.set_terminator(Terminator::Return(vec![c2, s2]));
 
     eliminate(&mut ssa);
@@ -1115,7 +1115,7 @@ fn aggregate_constructors_are_untouched() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
     for result in [r1, r2] {
-        entry.push_instruction(OpCode::MkSeq {
+        entry.push_test_instruction(OpCode::MkSeq {
             result,
             elems: vec![a, b],
             seq_type: SequenceTargetType::Array(2),
@@ -1139,7 +1139,7 @@ fn array_get_deduplicates() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
     for result in [g1, g2] {
-        entry.push_instruction(OpCode::ArrayGet {
+        entry.push_test_instruction(OpCode::ArrayGet {
             result,
             array: arr,
             index: c1,
@@ -1160,7 +1160,7 @@ fn read_global_deduplicates() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
     for result in [r1, r2] {
-        entry.push_instruction(OpCode::ReadGlobal {
+        entry.push_test_instruction(OpCode::ReadGlobal {
             result,
             offset: 0,
             result_type: Type::field(),
@@ -1188,7 +1188,7 @@ fn mismatched_type_leader_does_not_block_same_typed_dedup() {
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
     for (result, result_type) in [(m, Type::u(32)), (r1, Type::field()), (r2, Type::field())] {
-        entry.push_instruction(OpCode::ReadGlobal {
+        entry.push_test_instruction(OpCode::ReadGlobal {
             result,
             offset: 0,
             result_type,
@@ -1210,15 +1210,15 @@ fn integrated_dce_sweeps_redirected_definitions() {
     let (r1, r2, eq) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
-    entry.push_instruction(add(r1, a, b));
-    entry.push_instruction(add(r2, a, b));
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(add(r1, a, b));
+    entry.push_test_instruction(add(r2, a, b));
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: eq,
         lhs: r2,
         rhs: c5,
     });
-    entry.push_instruction(OpCode::Assert { value: eq });
+    entry.push_test_instruction(OpCode::Assert { value: eq });
     entry.set_terminator(Terminator::Return(vec![]));
 
     run_pass(&mut ssa);
@@ -1275,7 +1275,7 @@ fn invariant_loop(
 
     let hb = f.get_block_mut(header);
     hb.push_parameter(i, Type::u(32));
-    hb.push_instruction(OpCode::Cmp {
+    hb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: cond,
         lhs: i,
@@ -1284,22 +1284,22 @@ fn invariant_loop(
     hb.set_terminator(Terminator::JmpIf(cond, body, exit));
 
     let bb = f.get_block_mut(body);
-    bb.push_instruction(OpCode::BinaryArithOp {
+    bb.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Mul,
         result: inv,
         lhs: a,
         rhs: b,
     });
-    bb.push_instruction(OpCode::Rangecheck {
+    bb.push_test_instruction(OpCode::Rangecheck {
         value: inv,
         max_bits: 32,
     });
-    bb.push_instruction(add(i2, i, c1));
+    bb.push_test_instruction(add(i2, i, c1));
     bb.set_terminator(Terminator::Jmp(header, vec![i2]));
 
     let eb = f.get_block_mut(exit);
     if with_exit_occurrence {
-        eb.push_instruction(OpCode::BinaryArithOp {
+        eb.push_test_instruction(OpCode::BinaryArithOp {
             kind: BinaryArithOpKind::Mul,
             result: inv2,
             lhs: a,
@@ -1488,7 +1488,7 @@ fn post_loop_only_shape() -> (
 
     let hb = f.get_block_mut(header);
     hb.push_parameter(i, Type::u(32));
-    hb.push_instruction(OpCode::Cmp {
+    hb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: cond,
         lhs: i,
@@ -1497,11 +1497,11 @@ fn post_loop_only_shape() -> (
     hb.set_terminator(Terminator::JmpIf(cond, body, exit));
 
     let bb = f.get_block_mut(body);
-    bb.push_instruction(add(i2, i, c1));
+    bb.push_test_instruction(add(i2, i, c1));
     bb.set_terminator(Terminator::Jmp(header, vec![i2]));
 
     let eb = f.get_block_mut(exit);
-    eb.push_instruction(OpCode::BinaryArithOp {
+    eb.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Mul,
         result: post,
         lhs: a,
@@ -1568,7 +1568,7 @@ fn loop_carried_operand_blocks_hoist() {
     let ohb = f.get_block_mut(oh);
     ohb.push_parameter(j, Type::u(32));
     ohb.push_parameter(acc, Type::field());
-    ohb.push_instruction(OpCode::Cmp {
+    ohb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: jc,
         lhs: j,
@@ -1578,12 +1578,12 @@ fn loop_carried_operand_blocks_hoist() {
 
     // `x` is rebound every outer iteration.
     let obb = f.get_block_mut(obody);
-    obb.push_instruction(add(x, acc, c1f));
+    obb.push_test_instruction(add(x, acc, c1f));
     obb.set_terminator(Terminator::Jmp(ih, vec![c0]));
 
     let ihb = f.get_block_mut(ih);
     ihb.push_parameter(k, Type::u(32));
-    ihb.push_instruction(OpCode::Cmp {
+    ihb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: kc,
         lhs: k,
@@ -1592,31 +1592,31 @@ fn loop_carried_operand_blocks_hoist() {
     ihb.set_terminator(Terminator::JmpIf(kc, ibody, iafter));
 
     let ibb = f.get_block_mut(ibody);
-    ibb.push_instruction(OpCode::BinaryArithOp {
+    ibb.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Mul,
         result: m1,
         lhs: x,
         rhs: c2f,
     });
-    ibb.push_instruction(OpCode::Rangecheck {
+    ibb.push_test_instruction(OpCode::Rangecheck {
         value: m1,
         max_bits: 32,
     });
-    ibb.push_instruction(add(k2, k, c1));
+    ibb.push_test_instruction(add(k2, k, c1));
     ibb.set_terminator(Terminator::Jmp(ih, vec![k2]));
 
     let iab = f.get_block_mut(iafter);
-    iab.push_instruction(OpCode::BinaryArithOp {
+    iab.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Mul,
         result: m2,
         lhs: x,
         rhs: c2f,
     });
-    iab.push_instruction(OpCode::Rangecheck {
+    iab.push_test_instruction(OpCode::Rangecheck {
         value: m2,
         max_bits: 32,
     });
-    iab.push_instruction(add(j2, j, c1));
+    iab.push_test_instruction(add(j2, j, c1));
     iab.set_terminator(Terminator::Jmp(oh, vec![j2, x]));
 
     f.get_block_mut(oexit)
@@ -2101,13 +2101,13 @@ fn jmp_if_entry_edge_is_split_for_the_hoist() {
     // A parameterless self-loop: the invariant is generated in the header itself, so it is
     // anticipated there regardless of the exit path.
     let hb = f.get_block_mut(h);
-    hb.push_instruction(OpCode::BinaryArithOp {
+    hb.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Mul,
         result: inv,
         lhs: a,
         rhs: b,
     });
-    hb.push_instruction(OpCode::Rangecheck {
+    hb.push_test_instruction(OpCode::Rangecheck {
         value: inv,
         max_bits: 32,
     });
@@ -2173,7 +2173,7 @@ fn multi_entry_header_is_skipped() {
 
     let hb = f.get_block_mut(header);
     hb.push_parameter(i, Type::u(32));
-    hb.push_instruction(OpCode::Cmp {
+    hb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: cond,
         lhs: i,
@@ -2182,21 +2182,21 @@ fn multi_entry_header_is_skipped() {
     hb.set_terminator(Terminator::JmpIf(cond, body, exit));
 
     let bb = f.get_block_mut(body);
-    bb.push_instruction(OpCode::BinaryArithOp {
+    bb.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Mul,
         result: inv,
         lhs: a,
         rhs: b,
     });
-    bb.push_instruction(OpCode::Rangecheck {
+    bb.push_test_instruction(OpCode::Rangecheck {
         value: inv,
         max_bits: 32,
     });
-    bb.push_instruction(add(i2, i, c1));
+    bb.push_test_instruction(add(i2, i, c1));
     bb.set_terminator(Terminator::Jmp(header, vec![i2]));
 
     let eb = f.get_block_mut(exit);
-    eb.push_instruction(OpCode::BinaryArithOp {
+    eb.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Mul,
         result: inv2,
         lhs: a,
@@ -2230,12 +2230,15 @@ fn value_available_before_the_loop_is_not_rehoisted() {
         let mut instructions = eb.take_instructions();
         instructions.insert(
             0,
-            crate::compiler::ssa::Located::without(OpCode::BinaryArithOp {
-                kind: BinaryArithOpKind::Mul,
-                result: pre,
-                lhs: a,
-                rhs: b,
-            }),
+            crate::compiler::ssa::Located::new(
+                OpCode::BinaryArithOp {
+                    kind: BinaryArithOpKind::Mul,
+                    result: pre,
+                    lhs: a,
+                    rhs: b,
+                },
+                SourceLocation::test(),
+            ),
         );
         eb.put_instructions(instructions);
     }
@@ -2312,7 +2315,7 @@ fn sibling_recomputations(
         .set_terminator(Terminator::JmpIf(cond, x, y));
     for (block, t) in [(x, tx), (y, ty)] {
         let bb = f.get_block_mut(block);
-        bb.push_instruction(add(t, a, b));
+        bb.push_test_instruction(add(t, a, b));
         let mut rets = vec![t];
         rets.extend(extra_return);
         bb.set_terminator(Terminator::Return(rets));
@@ -2337,7 +2340,7 @@ fn diamond_partial_redundancy_joins_through_parameter() {
     };
     ssa.get_unique_entrypoint_mut()
         .get_block_mut(left)
-        .push_instruction(add(t1, a, b));
+        .push_test_instruction(add(t1, a, b));
     let (x, y, _tx, _ty) = sibling_recomputations(&mut ssa, merge, c, a, b, None);
 
     join_insert(&mut ssa);
@@ -2374,9 +2377,9 @@ fn instruction_neutral_diamond_is_refused() {
     let (mut ssa, a, b, left, right, merge) = diamond();
     let (t1, t2) = (ssa.fresh_value(), ssa.fresh_value());
     let f = ssa.get_unique_entrypoint_mut();
-    f.get_block_mut(left).push_instruction(add(t1, a, b));
+    f.get_block_mut(left).push_test_instruction(add(t1, a, b));
     let mb = f.get_block_mut(merge);
-    mb.push_instruction(add(t2, a, b));
+    mb.push_test_instruction(add(t2, a, b));
     mb.set_terminator(Terminator::Return(vec![t2]));
 
     join_insert(&mut ssa);
@@ -2394,10 +2397,10 @@ fn cross_branch_full_availability_joins_without_copies() {
     let (mut ssa, a, b, left, right, merge) = diamond();
     let (t1, t2, t3) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
     let f = ssa.get_unique_entrypoint_mut();
-    f.get_block_mut(left).push_instruction(add(t1, a, b));
-    f.get_block_mut(right).push_instruction(add(t2, a, b));
+    f.get_block_mut(left).push_test_instruction(add(t1, a, b));
+    f.get_block_mut(right).push_test_instruction(add(t2, a, b));
     let mb = f.get_block_mut(merge);
-    mb.push_instruction(add(t3, a, b));
+    mb.push_test_instruction(add(t3, a, b));
     mb.set_terminator(Terminator::Return(vec![t3]));
 
     join_insert(&mut ssa);
@@ -2426,7 +2429,7 @@ fn key_available_on_no_edge_is_refused() {
     let t = ssa.fresh_value();
     let f = ssa.get_unique_entrypoint_mut();
     let mb = f.get_block_mut(merge);
-    mb.push_instruction(add(t, a, b));
+    mb.push_test_instruction(add(t, a, b));
     mb.set_terminator(Terminator::Return(vec![t]));
 
     join_insert(&mut ssa);
@@ -2461,8 +2464,8 @@ fn merge_without_dominated_occurrence_is_refused() {
     f.get_block_mut(pre)
         .set_terminator(Terminator::JmpIf(c, left, right));
     let lb = f.get_block_mut(left);
-    lb.push_instruction(add(t1, a, b));
-    lb.push_instruction(OpCode::Rangecheck {
+    lb.push_test_instruction(add(t1, a, b));
+    lb.push_test_instruction(OpCode::Rangecheck {
         value: t1,
         max_bits: 32,
     });
@@ -2474,7 +2477,7 @@ fn merge_without_dominated_occurrence_is_refused() {
     f.get_block_mut(w)
         .set_terminator(Terminator::Jmp(x, vec![]));
     let xb = f.get_block_mut(x);
-    xb.push_instruction(add(t2, a, b));
+    xb.push_test_instruction(add(t2, a, b));
     xb.set_terminator(Terminator::Return(vec![t2]));
 
     join_insert(&mut ssa);
@@ -2505,7 +2508,7 @@ fn branching_predecessor_edge_is_split_to_carry_the_argument() {
     entry.push_parameter(c, Type::u(1));
     entry.set_terminator(Terminator::JmpIf(c, p1, p2));
     let p1b = f.get_block_mut(p1);
-    p1b.push_instruction(add(t1, a, b));
+    p1b.push_test_instruction(add(t1, a, b));
     p1b.set_terminator(Terminator::Jmp(m, vec![]));
     f.get_block_mut(p2)
         .set_terminator(Terminator::JmpIf(c, m, z));
@@ -2558,7 +2561,7 @@ fn both_arms_predecessor_hosts_one_copy_and_two_arguments() {
     entry.push_parameter(c, Type::u(1));
     entry.set_terminator(Terminator::JmpIf(c, left, bi));
     let lb = f.get_block_mut(left);
-    lb.push_instruction(add(t1, a, b));
+    lb.push_test_instruction(add(t1, a, b));
     lb.set_terminator(Terminator::Jmp(m, vec![]));
     // The degenerate branch: both arms enter the merge, two distinct edges from one predecessor.
     f.get_block_mut(bi)
@@ -2618,7 +2621,7 @@ fn merge_with_unreachable_predecessor_is_refused() {
             .unwrap()
     };
     let f = ssa.get_unique_entrypoint_mut();
-    f.get_block_mut(left).push_instruction(add(t1, a, b));
+    f.get_block_mut(left).push_test_instruction(add(t1, a, b));
     // A block no path reaches, jumping into the merge.
     let dead = f.add_block();
     f.get_block_mut(dead)
@@ -2664,7 +2667,7 @@ fn existing_parameters_and_arguments_stay_aligned() {
     entry.push_parameter(c, Type::u(1));
     entry.set_terminator(Terminator::JmpIf(c, left, right));
     let lb = f.get_block_mut(left);
-    lb.push_instruction(add(t1, a, b));
+    lb.push_test_instruction(add(t1, a, b));
     lb.set_terminator(Terminator::Jmp(m, vec![a]));
     f.get_block_mut(right)
         .set_terminator(Terminator::Jmp(m, vec![b]));
@@ -2718,7 +2721,7 @@ fn multi_entry_loop_header_joins_with_self_carrying_back_edge() {
     entry.push_parameter(c, Type::u(1));
     entry.set_terminator(Terminator::JmpIf(c, e1, e2));
     let e1b = f.get_block_mut(e1);
-    e1b.push_instruction(add(t1, a, b));
+    e1b.push_test_instruction(add(t1, a, b));
     e1b.set_terminator(Terminator::Jmp(h, vec![]));
     f.get_block_mut(e2)
         .set_terminator(Terminator::Jmp(h, vec![]));
@@ -2726,14 +2729,14 @@ fn multi_entry_loop_header_joins_with_self_carrying_back_edge() {
         .set_terminator(Terminator::JmpIf(c, body, exit));
     // Sibling occurrences below the header: per-iteration in the body, and on the exit path.
     let bb = f.get_block_mut(body);
-    bb.push_instruction(add(tb, a, b));
-    bb.push_instruction(OpCode::Rangecheck {
+    bb.push_test_instruction(add(tb, a, b));
+    bb.push_test_instruction(OpCode::Rangecheck {
         value: tb,
         max_bits: 32,
     });
     bb.set_terminator(Terminator::Jmp(h, vec![]));
     let eb = f.get_block_mut(exit);
-    eb.push_instruction(add(te, a, b));
+    eb.push_test_instruction(add(te, a, b));
     eb.set_terminator(Terminator::Return(vec![te]));
 
     join_insert(&mut ssa);
@@ -2778,7 +2781,7 @@ fn join_insertion_requires_the_join_insert_level() {
     };
     ssa.get_unique_entrypoint_mut()
         .get_block_mut(left)
-        .push_instruction(add(t1, a, b));
+        .push_test_instruction(add(t1, a, b));
     let (x, y, tx, ty) = sibling_recomputations(&mut ssa, merge, c, a, b, None);
 
     hoist(&mut ssa);
@@ -2867,7 +2870,7 @@ fn wrapping_integer_invariant_is_not_speculated() {
     let hb = f.get_block_mut(header);
     hb.push_parameter(i, Type::u(32));
     hb.push_parameter(s, Type::u(32));
-    hb.push_instruction(OpCode::Cmp {
+    hb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: cond,
         lhs: i,
@@ -2877,8 +2880,8 @@ fn wrapping_integer_invariant_is_not_speculated() {
 
     // The invariant wrapping sum, kept live as a loop-carried argument.
     let bb = f.get_block_mut(body);
-    bb.push_instruction(add(u, a, b));
-    bb.push_instruction(add(i2, i, c1));
+    bb.push_test_instruction(add(u, a, b));
+    bb.push_test_instruction(add(i2, i, c1));
     bb.set_terminator(Terminator::Jmp(header, vec![i2, u]));
 
     f.get_block_mut(exit)
@@ -2920,7 +2923,7 @@ fn guarded_division_is_speculated_where_the_fact_holds() {
     let entry = f.get_entry_mut();
     entry.push_parameter(x, Type::u(32));
     entry.push_parameter(d, Type::u(32));
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: eq,
         lhs: d,
@@ -2936,7 +2939,7 @@ fn guarded_division_is_speculated_where_the_fact_holds() {
     let hb = f.get_block_mut(header);
     hb.push_parameter(i, Type::u(32));
     hb.push_parameter(acc, Type::u(32));
-    hb.push_instruction(OpCode::Cmp {
+    hb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: cond,
         lhs: i,
@@ -2945,13 +2948,13 @@ fn guarded_division_is_speculated_where_the_fact_holds() {
     hb.set_terminator(Terminator::JmpIf(cond, body, exit));
 
     let bb = f.get_block_mut(body);
-    bb.push_instruction(OpCode::BinaryArithOp {
+    bb.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Div,
         result: q,
         lhs: x,
         rhs: d,
     });
-    bb.push_instruction(add(i2, i, c1));
+    bb.push_test_instruction(add(i2, i, c1));
     bb.set_terminator(Terminator::Jmp(header, vec![i2, q]));
 
     f.get_block_mut(exit)
@@ -3008,7 +3011,7 @@ fn unguarded_division_is_not_speculated() {
     let hb = f.get_block_mut(header);
     hb.push_parameter(i, Type::u(32));
     hb.push_parameter(acc, Type::u(32));
-    hb.push_instruction(OpCode::Cmp {
+    hb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: cond,
         lhs: i,
@@ -3017,13 +3020,13 @@ fn unguarded_division_is_not_speculated() {
     hb.set_terminator(Terminator::JmpIf(cond, body, exit));
 
     let bb = f.get_block_mut(body);
-    bb.push_instruction(OpCode::BinaryArithOp {
+    bb.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Div,
         result: q,
         lhs: x,
         rhs: d,
     });
-    bb.push_instruction(add(i2, i, c1));
+    bb.push_test_instruction(add(i2, i, c1));
     bb.set_terminator(Terminator::Jmp(header, vec![i2, q]));
 
     f.get_block_mut(exit)
@@ -3103,7 +3106,7 @@ fn hoisted_copy_carries_the_template_source_location() {
 
     let hb = f.get_block_mut(header);
     hb.push_parameter(i, Type::u(32));
-    hb.push_instruction(OpCode::Cmp {
+    hb.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: cond,
         lhs: i,
@@ -3113,7 +3116,7 @@ fn hoisted_copy_carries_the_template_source_location() {
 
     let bb = f.get_block_mut(body);
     bb.push_instruction_with_source_location(mul(inv, a, b), test_location());
-    bb.push_instruction(add(i2, i, c1));
+    bb.push_test_instruction(add(i2, i, c1));
     bb.set_terminator(Terminator::Jmp(header, vec![i2]));
 
     let eb = f.get_block_mut(exit);
@@ -3128,7 +3131,7 @@ fn hoisted_copy_carries_the_template_source_location() {
         .get_instructions_with_source_locations()
         .collect();
     assert_eq!(hoisted.len(), 1);
-    assert_eq!(hoisted[0].1, Some(&test_location()));
+    assert_eq!(hoisted[0].1, &test_location());
 }
 
 /// A join copy materialized on a leaderless edge carries its template's source location. The
@@ -3167,5 +3170,5 @@ fn join_copy_carries_the_template_source_location() {
         .get_instructions_with_source_locations()
         .collect();
     assert_eq!(copies.len(), 1);
-    assert_eq!(copies[0].1, Some(&test_location()));
+    assert_eq!(copies[0].1, &test_location());
 }

--- a/compiler/src/compiler/passes/prepare_entry_point.rs
+++ b/compiler/src/compiler/passes/prepare_entry_point.rs
@@ -24,7 +24,7 @@ use crate::{
     compiler::{
         pass_manager::{AnalysisStore, Pass},
         ssa::{
-            BlockId, FunctionId, Located, ValueId,
+            BlockId, FunctionId, Located, SourceLocation, ValueId,
             hlssa::{
                 CallTarget, CastTarget, HLSSA, OpCode, SequenceTargetType, Type, TypeExpr,
                 builder::{HLBlockEmitter, HLEmitter, HLSSABuilder},
@@ -94,7 +94,9 @@ impl PrepareEntryPoint {
         let mut sb = HLSSABuilder::new(ssa);
         sb.modify_function(wrapper_id, |b| {
             let entry_block = b.function.get_entry_id();
-            let mut e = b.block(entry_block);
+            let mut e = b
+                .block(entry_block)
+                .with_source_location(SourceLocation::synthetic("wrapper_main"));
 
             let blob_param = e.add_parameter(Type::blob(Type::field(), total_fields));
 
@@ -379,7 +381,8 @@ impl PrepareEntryPoint {
         sb.modify_function(fn_id, |b| {
             b.function.add_return_type(typ.clone());
             let entry_block = b.function.get_entry_id();
-            let mut e = b.block(entry_block);
+            let location = SourceLocation::synthetic(b.function.get_name());
+            let mut e = b.block(entry_block).with_source_location(location);
             let param = e.add_parameter(typ.clone());
             let result = Self::emit_prepare_body(&mut e, param, typ, &child_fns);
             e.terminate_return(vec![result]);
@@ -495,7 +498,8 @@ impl PrepareEntryPoint {
         sb.modify_function(fn_id, |b| {
             b.function.add_return_type(typ.clone());
             let entry_block = b.function.get_entry_id();
-            let mut e = b.block(entry_block);
+            let location = SourceLocation::synthetic(b.function.get_name());
+            let mut e = b.block(entry_block).with_source_location(location);
 
             let input_len = Self::flattened_field_count(typ);
             let input_array = e.add_parameter(Type::field().array_of(input_len));

--- a/compiler/src/compiler/passes/rc_insertion.rs
+++ b/compiler/src/compiler/passes/rc_insertion.rs
@@ -68,10 +68,7 @@ impl RCInsertion {
             // inserting drops.
             let mut currently_live = liveness.block_liveness[block_id].live_out.clone();
             let mut new_instructions = vec![];
-            let block_location = block
-                .get_instructions_with_source_locations()
-                .next()
-                .map(|(_, location)| location.clone());
+            let block_location = block.first_location().cloned();
 
             match block.get_terminator().unwrap() {
                 Terminator::Return(values) => {

--- a/compiler/src/compiler/passes/rc_insertion.rs
+++ b/compiler/src/compiler/passes/rc_insertion.rs
@@ -17,7 +17,7 @@ use crate::compiler::{
     },
     pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
     ssa::{
-        Instruction, Located, Location, Terminator, ValueId,
+        Instruction, Located, SourceLocation, Terminator, ValueId,
         hlssa::{CastTarget, HLFunction, HLSSA, OpCode, RefCountOp, Type, TypeExpr},
     },
 };
@@ -68,7 +68,10 @@ impl RCInsertion {
             // inserting drops.
             let mut currently_live = liveness.block_liveness[block_id].live_out.clone();
             let mut new_instructions = vec![];
-            let block_location = None;
+            let block_location = block
+                .get_instructions_with_source_locations()
+                .next()
+                .map(|(_, location)| location.clone());
 
             match block.get_terminator().unwrap() {
                 Terminator::Return(values) => {
@@ -87,7 +90,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(count),
                                 *value,
                                 &value_locations,
-                                &block_location,
+                                block_location.as_ref(),
                             );
                         }
                     }
@@ -115,7 +118,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(count),
                                 *value,
                                 &value_locations,
-                                &block_location,
+                                block_location.as_ref(),
                             );
                         }
                     }
@@ -158,7 +161,7 @@ impl RCInsertion {
                                     RefCountOp::Bump(count),
                                     *input,
                                     &value_locations,
-                                    &instruction_location,
+                                    Some(&instruction_location),
                                 );
                             }
                         }
@@ -180,7 +183,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 *v,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         if !currently_live.contains(r) {
@@ -215,7 +218,7 @@ impl RCInsertion {
                                     RefCountOp::Bump(1),
                                     *v,
                                     &value_locations,
-                                    &instruction_location,
+                                    Some(&instruction_location),
                                 );
                             }
                             // If only result is live (input dead), no RC op needed — single alias.
@@ -292,7 +295,7 @@ impl RCInsertion {
                                     RefCountOp::Drop,
                                     *input,
                                     &value_locations,
-                                    &instruction_location,
+                                    Some(&instruction_location),
                                 );
                             }
                         }
@@ -311,7 +314,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *r,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         new_instructions.push(instruction.clone());
@@ -327,7 +330,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *v,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         new_instructions.push(instruction.clone());
@@ -362,7 +365,7 @@ impl RCInsertion {
                                         RefCountOp::Bump(count),
                                         *input,
                                         &value_locations,
-                                        &instruction_location,
+                                        Some(&instruction_location),
                                     );
                                 }
                             }
@@ -415,7 +418,7 @@ impl RCInsertion {
                                     RefCountOp::Bump(bump),
                                     *element,
                                     &value_locations,
-                                    &instruction_location,
+                                    Some(&instruction_location),
                                 );
                             }
                         }
@@ -434,7 +437,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *result,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         new_instructions.push(instruction);
@@ -444,7 +447,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 value,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         currently_live.insert(value);
@@ -461,7 +464,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 ptr,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         new_instructions.push(instruction);
@@ -471,7 +474,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 value,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         currently_live.insert(ptr);
@@ -484,7 +487,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *ptr,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         if self.needs_rc(type_info, result) {
@@ -494,7 +497,7 @@ impl RCInsertion {
                                     RefCountOp::Bump(1),
                                     *result,
                                     &value_locations,
-                                    &instruction_location,
+                                    Some(&instruction_location),
                                 );
                             } else {
                                 panic!(
@@ -525,7 +528,7 @@ impl RCInsertion {
                                     RefCountOp::Drop,
                                     *return_id,
                                     &value_locations,
-                                    &instruction_location,
+                                    Some(&instruction_location),
                                 );
                             }
                         }
@@ -548,7 +551,7 @@ impl RCInsertion {
                                     RefCountOp::Bump(count),
                                     *param,
                                     &value_locations,
-                                    &instruction_location,
+                                    Some(&instruction_location),
                                 );
                             }
                         }
@@ -567,7 +570,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *array,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         if self.needs_rc(type_info, result) {
@@ -579,7 +582,7 @@ impl RCInsertion {
                                     RefCountOp::Bump(1),
                                     *result,
                                     &value_locations,
-                                    &instruction_location,
+                                    Some(&instruction_location),
                                 );
                             } else {
                                 panic!(
@@ -607,7 +610,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *slice,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         new_instructions.push(instruction.clone());
@@ -629,7 +632,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 *r,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         new_instructions.push(instruction.clone());
@@ -651,7 +654,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 *array,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         if self.needs_rc(type_info, value) && currently_live.contains(value) {
@@ -660,7 +663,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 *value,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             )
                         }
                         if !currently_live.contains(result) {
@@ -687,7 +690,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 *slice,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         let slice_type = type_info.get_value_type(*slice);
@@ -711,7 +714,7 @@ impl RCInsertion {
                                         RefCountOp::Bump(count),
                                         *value,
                                         &value_locations,
-                                        &instruction_location,
+                                        Some(&instruction_location),
                                     );
                                 }
                             }
@@ -738,7 +741,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 v,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         new_instructions.push(instruction);
@@ -772,7 +775,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *r,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         // ToBits should return an RC counter of 1.
@@ -792,7 +795,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *r,
                                 &value_locations,
-                                &instruction_location,
+                                Some(&instruction_location),
                             );
                         }
                         // ToRadix should return an RC counter of 1.
@@ -821,7 +824,7 @@ impl RCInsertion {
                         RefCountOp::Drop,
                         *param,
                         &value_locations,
-                        &block_location,
+                        block_location.as_ref(),
                     );
                 }
             }
@@ -887,18 +890,18 @@ impl RCInsertion {
                     RefCountOp::Drop,
                     *value,
                     &value_locations,
-                    &None,
+                    None,
                 ));
             }
         }
     }
 
-    fn value_source_locations(function: &HLFunction) -> HashMap<ValueId, Location> {
+    fn value_source_locations(function: &HLFunction) -> HashMap<ValueId, SourceLocation> {
         let mut locations = HashMap::default();
         for (_, block) in function.get_blocks() {
             for instruction in block.get_instructions_with_source_locations() {
                 for result in instruction.0.get_results() {
-                    locations.insert(*result, instruction.1.cloned());
+                    locations.insert(*result, instruction.1.clone());
                 }
             }
         }
@@ -908,24 +911,24 @@ impl RCInsertion {
     fn located_mem_op(
         kind: RefCountOp,
         value: ValueId,
-        value_locations: &HashMap<ValueId, Location>,
-        fallback_location: &Location,
+        value_locations: &HashMap<ValueId, SourceLocation>,
+        fallback_location: Option<&SourceLocation>,
     ) -> Located<OpCode> {
-        Located::new(
-            OpCode::MemOp { kind, value },
-            value_locations
-                .get(&value)
-                .cloned()
-                .unwrap_or_else(|| fallback_location.clone()),
-        )
+        let location = value_locations
+            .get(&value)
+            .or(fallback_location)
+            .cloned()
+            .expect("ICE: reference-count op emitted without a source location");
+
+        Located::new(OpCode::MemOp { kind, value }, location)
     }
 
     fn push_mem_op(
         instructions: &mut Vec<Located<OpCode>>,
         kind: RefCountOp,
         value: ValueId,
-        value_locations: &HashMap<ValueId, Location>,
-        fallback_location: &Location,
+        value_locations: &HashMap<ValueId, SourceLocation>,
+        fallback_location: Option<&SourceLocation>,
     ) {
         instructions.push(Self::located_mem_op(
             kind,

--- a/compiler/src/compiler/passes/rc_insertion.rs
+++ b/compiler/src/compiler/passes/rc_insertion.rs
@@ -61,6 +61,9 @@ impl RCInsertion {
         liveness: &FunctionLiveness,
     ) {
         let value_locations = Self::value_source_locations(function);
+        // Last-resort anchor for mem-ops on values with no defining instruction in an
+        // instruction-less block.
+        let pass_location = SourceLocation::synthetic("rc_insertion");
         for (block_id, block) in function.get_blocks_mut() {
             // We're traversing the block backwards, dropping everything that's not live
             // after the currently visited instruction.
@@ -68,7 +71,10 @@ impl RCInsertion {
             // inserting drops.
             let mut currently_live = liveness.block_liveness[block_id].live_out.clone();
             let mut new_instructions = vec![];
-            let block_location = block.first_location().cloned();
+            // Mem-ops inserted next to the terminator anchor to the last instruction; drops of
+            // dead parameters end up at the top of the block and anchor to the first.
+            let first_location = block.first_location().cloned();
+            let last_location = block.last_location().cloned();
 
             match block.get_terminator().unwrap() {
                 Terminator::Return(values) => {
@@ -87,7 +93,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(count),
                                 *value,
                                 &value_locations,
-                                block_location.as_ref(),
+                                last_location.as_ref().unwrap_or(&pass_location),
                             );
                         }
                     }
@@ -115,7 +121,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(count),
                                 *value,
                                 &value_locations,
-                                block_location.as_ref(),
+                                last_location.as_ref().unwrap_or(&pass_location),
                             );
                         }
                     }
@@ -158,7 +164,7 @@ impl RCInsertion {
                                     RefCountOp::Bump(count),
                                     *input,
                                     &value_locations,
-                                    Some(&instruction_location),
+                                    &instruction_location,
                                 );
                             }
                         }
@@ -180,7 +186,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 *v,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         if !currently_live.contains(r) {
@@ -215,7 +221,7 @@ impl RCInsertion {
                                     RefCountOp::Bump(1),
                                     *v,
                                     &value_locations,
-                                    Some(&instruction_location),
+                                    &instruction_location,
                                 );
                             }
                             // If only result is live (input dead), no RC op needed — single alias.
@@ -292,7 +298,7 @@ impl RCInsertion {
                                     RefCountOp::Drop,
                                     *input,
                                     &value_locations,
-                                    Some(&instruction_location),
+                                    &instruction_location,
                                 );
                             }
                         }
@@ -311,7 +317,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *r,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         new_instructions.push(instruction.clone());
@@ -327,7 +333,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *v,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         new_instructions.push(instruction.clone());
@@ -362,7 +368,7 @@ impl RCInsertion {
                                         RefCountOp::Bump(count),
                                         *input,
                                         &value_locations,
-                                        Some(&instruction_location),
+                                        &instruction_location,
                                     );
                                 }
                             }
@@ -415,7 +421,7 @@ impl RCInsertion {
                                     RefCountOp::Bump(bump),
                                     *element,
                                     &value_locations,
-                                    Some(&instruction_location),
+                                    &instruction_location,
                                 );
                             }
                         }
@@ -434,7 +440,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *result,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         new_instructions.push(instruction);
@@ -444,7 +450,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 value,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         currently_live.insert(value);
@@ -461,7 +467,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 ptr,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         new_instructions.push(instruction);
@@ -471,7 +477,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 value,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         currently_live.insert(ptr);
@@ -484,7 +490,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *ptr,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         if self.needs_rc(type_info, result) {
@@ -494,7 +500,7 @@ impl RCInsertion {
                                     RefCountOp::Bump(1),
                                     *result,
                                     &value_locations,
-                                    Some(&instruction_location),
+                                    &instruction_location,
                                 );
                             } else {
                                 panic!(
@@ -525,7 +531,7 @@ impl RCInsertion {
                                     RefCountOp::Drop,
                                     *return_id,
                                     &value_locations,
-                                    Some(&instruction_location),
+                                    &instruction_location,
                                 );
                             }
                         }
@@ -548,7 +554,7 @@ impl RCInsertion {
                                     RefCountOp::Bump(count),
                                     *param,
                                     &value_locations,
-                                    Some(&instruction_location),
+                                    &instruction_location,
                                 );
                             }
                         }
@@ -567,7 +573,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *array,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         if self.needs_rc(type_info, result) {
@@ -579,7 +585,7 @@ impl RCInsertion {
                                     RefCountOp::Bump(1),
                                     *result,
                                     &value_locations,
-                                    Some(&instruction_location),
+                                    &instruction_location,
                                 );
                             } else {
                                 panic!(
@@ -607,7 +613,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *slice,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         new_instructions.push(instruction.clone());
@@ -629,7 +635,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 *r,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         new_instructions.push(instruction.clone());
@@ -651,7 +657,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 *array,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         if self.needs_rc(type_info, value) && currently_live.contains(value) {
@@ -660,7 +666,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 *value,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             )
                         }
                         if !currently_live.contains(result) {
@@ -687,7 +693,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 *slice,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         let slice_type = type_info.get_value_type(*slice);
@@ -711,7 +717,7 @@ impl RCInsertion {
                                         RefCountOp::Bump(count),
                                         *value,
                                         &value_locations,
-                                        Some(&instruction_location),
+                                        &instruction_location,
                                     );
                                 }
                             }
@@ -738,7 +744,7 @@ impl RCInsertion {
                                 RefCountOp::Bump(1),
                                 v,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         new_instructions.push(instruction);
@@ -772,7 +778,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *r,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         // ToBits should return an RC counter of 1.
@@ -792,7 +798,7 @@ impl RCInsertion {
                                 RefCountOp::Drop,
                                 *r,
                                 &value_locations,
-                                Some(&instruction_location),
+                                &instruction_location,
                             );
                         }
                         // ToRadix should return an RC counter of 1.
@@ -821,7 +827,7 @@ impl RCInsertion {
                         RefCountOp::Drop,
                         *param,
                         &value_locations,
-                        block_location.as_ref(),
+                        first_location.as_ref().unwrap_or(&pass_location),
                     );
                 }
             }
@@ -887,7 +893,7 @@ impl RCInsertion {
                     RefCountOp::Drop,
                     *value,
                     &value_locations,
-                    None,
+                    &pass_location,
                 ));
             }
         }
@@ -909,15 +915,13 @@ impl RCInsertion {
         kind: RefCountOp,
         value: ValueId,
         value_locations: &HashMap<ValueId, SourceLocation>,
-        fallback_location: Option<&SourceLocation>,
+        fallback_location: &SourceLocation,
     ) -> Located<OpCode> {
-        // Block parameters have no defining instruction; in an instruction-less block there is
-        // no fallback either.
+        // Block parameters have no defining instruction; they use the fallback anchor.
         let location = value_locations
             .get(&value)
-            .or(fallback_location)
-            .cloned()
-            .unwrap_or_else(|| SourceLocation::synthetic("rc_insertion"));
+            .unwrap_or(fallback_location)
+            .clone();
 
         Located::new(OpCode::MemOp { kind, value }, location)
     }
@@ -927,7 +931,7 @@ impl RCInsertion {
         kind: RefCountOp,
         value: ValueId,
         value_locations: &HashMap<ValueId, SourceLocation>,
-        fallback_location: Option<&SourceLocation>,
+        fallback_location: &SourceLocation,
     ) {
         instructions.push(Self::located_mem_op(
             kind,

--- a/compiler/src/compiler/passes/rc_insertion.rs
+++ b/compiler/src/compiler/passes/rc_insertion.rs
@@ -914,11 +914,13 @@ impl RCInsertion {
         value_locations: &HashMap<ValueId, SourceLocation>,
         fallback_location: Option<&SourceLocation>,
     ) -> Located<OpCode> {
+        // Block parameters have no defining instruction; in an instruction-less block there is
+        // no fallback either.
         let location = value_locations
             .get(&value)
             .or(fallback_location)
             .cloned()
-            .expect("ICE: reference-count op emitted without a source location");
+            .unwrap_or_else(|| SourceLocation::synthetic("rc_insertion"));
 
         Located::new(OpCode::MemOp { kind, value }, location)
     }

--- a/compiler/src/compiler/passes/sparse_conditional_simplification/mod.rs
+++ b/compiler/src/compiler/passes/sparse_conditional_simplification/mod.rs
@@ -239,10 +239,11 @@ fn propagate(
 
     // Witness-typed constants materialized as casts — fed by `substitute_asserted_consts`
     // (witness-typed asserted-constant operands) and the anticipated witness `Cmp{Eq}` fold: keyed
-    // by the bare interned constant, valued by the fresh `cast <const> to WitnessOf` result.
-    // Accumulated across the whole function and hoisted into the entry block at the end (so each
-    // definition dominates every use, and identical constants share one cast).
-    let mut witness_const_casts: HashMap<ValueId, ValueId> = HashMap::default();
+    // by the bare interned constant, valued by the fresh `cast <const> to WitnessOf` result and the
+    // source location of the original instruction that required it. Accumulated across the whole
+    // function and hoisted into the entry block at the end (so each definition dominates every
+    // use, and identical constants share one cast without losing their original provenance).
+    let mut witness_const_casts: HashMap<ValueId, (ValueId, SourceLocation)> = HashMap::default();
     let const_values = cc.new_const_values(fid);
     let const_set: HashSet<ValueId> = const_values.iter().map(|(v, _)| *v).collect();
 
@@ -386,9 +387,10 @@ fn propagate(
                 if cc.anticipated_equal(fid, point, lhs, rhs) {
                     let bare = ssa.add_const((*bool_constant(true)).clone());
                     if fn_type_info.get_value_type(result).is_witness_of() {
-                        let wit = *witness_const_casts
+                        let wit = witness_const_casts
                             .entry(bare)
-                            .or_insert_with(|| ssa.fresh_value());
+                            .or_insert_with(|| (ssa.fresh_value(), location.clone()))
+                            .0;
                         anticipated_witness_replacements.insert(result, wit);
                     } else {
                         anticipated_replacements.insert(result, bare);
@@ -445,6 +447,7 @@ fn propagate(
                 ProgramPoint::new(bid, i),
                 allow_witness,
                 allow_anticipated,
+                &location,
                 &mut witness_const_casts,
                 instr.get_inputs_mut(),
             );
@@ -497,6 +500,10 @@ fn propagate(
         // `Return` values and `Jmp` args are pure value consumers, so witness substitution is
         // allowed here just as for the safe-target instructions above.
         let term_point = ProgramPoint::new(bid, instr_count);
+        let terminator_location = block
+            .last_location()
+            .cloned()
+            .unwrap_or_else(|| SourceLocation::synthetic("sparse_conditional_simplification"));
         match block.get_terminator_mut() {
             Terminator::Return(vals) => {
                 substitute_asserted_consts(
@@ -507,6 +514,7 @@ fn propagate(
                     term_point,
                     true,
                     true,
+                    &terminator_location,
                     &mut witness_const_casts,
                     vals.iter_mut(),
                 );
@@ -520,6 +528,7 @@ fn propagate(
                     term_point,
                     true,
                     true,
+                    &terminator_location,
                     &mut witness_const_casts,
                     params.iter_mut(),
                 );
@@ -624,25 +633,22 @@ fn propagate(
     // 9. Hoist the witness-typed constants materialized above — by the asserted-constant
     // substitution and the anticipated witness `Cmp{Eq}` fold — into the entry block, whose every
     // instruction it dominates, so each `cast <const> to WitnessOf` definition dominates the uses
-    // redirected to it. Emit them in result-id order for a deterministic instruction sequence.
+    // redirected to it. Each cast keeps the source location of the original instruction that first
+    // required it. Emit them in result-id order for a deterministic instruction sequence.
     if !witness_const_casts.is_empty() {
-        let entry_location = function
-            .get_entry()
-            .first_location()
-            .cloned()
-            .unwrap_or_else(|| SourceLocation::synthetic("sparse_conditional_simplification"));
-        let mut casts: Vec<(ValueId, ValueId)> = witness_const_casts.into_iter().collect();
-        casts.sort_by_key(|(_, wit)| wit.0);
+        let mut casts: Vec<(ValueId, (ValueId, SourceLocation))> =
+            witness_const_casts.into_iter().collect();
+        casts.sort_by_key(|(_, (wit, _))| wit.0);
         let mut entry_instrs: Vec<Located<OpCode>> = casts
             .into_iter()
-            .map(|(bare, wit)| {
+            .map(|(bare, (wit, location))| {
                 Located::new(
                     OpCode::Cast {
                         result: wit,
                         value: bare,
                         target: CastTarget::WitnessOf,
                     },
-                    entry_location.clone(),
+                    location,
                 )
             })
             .collect();
@@ -722,7 +728,8 @@ fn substitute_asserted_consts<'a>(
     point: ProgramPoint,
     allow_witness: bool,
     allow_anticipated: bool,
-    witness_casts: &mut HashMap<ValueId, ValueId>,
+    source_location: &SourceLocation,
+    witness_casts: &mut HashMap<ValueId, (ValueId, SourceLocation)>,
     inputs: impl Iterator<Item = &'a mut ValueId>,
 ) {
     for input in inputs {
@@ -739,9 +746,10 @@ fn substitute_asserted_consts<'a>(
             if !fn_type_info.get_value_type(*input).is_witness_of() {
                 *input = bare;
             } else if allow_witness {
-                let wit = *witness_casts
+                let wit = witness_casts
                     .entry(bare)
-                    .or_insert_with(|| ssa.fresh_value());
+                    .or_insert_with(|| (ssa.fresh_value(), source_location.clone()))
+                    .0;
                 *input = wit;
             }
         }

--- a/compiler/src/compiler/passes/sparse_conditional_simplification/mod.rs
+++ b/compiler/src/compiler/passes/sparse_conditional_simplification/mod.rs
@@ -99,7 +99,8 @@ use crate::{
             shared::value_replacements::{ReplaceScope, ValueReplacements},
         },
         ssa::{
-            BlockId, FunctionId, Instruction, Located, ProgramPoint, Terminator, ValueId,
+            BlockId, FunctionId, Instruction, Located, ProgramPoint, SourceLocation, Terminator,
+            ValueId,
             hlssa::{CastTarget, CmpKind, HLFunction, HLSSA, OpCode},
         },
     },
@@ -625,16 +626,24 @@ fn propagate(
     // instruction it dominates, so each `cast <const> to WitnessOf` definition dominates the uses
     // redirected to it. Emit them in result-id order for a deterministic instruction sequence.
     if !witness_const_casts.is_empty() {
+        let entry_location = function
+            .get_entry()
+            .first_location()
+            .cloned()
+            .unwrap_or_else(|| SourceLocation::synthetic("sparse_conditional_simplification"));
         let mut casts: Vec<(ValueId, ValueId)> = witness_const_casts.into_iter().collect();
         casts.sort_by_key(|(_, wit)| wit.0);
         let mut entry_instrs: Vec<Located<OpCode>> = casts
             .into_iter()
             .map(|(bare, wit)| {
-                Located::without(OpCode::Cast {
-                    result: wit,
-                    value: bare,
-                    target: CastTarget::WitnessOf,
-                })
+                Located::new(
+                    OpCode::Cast {
+                        result: wit,
+                        value: bare,
+                        target: CastTarget::WitnessOf,
+                    },
+                    entry_location.clone(),
+                )
             })
             .collect();
         let entry = function.get_entry_mut();

--- a/compiler/src/compiler/passes/sparse_conditional_simplification/test.rs
+++ b/compiler/src/compiler/passes/sparse_conditional_simplification/test.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::compiler::{
     Field,
     analysis::click_cooper::test::run_in_test,
+    ssa::SourcePosition,
     ssa::hlssa::{BinaryArithOpKind, CastTarget, CmpKind, Constant, SequenceTargetType, Type},
 };
 
@@ -2279,6 +2280,11 @@ fn anticipated_witnessed_cmp_fold_redirects_use_via_hoisted_cast() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let c_true = ssa.add_const(Constant::U(1, 1));
     let (a, b, ww) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
+    let cmp_location = SourceLocation::new(
+        "src/main.nr",
+        SourcePosition::new(7, 9),
+        SourcePosition::new(7, 15),
+    );
 
     let f = ssa.get_unique_entrypoint_mut();
     f.get_entry_mut()
@@ -2289,12 +2295,15 @@ fn anticipated_witnessed_cmp_fold_redirects_use_via_hoisted_cast() {
 
     // A witness operand makes the result `WitnessOf(u1)`; the assert comes _after_, so only
     // the anticipated ("bound to run") direction proves the fold.
-    entry.push_test_instruction(OpCode::Cmp {
-        kind: CmpKind::Eq,
-        result: ww,
-        lhs: a,
-        rhs: b,
-    });
+    entry.push_instruction_with_source_location(
+        OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: ww,
+            lhs: a,
+            rhs: b,
+        },
+        cmp_location.clone(),
+    );
     entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
@@ -2315,18 +2324,22 @@ fn anticipated_witnessed_cmp_fold_redirects_use_via_hoisted_cast() {
         "the folded witnessed comparison must be kept"
     );
     // A fresh `cast true to WitnessOf` was hoisted into the entry block...
-    let cast_result = entry
-        .get_instructions()
-        .find_map(|i| match i {
+    let (cast_result, cast_location) = entry
+        .get_instructions_with_source_locations()
+        .find_map(|(i, location)| match i {
             OpCode::Cast {
                 result,
                 value,
                 target: CastTarget::WitnessOf,
-            } if *value == c_true => Some(*result),
+            } if *value == c_true => Some((*result, location)),
             _ => None,
         })
         .expect("a witness cast of `true` should be hoisted into the entry block");
     assert_ne!(cast_result, ww, "the recast must not redefine the kept Cmp");
+    assert_eq!(
+        cast_location, &cmp_location,
+        "the hoisted elaboration must retain the original comparison's source location"
+    );
     // ...and the pure use is redirected to it.
     assert!(matches!(
         entry.get_terminator(),

--- a/compiler/src/compiler/passes/sparse_conditional_simplification/test.rs
+++ b/compiler/src/compiler/passes/sparse_conditional_simplification/test.rs
@@ -2162,13 +2162,15 @@ fn anticipated_const_folds_post_loop_use() {
         rhs: c1,
     });
     body_block.set_terminator(Terminator::Jmp(header, vec![v1]));
-    f.get_block_mut(after)
-        .push_instruction(OpCode::BinaryArithOp {
+    f.get_block_mut(after).push_instruction(Located::with(
+        OpCode::BinaryArithOp {
             kind: BinaryArithOpKind::Add,
             result: r,
             lhs: v,
             rhs: n,
-        });
+        },
+        SourceLocation::test(),
+    ));
     f.get_block_mut(after)
         .set_terminator(Terminator::Jmp(tail, vec![]));
     f.get_block_mut(tail).push_instruction(OpCode::AssertCmp {
@@ -2215,19 +2217,27 @@ fn bare_assert_over_cmp_chain_protected() {
     let f = ssa.get_unique_entrypoint_mut();
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(b, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::Cmp {
-        kind: CmpKind::Eq,
-        result: w,
-        lhs: a,
-        rhs: b,
-    });
-    f.get_entry_mut()
-        .push_instruction(OpCode::Assert { value: w });
-    f.get_entry_mut().push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: a,
-        rhs: b,
-    });
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::Cmp {
+            kind: CmpKind::Eq,
+            result: w,
+            lhs: a,
+            rhs: b,
+        },
+        SourceLocation::test(),
+    ));
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::Assert { value: w },
+        SourceLocation::test(),
+    ));
+    f.get_entry_mut().push_instruction(Located::with(
+        OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: a,
+            rhs: b,
+        },
+        SourceLocation::test(),
+    ));
     f.get_entry_mut().set_terminator(Terminator::Return(vec![]));
 
     fold(&mut ssa);

--- a/compiler/src/compiler/passes/sparse_conditional_simplification/test.rs
+++ b/compiler/src/compiler/passes/sparse_conditional_simplification/test.rs
@@ -42,13 +42,13 @@ fn folds_constants_and_prunes_dead_branch() {
     let else_b = f.add_block();
 
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: sum,
         lhs: c2,
         rhs: c3,
     });
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: is_five,
         lhs: sum,
@@ -133,7 +133,7 @@ fn loop_variant_value_is_not_folded() {
         .set_terminator(Terminator::Jmp(header, vec![c0]));
     let header_block = f.get_block_mut(header);
     header_block.push_parameter(i_param, Type::u(32));
-    header_block.push_instruction(OpCode::Cmp {
+    header_block.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: lt,
         lhs: i_param,
@@ -141,7 +141,7 @@ fn loop_variant_value_is_not_folded() {
     });
     header_block.set_terminator(Terminator::JmpIf(lt, body, exit));
     let body_block = f.get_block_mut(body);
-    body_block.push_instruction(OpCode::BinaryArithOp {
+    body_block.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: next,
         lhs: i_param,
@@ -171,7 +171,7 @@ fn does_not_fold_overflow() {
 
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: sum,
         lhs: c200,
@@ -199,12 +199,12 @@ fn does_not_fold_witness_casts() {
 
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::Cast {
+    entry.push_test_instruction(OpCode::Cast {
         result: wit,
         value: c5,
         target: CastTarget::WitnessOf,
     });
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: doubled,
         lhs: wit,
@@ -258,7 +258,7 @@ fn select_with_constant_condition_aliases_to_arm() {
     f.get_entry_mut().push_parameter(arm_t, Type::field());
     f.get_entry_mut().push_parameter(arm_f, Type::field());
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::Select {
+    entry.push_test_instruction(OpCode::Select {
         result: sel,
         cond: c_true,
         if_t: arm_t,
@@ -300,13 +300,13 @@ fn branch_fact_folds_dominated_uses() {
         .set_terminator(Terminator::JmpIf(cond, then_b, else_b));
 
     let then_block = f.get_block_mut(then_b);
-    then_block.push_instruction(OpCode::Select {
+    then_block.push_test_instruction(OpCode::Select {
         result: selected,
         cond,
         if_t: arm_t,
         if_f: arm_f,
     });
-    then_block.push_instruction(OpCode::Not {
+    then_block.push_test_instruction(OpCode::Not {
         result: not_cond,
         value: cond,
     });
@@ -346,7 +346,7 @@ fn branch_fact_does_not_cross_conflicting_merge() {
     f.get_block_mut(else_b)
         .set_terminator(Terminator::Jmp(merge, vec![]));
     let merge_block = f.get_block_mut(merge);
-    merge_block.push_instruction(OpCode::Not {
+    merge_block.push_test_instruction(OpCode::Not {
         result: not_cond,
         value: cond,
     });
@@ -409,7 +409,7 @@ fn branch_with_same_successor_does_not_infer_condition() {
     f.get_entry_mut()
         .set_terminator(Terminator::JmpIf(cond, join, join));
     let join_block = f.get_block_mut(join);
-    join_block.push_instruction(OpCode::Not {
+    join_block.push_test_instruction(OpCode::Not {
         result: not_cond,
         value: cond,
     });
@@ -480,19 +480,19 @@ fn folds_congruence_decided_branch() {
     let else_b = f.add_block();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: a,
         lhs: x,
         rhs: c1,
     });
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: b,
         lhs: x,
         rhs: c1,
     });
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: eq,
         lhs: a,
@@ -527,7 +527,7 @@ fn redundant_self_equality_assert_is_dropped() {
     let f = ssa.get_unique_entrypoint_mut();
     f.get_entry_mut().push_parameter(a, Type::field());
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: a,
@@ -557,19 +557,19 @@ fn redundant_congruent_equality_assert_is_dropped() {
     f.get_entry_mut().push_parameter(x, Type::u(32));
     let entry = f.get_entry_mut();
     // Two identical adds: `a` and `b` are congruent (`known_equal`), independent of any assert.
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: a,
         lhs: x,
         rhs: c1,
     });
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: b,
         lhs: x,
         rhs: c1,
     });
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
@@ -606,7 +606,7 @@ fn non_congruent_equality_assert_is_kept() {
     f.get_entry_mut().push_parameter(a, Type::field());
     f.get_entry_mut().push_parameter(b, Type::field());
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
@@ -637,7 +637,7 @@ fn witnessed_constant_is_cast_to_witness_of() {
     let entry = f.get_entry_mut();
     // An operand is `WitnessOf`, so the comparison result is `WitnessOf(u1)`.
     entry.push_parameter(w, Type::witness_of(Type::u(32)));
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: ww,
         lhs: w,
@@ -682,18 +682,18 @@ fn folds_constant_aggregate_projections() {
     let (seq, got, len) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
-    entry.push_instruction(OpCode::MkSeq {
+    entry.push_test_instruction(OpCode::MkSeq {
         result: seq,
         elems: vec![c10, c20, c30],
         seq_type: SequenceTargetType::Array(3),
         elem_type: Type::u(32),
     });
-    entry.push_instruction(OpCode::ArrayGet {
+    entry.push_test_instruction(OpCode::ArrayGet {
         result: got,
         array: seq,
         index: idx,
     });
-    entry.push_instruction(OpCode::SliceLen {
+    entry.push_test_instruction(OpCode::SliceLen {
         result: len,
         slice: seq,
     });
@@ -731,7 +731,7 @@ fn asserted_const_substituted_after_assert() {
     let f = ssa.get_unique_entrypoint_mut();
     f.get_entry_mut().push_parameter(b, Type::u(1));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::Assert { value: b });
+    entry.push_test_instruction(OpCode::Assert { value: b });
     entry.set_terminator(Terminator::Return(vec![b]));
 
     fold(&mut ssa);
@@ -760,7 +760,7 @@ fn asserted_const_substituted_after_assert_cmp_eq() {
     let f = ssa.get_unique_entrypoint_mut();
     f.get_entry_mut().push_parameter(x, Type::field());
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: x,
         rhs: c5,
@@ -791,12 +791,12 @@ fn same_block_assert_is_index_granular() {
     let f = ssa.get_unique_entrypoint_mut();
     f.get_entry_mut().push_parameter(b, Type::u(1));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::Not {
+    entry.push_test_instruction(OpCode::Not {
         result: before,
         value: b,
     });
-    entry.push_instruction(OpCode::Assert { value: b });
-    entry.push_instruction(OpCode::Not {
+    entry.push_test_instruction(OpCode::Assert { value: b });
+    entry.push_test_instruction(OpCode::Not {
         result: after,
         value: b,
     });
@@ -844,7 +844,7 @@ fn known_unequal_folds_cmp_eq_to_false() {
     let else_b = f.add_block();
     f.get_entry_mut().push_parameter(a, Type::field());
     f.get_entry_mut().push_parameter(b, Type::field());
-    f.get_entry_mut().push_instruction(OpCode::Cmp {
+    f.get_entry_mut().push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: eq,
         lhs: a,
@@ -855,7 +855,7 @@ fn known_unequal_folds_cmp_eq_to_false() {
     f.get_block_mut(then_b)
         .set_terminator(Terminator::Return(vec![]));
     let else_block = f.get_block_mut(else_b);
-    else_block.push_instruction(OpCode::Cmp {
+    else_block.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: eq2,
         lhs: a,
@@ -901,7 +901,7 @@ fn known_unequal_folds_and_prunes_nested_jmpif() {
     let y_b = f.add_block();
     f.get_entry_mut().push_parameter(a, Type::field());
     f.get_entry_mut().push_parameter(b, Type::field());
-    f.get_entry_mut().push_instruction(OpCode::Cmp {
+    f.get_entry_mut().push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: eq,
         lhs: a,
@@ -912,7 +912,7 @@ fn known_unequal_folds_and_prunes_nested_jmpif() {
     f.get_block_mut(then_b)
         .set_terminator(Terminator::Return(vec![]));
     let else_block = f.get_block_mut(else_b);
-    else_block.push_instruction(OpCode::Cmp {
+    else_block.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: eq2,
         lhs: a,
@@ -953,12 +953,12 @@ fn asserted_equal_folds_cmp_eq_to_true() {
     f.get_entry_mut().push_parameter(a, Type::field());
     f.get_entry_mut().push_parameter(b, Type::field());
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
     });
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: eq,
         lhs: a,
@@ -1008,13 +1008,13 @@ fn witnessed_cmp_eq_folded_conditionally_is_cast_to_witness_of() {
     f.get_entry_mut()
         .push_parameter(b, Type::witness_of(Type::field()));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
     });
     // A witness operand makes the result `WitnessOf(u1)`.
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: ww,
         lhs: a,
@@ -1056,7 +1056,7 @@ fn select_with_constant_false_condition_aliases_to_else_arm() {
     f.get_entry_mut().push_parameter(arm_t, Type::field());
     f.get_entry_mut().push_parameter(arm_f, Type::field());
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::Select {
+    entry.push_test_instruction(OpCode::Select {
         result: sel,
         cond: c_false,
         if_t: arm_t,
@@ -1087,7 +1087,7 @@ fn asserted_const_substituted_in_jmp_args() {
     let target = f.add_block();
     f.get_entry_mut().push_parameter(b, Type::u(1));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::Assert { value: b });
+    entry.push_test_instruction(OpCode::Assert { value: b });
     entry.set_terminator(Terminator::Jmp(target, vec![b]));
     let target_block = f.get_block_mut(target);
     target_block.push_parameter(p, Type::u(1));
@@ -1116,7 +1116,7 @@ fn asserted_const_substituted_for_witness_operand_via_cast() {
     f.get_entry_mut()
         .push_parameter(w, Type::witness_of(Type::u(1)));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::Assert { value: w });
+    entry.push_test_instruction(OpCode::Assert { value: w });
     entry.set_terminator(Terminator::Return(vec![w]));
 
     fold(&mut ssa);
@@ -1165,8 +1165,8 @@ fn asserted_const_not_substituted_for_excluded_witness_consumer() {
     f.get_entry_mut()
         .push_parameter(w, Type::witness_of(Type::u(1)));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::Assert { value: w });
-    entry.push_instruction(OpCode::WriteWitness {
+    entry.push_test_instruction(OpCode::Assert { value: w });
+    entry.push_test_instruction(OpCode::WriteWitness {
         result: None,
         value: w,
         pinned: false,
@@ -1208,13 +1208,13 @@ fn asserted_equal_copy_propagates_to_dominating_leader() {
     let f = ssa.get_unique_entrypoint_mut();
     f.get_entry_mut().push_parameter(a, Type::field());
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: b,
         lhs: a,
         rhs: a,
     });
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
@@ -1263,18 +1263,18 @@ fn asserted_equal_copy_prop_redirects_both_directions() {
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(b, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: before,
         lhs: b,
         rhs: c0,
     });
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
     });
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: after,
         lhs: b,
@@ -1338,28 +1338,28 @@ fn anticipated_copy_prop_to_block_defined_leader() {
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(b, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         // index 0: def(x)
         kind: BinaryArithOpKind::Add,
         result: x,
         lhs: a,
         rhs: c1,
     });
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         // index 1: def(y)
         kind: BinaryArithOpKind::Add,
         result: y,
         lhs: b,
         rhs: c2,
     });
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         // index 2: a use of `y` before the assert
         kind: BinaryArithOpKind::Add,
         result: m,
         lhs: y,
         rhs: c1,
     });
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         // index 3: x == y
         kind: CmpKind::Eq,
         lhs: x,
@@ -1408,7 +1408,7 @@ fn asserted_equal_copy_prop_skips_type_mismatch() {
     f.get_entry_mut().push_parameter(x, Type::u(32));
     f.get_entry_mut().push_parameter(y, Type::u(8));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: x,
         rhs: y,
@@ -1436,12 +1436,12 @@ fn asserted_equal_copy_prop_is_transitive() {
     f.get_entry_mut().push_parameter(b, Type::field());
     f.get_entry_mut().push_parameter(c, Type::field());
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
     });
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: b,
         rhs: c,
@@ -1469,7 +1469,7 @@ fn asserted_equal_copy_prop_reaches_jmp_args() {
     f.get_entry_mut().push_parameter(a, Type::field());
     f.get_entry_mut().push_parameter(b, Type::field());
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
@@ -1511,19 +1511,19 @@ fn asserted_equal_copy_prop_yields_to_function_wide_fold() {
     f.get_entry_mut().push_parameter(w, Type::u(1));
     let entry = f.get_entry_mut();
     // x == y pins the comparison `v` to `true` at later points.
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: x,
         rhs: y,
     });
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: v,
         lhs: x,
         rhs: y,
     });
     // `v` is also placed in an asserted-equal class with `w`.
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: v,
         rhs: w,
@@ -1554,7 +1554,7 @@ fn asserted_equal_copy_prop_redirects_equal_witnesses() {
     f.get_entry_mut()
         .push_parameter(wb, Type::witness_of(Type::field()));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: wa,
         rhs: wb,
@@ -1589,7 +1589,7 @@ fn asserted_equal_copy_prop_redirects_witness_machinery_consumer() {
     f.get_entry_mut()
         .push_parameter(wb, Type::witness_of(Type::field()));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: wa,
         rhs: wb,
@@ -1598,7 +1598,7 @@ fn asserted_equal_copy_prop_redirects_witness_machinery_consumer() {
     // A witness-machinery consumer of `wb`: its `value` operand is exposed via `get_inputs_mut`
     // like every witness-machinery operand (`Lookup`/`DLookup` args included), so copy-prop
     // reaches it.
-    entry.push_instruction(OpCode::WriteWitness {
+    entry.push_test_instruction(OpCode::WriteWitness {
         result: None,
         value: wb,
         pinned: false,
@@ -1640,13 +1640,13 @@ fn asserted_equal_copy_prop_keeps_establisher_under_dce() {
     let f = ssa.get_unique_entrypoint_mut();
     f.get_entry_mut().push_parameter(a, Type::field());
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: b,
         lhs: a,
         rhs: a,
     });
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
@@ -1693,20 +1693,20 @@ fn congruence_dropped_assert_still_copy_propagates_soundly() {
     f.get_entry_mut().push_parameter(x, Type::u(32));
     let entry = f.get_entry_mut();
     // Two identical adds ⇒ `a` and `b` are congruent (`known_equal`), `a` defined first.
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: a,
         lhs: x,
         rhs: c1,
     });
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: b,
         lhs: x,
         rhs: c1,
     });
     // Congruence-redundant: 4b drops this in the first walk.
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
@@ -1751,7 +1751,7 @@ fn integrated_dce_removes_dead_code() {
     let f = ssa.get_unique_entrypoint_mut();
     f.get_entry_mut().push_parameter(x, Type::u(32));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::BinaryArithOp {
+    entry.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: unused,
         lhs: x,
@@ -1784,18 +1784,18 @@ fn integrated_dce_sweeps_dead_aggregate() {
     let (seq, got, len) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
-    entry.push_instruction(OpCode::MkSeq {
+    entry.push_test_instruction(OpCode::MkSeq {
         result: seq,
         elems: vec![c10, c20, c30],
         seq_type: SequenceTargetType::Array(3),
         elem_type: Type::u(32),
     });
-    entry.push_instruction(OpCode::ArrayGet {
+    entry.push_test_instruction(OpCode::ArrayGet {
         result: got,
         array: seq,
         index: idx,
     });
-    entry.push_instruction(OpCode::SliceLen {
+    entry.push_test_instruction(OpCode::SliceLen {
         result: len,
         slice: seq,
     });
@@ -1842,12 +1842,12 @@ fn conditional_jmpif_fold_orphan_is_reclaimed_same_run() {
     let entry = f.get_entry_mut();
     // Dominating assert establishes `a == b` conditionally (distinct params, so never a
     // congruence/constant fact); the re-test below folds to `true` only via `asserted_equal`.
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
     });
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: eq2,
         lhs: a,
@@ -1859,7 +1859,7 @@ fn conditional_jmpif_fold_orphan_is_reclaimed_same_run() {
     // `else_b`'s sole predecessor is the entry, so folding the branch orphans it. Its distinct,
     // load-bearing constraint must not leak into the circuit.
     let else_block = f.get_block_mut(else_b);
-    else_block.push_instruction(OpCode::AssertCmp {
+    else_block.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: p,
         rhs: q,
@@ -1916,19 +1916,21 @@ fn anticipated_const_folds_earlier_use() {
     let f = ssa.get_unique_entrypoint_mut();
     let tail = f.add_block();
     f.get_entry_mut().push_parameter(x, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::BinaryArithOp {
-        kind: BinaryArithOpKind::Add,
-        result: r,
-        lhs: x,
-        rhs: c1,
-    });
+    f.get_entry_mut()
+        .push_test_instruction(OpCode::BinaryArithOp {
+            kind: BinaryArithOpKind::Add,
+            result: r,
+            lhs: x,
+            rhs: c1,
+        });
     f.get_entry_mut()
         .set_terminator(Terminator::Jmp(tail, vec![]));
-    f.get_block_mut(tail).push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: x,
-        rhs: c5,
-    });
+    f.get_block_mut(tail)
+        .push_test_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: x,
+            rhs: c5,
+        });
     f.get_block_mut(tail)
         .set_terminator(Terminator::Return(vec![r]));
 
@@ -1961,7 +1963,7 @@ fn anticipated_cmp_fold_decides_branch() {
     let merge = f.add_block();
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(b, Type::u(32));
-    f.get_entry_mut().push_instruction(OpCode::Cmp {
+    f.get_entry_mut().push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: w,
         lhs: a,
@@ -1973,11 +1975,12 @@ fn anticipated_cmp_fold_decides_branch() {
         .set_terminator(Terminator::Jmp(merge, vec![]));
     f.get_block_mut(else_b)
         .set_terminator(Terminator::Jmp(merge, vec![]));
-    f.get_block_mut(merge).push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: a,
-        rhs: b,
-    });
+    f.get_block_mut(merge)
+        .push_test_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: a,
+            rhs: b,
+        });
     f.get_block_mut(merge)
         .set_terminator(Terminator::Return(vec![]));
 
@@ -2019,7 +2022,7 @@ fn mutual_erasure_keeps_one_assert() {
     let f = ssa.get_unique_entrypoint_mut();
     f.get_entry_mut().push_parameter(v, Type::u(32));
     for _ in 0..2 {
-        f.get_entry_mut().push_instruction(OpCode::AssertCmp {
+        f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
             kind: CmpKind::Eq,
             lhs: v,
             rhs: c5,
@@ -2075,13 +2078,13 @@ fn loop_variant_value_not_rewritten_by_later_assert() {
         .set_terminator(Terminator::Jmp(header, vec![c0]));
     let header_block = f.get_block_mut(header);
     header_block.push_parameter(v, Type::u(32));
-    header_block.push_instruction(OpCode::BinaryArithOp {
+    header_block.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: used,
         lhs: v,
         rhs: c1,
     });
-    header_block.push_instruction(OpCode::Cmp {
+    header_block.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: lt,
         lhs: v,
@@ -2089,18 +2092,19 @@ fn loop_variant_value_not_rewritten_by_later_assert() {
     });
     header_block.set_terminator(Terminator::JmpIf(lt, body, after));
     let body_block = f.get_block_mut(body);
-    body_block.push_instruction(OpCode::BinaryArithOp {
+    body_block.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: v1,
         lhs: v,
         rhs: c1,
     });
     body_block.set_terminator(Terminator::Jmp(header, vec![v1]));
-    f.get_block_mut(after).push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: v,
-        rhs: c10,
-    });
+    f.get_block_mut(after)
+        .push_test_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: v,
+            rhs: c10,
+        });
     f.get_block_mut(after)
         .set_terminator(Terminator::Return(vec![used]));
 
@@ -2147,7 +2151,7 @@ fn anticipated_const_folds_post_loop_use() {
         .set_terminator(Terminator::Jmp(header, vec![c0]));
     let header_block = f.get_block_mut(header);
     header_block.push_parameter(v, Type::u(32));
-    header_block.push_instruction(OpCode::Cmp {
+    header_block.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Lt,
         result: lt,
         lhs: v,
@@ -2155,29 +2159,28 @@ fn anticipated_const_folds_post_loop_use() {
     });
     header_block.set_terminator(Terminator::JmpIf(lt, body, after));
     let body_block = f.get_block_mut(body);
-    body_block.push_instruction(OpCode::BinaryArithOp {
+    body_block.push_test_instruction(OpCode::BinaryArithOp {
         kind: BinaryArithOpKind::Add,
         result: v1,
         lhs: v,
         rhs: c1,
     });
     body_block.set_terminator(Terminator::Jmp(header, vec![v1]));
-    f.get_block_mut(after).push_instruction(Located::with(
-        OpCode::BinaryArithOp {
+    f.get_block_mut(after)
+        .push_test_instruction(OpCode::BinaryArithOp {
             kind: BinaryArithOpKind::Add,
             result: r,
             lhs: v,
             rhs: n,
-        },
-        SourceLocation::test(),
-    ));
+        });
     f.get_block_mut(after)
         .set_terminator(Terminator::Jmp(tail, vec![]));
-    f.get_block_mut(tail).push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: v,
-        rhs: c10,
-    });
+    f.get_block_mut(tail)
+        .push_test_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: v,
+            rhs: c10,
+        });
     f.get_block_mut(tail)
         .set_terminator(Terminator::Return(vec![r]));
 
@@ -2217,27 +2220,19 @@ fn bare_assert_over_cmp_chain_protected() {
     let f = ssa.get_unique_entrypoint_mut();
     f.get_entry_mut().push_parameter(a, Type::u(32));
     f.get_entry_mut().push_parameter(b, Type::u(32));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::Cmp {
-            kind: CmpKind::Eq,
-            result: w,
-            lhs: a,
-            rhs: b,
-        },
-        SourceLocation::test(),
-    ));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::Assert { value: w },
-        SourceLocation::test(),
-    ));
-    f.get_entry_mut().push_instruction(Located::with(
-        OpCode::AssertCmp {
-            kind: CmpKind::Eq,
-            lhs: a,
-            rhs: b,
-        },
-        SourceLocation::test(),
-    ));
+    f.get_entry_mut().push_test_instruction(OpCode::Cmp {
+        kind: CmpKind::Eq,
+        result: w,
+        lhs: a,
+        rhs: b,
+    });
+    f.get_entry_mut()
+        .push_test_instruction(OpCode::Assert { value: w });
+    f.get_entry_mut().push_test_instruction(OpCode::AssertCmp {
+        kind: CmpKind::Eq,
+        lhs: a,
+        rhs: b,
+    });
     f.get_entry_mut().set_terminator(Terminator::Return(vec![]));
 
     fold(&mut ssa);
@@ -2294,13 +2289,13 @@ fn anticipated_witnessed_cmp_fold_redirects_use_via_hoisted_cast() {
 
     // A witness operand makes the result `WitnessOf(u1)`; the assert comes _after_, so only
     // the anticipated ("bound to run") direction proves the fold.
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: ww,
         lhs: a,
         rhs: b,
     });
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
@@ -2358,14 +2353,14 @@ fn anticipated_witnessed_cmp_fold_keeps_excluded_assert_use() {
     f.get_entry_mut()
         .push_parameter(b, Type::witness_of(Type::field()));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: ww,
         lhs: a,
         rhs: b,
     });
-    entry.push_instruction(OpCode::Assert { value: ww });
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::Assert { value: ww });
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
@@ -2419,24 +2414,25 @@ fn anticipated_witnessed_cmp_fold_from_post_dominating_assert() {
     f.get_entry_mut()
         .push_parameter(b, Type::witness_of(Type::field()));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: ww,
         lhs: a,
         rhs: b,
     });
-    entry.push_instruction(OpCode::Select {
+    entry.push_test_instruction(OpCode::Select {
         result: s,
         cond: ww,
         if_t: a,
         if_f: b,
     });
     entry.set_terminator(Terminator::Jmp(tail, vec![]));
-    f.get_block_mut(tail).push_instruction(OpCode::AssertCmp {
-        kind: CmpKind::Eq,
-        lhs: a,
-        rhs: b,
-    });
+    f.get_block_mut(tail)
+        .push_test_instruction(OpCode::AssertCmp {
+            kind: CmpKind::Eq,
+            lhs: a,
+            rhs: b,
+        });
     f.get_block_mut(tail)
         .set_terminator(Terminator::Return(vec![s]));
 
@@ -2492,16 +2488,16 @@ fn anticipated_witness_cast_shared_with_asserted_const_channel() {
     f.get_entry_mut()
         .push_parameter(w, Type::witness_of(Type::u(1)));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: ww,
         lhs: a,
         rhs: b,
     });
     // Pins `w` to `true` for the dominance-channel constant substitution in the return.
-    entry.push_instruction(OpCode::Assert { value: w });
+    entry.push_test_instruction(OpCode::Assert { value: w });
     // Proves the fold of `ww` via the anticipated channel.
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,
@@ -2550,14 +2546,14 @@ fn anticipated_witness_cast_unused_is_swept_by_dce() {
     f.get_entry_mut()
         .push_parameter(b, Type::witness_of(Type::field()));
     let entry = f.get_entry_mut();
-    entry.push_instruction(OpCode::Cmp {
+    entry.push_test_instruction(OpCode::Cmp {
         kind: CmpKind::Eq,
         result: ww,
         lhs: a,
         rhs: b,
     });
-    entry.push_instruction(OpCode::Assert { value: ww });
-    entry.push_instruction(OpCode::AssertCmp {
+    entry.push_test_instruction(OpCode::Assert { value: ww });
+    entry.push_test_instruction(OpCode::AssertCmp {
         kind: CmpKind::Eq,
         lhs: a,
         rhs: b,

--- a/compiler/src/compiler/passes/specializer.rs
+++ b/compiler/src/compiler/passes/specializer.rs
@@ -1152,6 +1152,7 @@ impl Specializer {
         specialized_id: FunctionId,
         unspecialized_id: FunctionId,
     ) -> HLFunction {
+        let location = SourceLocation::synthetic(&fn_name);
         let mut dispatcher = HLFunction::empty(fn_name);
         let entry_block = dispatcher.get_entry_id();
 
@@ -1172,7 +1173,7 @@ impl Specializer {
         let mut specialized_params = vec![];
         let should_call_spec;
         {
-            let mut entry = b.block(entry_block);
+            let mut entry = b.block(entry_block).with_source_location(location.clone());
             let mut cond = entry.u_const(1, 1);
 
             for (pval, psig) in dispatcher_params.iter().zip(signature.get_params().iter()) {
@@ -1229,14 +1230,16 @@ impl Specializer {
         });
 
         {
-            let mut cb = b.block(unspecialized_caller);
+            let mut cb = b
+                .block(unspecialized_caller)
+                .with_source_location(location.clone());
             let unspecialized_returns =
                 cb.call(unspecialized_id, dispatcher_params, return_values.len());
             cb.terminate_jmp(return_block, unspecialized_returns);
         }
 
         {
-            let mut cb = b.block(specialized_caller);
+            let mut cb = b.block(specialized_caller).with_source_location(location);
             let specialized_returns =
                 cb.call(specialized_id, specialized_params, return_values.len());
             cb.terminate_jmp(return_block, specialized_returns);

--- a/compiler/src/compiler/passes/specializer.rs
+++ b/compiler/src/compiler/passes/specializer.rs
@@ -92,7 +92,9 @@ struct SpecializationState<'a> {
 
     /// The source location of the original instruction the symbolic executor is currently
     /// interpreting (via `Context::on_location`); residual instructions are located there.
-    current_location: Option<SourceLocation>,
+    /// Starts at the pass's synthetic location, covering anything emitted before execution
+    /// reaches the first instruction.
+    current_location: SourceLocation,
 }
 
 impl HLEmitter for SpecializationState<'_> {
@@ -102,12 +104,7 @@ impl HLEmitter for SpecializationState<'_> {
 
     fn emit(&mut self, instruction: OpCode) {
         let entry = self.body.get_entry_id();
-        // Constants materialized before execution starts have no current instruction to
-        // inherit a location from.
-        let location = self
-            .current_location
-            .clone()
-            .unwrap_or_else(|| SourceLocation::synthetic("specializer"));
+        let location = self.current_location.clone();
         self.body
             .get_block_mut(entry)
             .push_instruction(instruction.locate(location));
@@ -866,7 +863,7 @@ impl symbolic_executor::Context<Val> for SpecializationState<'_> {
     fn on_jmp(&mut self, _target: BlockId, _params: &mut [Val], _param_types: &[&Type]) {}
 
     fn on_location(&mut self, location: &SourceLocation) {
-        self.current_location = Some(location.clone());
+        self.current_location = location.clone();
     }
 
     fn lookup(&mut self, target: LookupTarget<Val>, args: Vec<Val>, flag: Val) {
@@ -1079,7 +1076,7 @@ impl Specializer {
                 ssa: &*ssa,
                 body,
                 const_vals,
-                current_location: None,
+                current_location: SourceLocation::synthetic("specializer"),
             };
 
             // Specialization is speculative: this candidate may sit behind a branch that never

--- a/compiler/src/compiler/passes/specializer.rs
+++ b/compiler/src/compiler/passes/specializer.rs
@@ -96,11 +96,23 @@ impl HLEmitter for SpecializationState<'_> {
         self.ssa.fresh_value()
     }
 
-    fn emit(&mut self, instruction: impl Into<LocatedOpCode>) {
+    fn emit(&mut self, instruction: OpCode) {
         let entry = self.body.get_entry_id();
+        let location = self
+            .body
+            .get_block(entry)
+            .get_instructions_with_source_locations()
+            .next()
+            .map(|(_, location)| location.clone())
+            .expect("ICE: specialization emitted without a source location");
         self.body
             .get_block_mut(entry)
-            .push_instruction(instruction.into());
+            .push_instruction(instruction.locate(location));
+    }
+
+    fn emit_located(&mut self, instruction: LocatedOpCode) {
+        let entry = self.body.get_entry_id();
+        self.body.get_block_mut(entry).push_instruction(instruction);
     }
 
     fn emit_constant(&mut self, value: Constant) -> ValueId {

--- a/compiler/src/compiler/passes/specializer.rs
+++ b/compiler/src/compiler/passes/specializer.rs
@@ -19,7 +19,7 @@ use crate::{
         },
         pass_manager::{Analysis, AnalysisId, AnalysisStore, Pass},
         ssa::{
-            BlockId, FunctionId, ValueId,
+            BlockId, FunctionId, SourceLocation, ValueId,
             hlssa::{
                 BinaryArithOpKind, Blob, CastTarget, CmpKind, Constant, Endianness, HLFunction,
                 HLSSA, LocatedOpCode, LookupTarget, MAX_SUPPORTED_UNSIGNED_BITS, OpCode, Radix,
@@ -89,6 +89,10 @@ struct SpecializationState<'a> {
 
     /// Constant values created during specialization, usually by constant folding.
     const_vals: HashMap<ValueId, ConstVal>,
+
+    /// The source location of the original instruction the symbolic executor is currently
+    /// interpreting (via `Context::on_location`); residual instructions are located there.
+    current_location: Option<SourceLocation>,
 }
 
 impl HLEmitter for SpecializationState<'_> {
@@ -98,13 +102,12 @@ impl HLEmitter for SpecializationState<'_> {
 
     fn emit(&mut self, instruction: OpCode) {
         let entry = self.body.get_entry_id();
+        // Constants materialized before execution starts have no current instruction to
+        // inherit a location from.
         let location = self
-            .body
-            .get_block(entry)
-            .get_instructions_with_source_locations()
-            .next()
-            .map(|(_, location)| location.clone())
-            .expect("ICE: specialization emitted without a source location");
+            .current_location
+            .clone()
+            .unwrap_or_else(|| SourceLocation::synthetic("specializer"));
         self.body
             .get_block_mut(entry)
             .push_instruction(instruction.locate(location));
@@ -862,6 +865,10 @@ impl symbolic_executor::Context<Val> for SpecializationState<'_> {
 
     fn on_jmp(&mut self, _target: BlockId, _params: &mut [Val], _param_types: &[&Type]) {}
 
+    fn on_location(&mut self, location: &SourceLocation) {
+        self.current_location = Some(location.clone());
+    }
+
     fn lookup(&mut self, target: LookupTarget<Val>, args: Vec<Val>, flag: Val) {
         self.emit(OpCode::Lookup {
             target: target.map(|v| v.0),
@@ -1072,6 +1079,7 @@ impl Specializer {
                 ssa: &*ssa,
                 body,
                 const_vals,
+                current_location: None,
             };
 
             // Specialization is speculative: this candidate may sit behind a branch that never

--- a/compiler/src/compiler/passes/specializer.rs
+++ b/compiler/src/compiler/passes/specializer.rs
@@ -92,8 +92,8 @@ struct SpecializationState<'a> {
 
     /// The source location of the original instruction the symbolic executor is currently
     /// interpreting (via `Context::on_location`); residual instructions are located there.
-    /// Starts at the pass's synthetic location, covering anything emitted before execution
-    /// reaches the first instruction.
+    /// Starts at the function entry's first instruction location, covering anything emitted before
+    /// execution reaches the first instruction.
     current_location: SourceLocation,
 }
 
@@ -1072,11 +1072,16 @@ impl Specializer {
         }
 
         let body = {
+            let current_location = body
+                .get_entry()
+                .first_location()
+                .cloned()
+                .unwrap_or_else(|| SourceLocation::synthetic("specializer"));
             let mut state = SpecializationState {
                 ssa: &*ssa,
                 body,
                 const_vals,
-                current_location: SourceLocation::synthetic("specializer"),
+                current_location,
             };
 
             // Specialization is speculative: this candidate may sit behind a branch that never

--- a/compiler/src/compiler/passes/witness_lowering.rs
+++ b/compiler/src/compiler/passes/witness_lowering.rs
@@ -81,7 +81,11 @@ impl WitnessLowering {
                 let terminator = fb.function.get_block_mut(bid).take_terminator();
                 let instructions = fb.function.get_block_mut(bid).take_instructions();
 
-                let mut emitter = fb.block(bid);
+                // Every rewritten instruction scopes its own location below; emitting outside a
+                // scope is an ICE.
+                let mut emitter = fb
+                    .block(bid)
+                    .with_scoped_source_locations("witness_lowering");
 
                 for instruction in instructions.into_iter() {
                     let location = instruction.location().clone();

--- a/compiler/src/compiler/ssa/builder.rs
+++ b/compiler/src/compiler/ssa/builder.rs
@@ -57,9 +57,9 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash>
         Self { function, ssa }
     }
 
-    pub fn add_block(&mut self, f: impl FnOnce(&mut BlockEmitter<'_, Op, Ty, C>)) -> BlockId {
-        let (id, mut emitter) = BlockEmitter::from_new_block(self.function, self.ssa);
-        f(&mut emitter);
+    pub fn add_block(&mut self, f: impl FnOnce(&mut BlockEditor<'_, Op, Ty, C>)) -> BlockId {
+        let (id, mut editor) = BlockEditor::from_new_block(self.function, self.ssa);
+        f(&mut editor);
         id
     }
 
@@ -82,9 +82,10 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash>
         self.ssa
     }
 
-    /// Get a BlockEmitter for a specific block.
-    pub fn block(&mut self, id: BlockId) -> BlockEmitter<'_, Op, Ty, C> {
-        BlockEmitter::new(self.function, self.ssa, id)
+    /// Get a BlockEditor for a specific block. Upgrade it with
+    /// `with_source_location` to emit instructions.
+    pub fn block(&mut self, id: BlockId) -> BlockEditor<'_, Op, Ty, C> {
+        BlockEditor::new(self.function, self.ssa, id)
     }
 
     /// Get a BlockEmitter whose ambient location is the shared test location. Test-only sugar so
@@ -96,22 +97,26 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash>
 }
 
 // ---------------------------------------------------------------------------
-// BlockEmitter — emits instructions into a specific block, with block-splitting
+// BlockEditor — structural access to a specific block (parameters, terminators)
 // ---------------------------------------------------------------------------
 
-/// Holds the current block *taken out* of the function, so `emit()` is a
+/// Holds the current block *taken out* of the function, so pushes are a
 /// direct `Vec::push` with no HashMap lookup.  The block is put back into the
 /// function on `seal_and_switch` or `Drop`.
-pub struct BlockEmitter<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> {
+///
+/// A `BlockEditor` can shape a block (parameters, terminators) and push
+/// pre-located instructions, but cannot emit new instructions: emitting needs
+/// an ambient source location, which `with_source_location` provides by
+/// upgrading to a [`BlockEmitter`].
+pub struct BlockEditor<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> {
     pub function: &'a mut Function<Op, Ty>,
     pub ssa: &'a mut SSA<Op, Ty, C>,
     pub(crate) block_id: BlockId,
     pub(crate) block: Block<Op, Ty>,
-    source_location: Option<SourceLocation>,
 }
 
 impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> Drop
-    for BlockEmitter<'_, Op, Ty, C>
+    for BlockEditor<'_, Op, Ty, C>
 {
     fn drop(&mut self) {
         let block = std::mem::replace(&mut self.block, Block::empty());
@@ -119,8 +124,8 @@ impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> Drop
     }
 }
 
-impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEmitter<'a, Op, Ty, C> {
-    /// Create an emitter for an existing block (takes it out of the function).
+impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEditor<'a, Op, Ty, C> {
+    /// Create an editor for an existing block (takes it out of the function).
     pub fn new(
         function: &'a mut Function<Op, Ty>,
         ssa: &'a mut SSA<Op, Ty, C>,
@@ -132,11 +137,10 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEmitte
             ssa,
             block_id,
             block,
-            source_location: None,
         }
     }
 
-    /// Create an emitter for a fresh block (not yet in the function).
+    /// Create an editor for a fresh block (not yet in the function).
     /// The block is inserted into the function on drop.
     pub(crate) fn from_new_block(
         function: &'a mut Function<Op, Ty>,
@@ -150,7 +154,6 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEmitte
                 ssa,
                 block_id,
                 block,
-                source_location: None,
             },
         )
     }
@@ -159,28 +162,30 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEmitte
         self.block_id
     }
 
-    pub fn with_source_location(mut self, source_location: SourceLocation) -> Self {
-        self.source_location = Some(source_location);
-        self
+    /// Upgrade to a [`BlockEmitter`] that emits every instruction at `source_location`.
+    pub fn with_source_location(
+        self,
+        source_location: SourceLocation,
+    ) -> BlockEmitter<'a, Op, Ty, C> {
+        BlockEmitter {
+            editor: self,
+            ambient_location: AmbientLocation::Location(source_location),
+        }
+    }
+
+    /// Upgrade to a [`BlockEmitter`] with no ambient location of its own: every emission must
+    /// happen inside an `emit_with_location` scope, and emitting outside one is an ICE naming
+    /// `pass`. For pass drivers that rewrite instructions one at a time and require every
+    /// emission to be anchored to a rewritten instruction's location.
+    pub fn with_scoped_source_locations(self, pass: &'static str) -> BlockEmitter<'a, Op, Ty, C> {
+        BlockEmitter {
+            editor: self,
+            ambient_location: AmbientLocation::IceOutsideScope(pass),
+        }
     }
 
     pub fn instruction_count(&self) -> usize {
         self.block.instruction_count()
-    }
-
-    /// Run `emit` with `source_location` as the ambient location: every instruction it emits
-    /// through this emitter (including into blocks it creates) is located there at push time.
-    /// Instructions pushed with an explicit location (`emit_located_instruction`) keep theirs,
-    /// as do instructions emitted by a nested `emit_with_location` scope.
-    pub fn emit_with_location<R>(
-        &mut self,
-        source_location: SourceLocation,
-        emit: impl FnOnce(&mut Self) -> R,
-    ) -> R {
-        let previous_source_location = self.source_location.replace(source_location);
-        let result = emit(self);
-        self.source_location = previous_source_location;
-        result
     }
 
     pub fn add_block(&mut self) -> (BlockId, &mut Block<Op, Ty>) {
@@ -224,17 +229,87 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEmitte
         self.block.get_terminator().is_some()
     }
 
-    pub fn emit_instruction(&mut self, instruction: Op) {
-        let source_location = self
-            .source_location
-            .clone()
-            .expect("ICE: emit_instruction called without a source location");
-        self.block
-            .push_instruction(Located::new(instruction, source_location));
-    }
-
+    /// Push an instruction that already carries its own location.
     pub fn emit_located_instruction(&mut self, instruction: Located<Op>) {
         self.block.push_instruction(instruction);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BlockEmitter — a BlockEditor plus the ambient source location, so it can
+//                emit instructions (with block-splitting)
+// ---------------------------------------------------------------------------
+
+/// The location an emitter stamps on instructions when no `emit_with_location` scope is active.
+enum AmbientLocation {
+    /// A real location, from [`BlockEditor::with_source_location`]: emitting outside a scope is
+    /// fine and uses it.
+    Location(SourceLocation),
+    /// From [`BlockEditor::with_scoped_source_locations`]: the named pass promises to emit only
+    /// inside `emit_with_location` scopes, and emitting outside one is an ICE.
+    IceOutsideScope(&'static str),
+}
+
+impl AmbientLocation {
+    fn resolve(&self) -> SourceLocation {
+        match self {
+            AmbientLocation::Location(source_location) => source_location.clone(),
+            AmbientLocation::IceOutsideScope(pass) => {
+                panic!("ICE: {pass} emitted an instruction outside an `emit_with_location` scope")
+            }
+        }
+    }
+}
+
+/// A [`BlockEditor`] paired with the ambient source location that every
+/// instruction it emits is located at. Constructed via
+/// [`BlockEditor::with_source_location`], so holding one proves a location was
+/// provided — there is no location-less way to emit.
+pub struct BlockEmitter<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> {
+    editor: BlockEditor<'a, Op, Ty, C>,
+    ambient_location: AmbientLocation,
+}
+
+impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> std::ops::Deref
+    for BlockEmitter<'a, Op, Ty, C>
+{
+    type Target = BlockEditor<'a, Op, Ty, C>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.editor
+    }
+}
+
+impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> std::ops::DerefMut
+    for BlockEmitter<'_, Op, Ty, C>
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.editor
+    }
+}
+
+impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEmitter<'_, Op, Ty, C> {
+    /// Run `emit` with `source_location` as the ambient location: every instruction it emits
+    /// through this emitter (including into blocks it creates) is located there at push time.
+    /// Instructions pushed with an explicit location (`emit_located_instruction`) keep theirs,
+    /// as do instructions emitted by a nested `emit_with_location` scope.
+    pub fn emit_with_location<R>(
+        &mut self,
+        source_location: SourceLocation,
+        emit: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        let previous_ambient_location = std::mem::replace(
+            &mut self.ambient_location,
+            AmbientLocation::Location(source_location),
+        );
+        let result = emit(self);
+        self.ambient_location = previous_ambient_location;
+        result
+    }
+
+    pub fn emit_instruction(&mut self, instruction: Op) {
+        let instruction = Located::new(instruction, self.ambient_location.resolve());
+        self.editor.block.push_instruction(instruction);
     }
 
     /// Build a loop with the three-block structure: header -> body -> back-edge.
@@ -282,13 +357,10 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEmitte
         // Call header closure to emit condition into a temporary instruction buffer
         let mut header_instructions = vec![];
         let cond = {
-            let source_location = self
-                .source_location
-                .clone()
-                .expect("ICE: build_loop header emitted without a source location");
+            let source_location = self.ambient_location.resolve();
             let mut b = InstrBuilder::new(
-                self.function,
-                self.ssa,
+                self.editor.function,
+                self.editor.ssa,
                 &mut header_instructions,
                 source_location,
             );
@@ -564,6 +636,43 @@ mod tests {
 
         assert_eq!(instructions.len(), 1);
         assert_eq!(instructions[0].location(), &loc);
+    }
+
+    /// A scoped-locations emitter carries no ambient location of its own: emitting outside an
+    /// `emit_with_location` scope is an attribution bug and must fail fast.
+    #[test]
+    #[should_panic(expected = "outside an `emit_with_location` scope")]
+    fn scoped_locations_emitter_ices_outside_a_scope() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+
+        let mut sb = HLSSABuilder::new(&mut ssa);
+        sb.modify_function(main_id, |fb| {
+            let entry_id = fb.function.get_entry_id();
+            let mut block = fb.block(entry_id).with_scoped_source_locations("test_pass");
+            block.not(ValueId(0));
+        });
+    }
+
+    #[test]
+    fn scoped_locations_emitter_emits_inside_a_scope() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let loc = test_location();
+
+        {
+            let mut sb = HLSSABuilder::new(&mut ssa);
+            sb.modify_function(main_id, |fb| {
+                let entry_id = fb.function.get_entry_id();
+                let mut block = fb.block(entry_id).with_scoped_source_locations("test_pass");
+                block.emit_with_location(loc.clone(), |block| {
+                    block.not(ValueId(0));
+                });
+            });
+        }
+
+        let entry = ssa.get_unique_entrypoint().get_entry();
+        assert_eq!(entry.get_instruction_source_location(0), &loc);
     }
 
     #[test]

--- a/compiler/src/compiler/ssa/builder.rs
+++ b/compiler/src/compiler/ssa/builder.rs
@@ -1,7 +1,8 @@
 use std::{fmt::Debug, hash::Hash};
 
 use crate::compiler::ssa::{
-    Block, BlockId, Function, FunctionId, Instruction, Located, SSA, SSAType, Terminator, ValueId,
+    Block, BlockId, Function, FunctionId, Instruction, Located, SSA, SSAType, SourceLocation,
+    Terminator, ValueId,
 };
 
 // ---------------------------------------------------------------------------
@@ -12,6 +13,7 @@ pub struct InstrBuilder<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq 
     pub function: &'a mut Function<Op, Ty>,
     pub ssa: &'a mut SSA<Op, Ty, C>,
     pub instructions: &'a mut Vec<Located<Op>>,
+    source_location: SourceLocation,
 }
 
 impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> InstrBuilder<'a, Op, Ty, C> {
@@ -19,17 +21,23 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> InstrBuilde
         function: &'a mut Function<Op, Ty>,
         ssa: &'a mut SSA<Op, Ty, C>,
         instructions: &'a mut Vec<Located<Op>>,
+        source_location: SourceLocation,
     ) -> Self {
         Self {
             function,
             ssa,
             instructions,
+            source_location,
         }
     }
 
     /// Push a pre-built instruction (passthrough or pre-allocated result).
-    pub fn push(&mut self, instruction: impl Into<Located<Op>>) {
-        self.instructions.push(instruction.into());
+    pub fn push_located(&mut self, instruction: Located<Op>) {
+        self.instructions.push(instruction);
+    }
+
+    pub fn push(&mut self, instruction: Op) {
+        self.push_located(Located::with(instruction, self.source_location.clone()));
     }
 }
 
@@ -92,6 +100,7 @@ pub struct BlockEmitter<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq 
     pub ssa: &'a mut SSA<Op, Ty, C>,
     pub(crate) block_id: BlockId,
     pub(crate) block: Block<Op, Ty>,
+    source_location: Option<SourceLocation>,
 }
 
 impl<Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> Drop
@@ -116,6 +125,7 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEmitte
             ssa,
             block_id,
             block,
+            source_location: None,
         }
     }
 
@@ -133,6 +143,7 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEmitte
                 ssa,
                 block_id,
                 block,
+                source_location: None,
             },
         )
     }
@@ -141,59 +152,57 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEmitte
         self.block_id
     }
 
+    pub fn with_source_location(mut self, source_location: SourceLocation) -> Self {
+        self.source_location = Some(source_location);
+        self
+    }
+
     pub fn instruction_count(&self) -> usize {
         self.block.instruction_count()
     }
 
-    pub fn stamp_source_location_from(
-        &mut self,
-        start: usize,
-        source_location: Option<crate::compiler::ssa::SourceLocation>,
-    ) {
+    pub fn stamp_source_location_from(&mut self, start: usize, source_location: SourceLocation) {
         self.block
             .stamp_source_location_from(start, source_location);
     }
 
     pub fn emit_with_location<R>(
         &mut self,
-        source_location: Option<crate::compiler::ssa::SourceLocation>,
+        source_location: SourceLocation,
         emit: impl FnOnce(&mut Self) -> R,
     ) -> R {
         let start_block = self.block_id;
         let start_len = self.block.instruction_count();
         let next_block_before = self.function.next_block_id_bound();
 
+        let previous_source_location = self.source_location.replace(source_location.clone());
         let result = emit(self);
-
-        let Some(source_location) = source_location else {
-            return result;
-        };
+        self.source_location = previous_source_location;
 
         if self.block_id == start_block && self.function.next_block_id_bound() == next_block_before
         {
             self.block
-                .stamp_source_location_from(start_len, Some(source_location));
+                .stamp_source_location_from(start_len, source_location);
             return result;
         };
 
         if self.block_id == start_block {
             self.block
-                .stamp_source_location_from(start_len, Some(source_location.clone()));
+                .stamp_source_location_from(start_len, source_location.clone());
         } else {
             self.function
                 .get_block_mut(start_block)
-                .stamp_source_location_from(start_len, Some(source_location.clone()));
+                .stamp_source_location_from(start_len, source_location.clone());
         }
 
         for (block_id, block) in self.function.get_blocks_mut() {
             if block_id.0 >= next_block_before {
-                block.stamp_source_location_from(0, Some(source_location.clone()));
+                block.stamp_source_location_from(0, source_location.clone());
             }
         }
 
         if self.block_id.0 >= next_block_before {
-            self.block
-                .stamp_source_location_from(0, Some(source_location));
+            self.block.stamp_source_location_from(0, source_location);
         }
 
         result
@@ -240,8 +249,17 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEmitte
         self.block.get_terminator().is_some()
     }
 
-    pub fn emit_instruction(&mut self, instruction: impl Into<Located<Op>>) {
-        self.block.push_instruction(instruction.into());
+    pub fn emit_instruction(&mut self, instruction: Op) {
+        let source_location = self
+            .source_location
+            .clone()
+            .expect("ICE: emit_instruction called without a source location");
+        self.block
+            .push_instruction(Located::with(instruction, source_location));
+    }
+
+    pub fn emit_located_instruction(&mut self, instruction: Located<Op>) {
+        self.block.push_instruction(instruction);
     }
 
     /// Build a loop with the three-block structure: header -> body -> back-edge.
@@ -289,7 +307,16 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEmitte
         // Call header closure to emit condition into a temporary instruction buffer
         let mut header_instructions = vec![];
         let cond = {
-            let mut b = InstrBuilder::new(self.function, self.ssa, &mut header_instructions);
+            let source_location = self
+                .source_location
+                .clone()
+                .expect("ICE: build_loop header emitted without a source location");
+            let mut b = InstrBuilder::new(
+                self.function,
+                self.ssa,
+                &mut header_instructions,
+                source_location,
+            );
             header(&mut b, &param_ids)
         };
         self.function
@@ -526,8 +553,10 @@ mod tests {
             let mut sb = HLSSABuilder::new(&mut ssa);
             sb.modify_function(main_id, |fb| {
                 let entry_id = fb.function.get_entry_id();
-                let mut block = fb.block(entry_id);
-                block.emit(Located::with(
+                let mut block = fb
+                    .block(entry_id)
+                    .with_source_location(SourceLocation::test());
+                block.emit_located(Located::with(
                     OpCode::Not {
                         result: ValueId(1),
                         value: ValueId(0),
@@ -538,7 +567,7 @@ mod tests {
         }
 
         let entry = ssa.get_unique_entrypoint().get_entry();
-        assert_eq!(entry.get_instruction_source_location(0), Some(&loc));
+        assert_eq!(entry.get_instruction_source_location(0), &loc);
     }
 
     #[test]
@@ -549,8 +578,9 @@ mod tests {
         let loc = test_location();
 
         {
-            let mut builder = InstrBuilder::new(&mut function, &mut ssa, &mut instructions);
-            builder.emit(Located::with(
+            let mut builder =
+                InstrBuilder::new(&mut function, &mut ssa, &mut instructions, loc.clone());
+            builder.emit_located(Located::with(
                 OpCode::Not {
                     result: ValueId(1),
                     value: ValueId(0),
@@ -560,7 +590,7 @@ mod tests {
         }
 
         assert_eq!(instructions.len(), 1);
-        assert_eq!(instructions[0].get_location(), Some(&loc));
+        assert_eq!(instructions[0].get_location(), &loc);
     }
 
     #[test]
@@ -573,8 +603,10 @@ mod tests {
             let mut sb = HLSSABuilder::new(&mut ssa);
             sb.modify_function(main_id, |fb| {
                 let entry_id = fb.function.get_entry_id();
-                let mut block = fb.block(entry_id);
-                block.emit_with_location(Some(loc.clone()), |block| {
+                let mut block = fb
+                    .block(entry_id)
+                    .with_source_location(SourceLocation::test());
+                block.emit_with_location(loc.clone(), |block| {
                     let cond = block.not(ValueId(0));
                     block.build_if_else(
                         cond,
@@ -598,7 +630,7 @@ mod tests {
             .map(|(_, block)| {
                 block
                     .get_instructions_with_source_locations()
-                    .inspect(|(_, location)| assert_eq!(*location, Some(&loc)))
+                    .inspect(|(_, location)| assert_eq!(*location, &loc))
                     .count()
             })
             .sum();

--- a/compiler/src/compiler/ssa/builder.rs
+++ b/compiler/src/compiler/ssa/builder.rs
@@ -161,50 +161,18 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEmitte
         self.block.instruction_count()
     }
 
-    pub fn stamp_source_location_from(&mut self, start: usize, source_location: SourceLocation) {
-        self.block
-            .stamp_source_location_from(start, source_location);
-    }
-
+    /// Run `emit` with `source_location` as the ambient location: every instruction it emits
+    /// through this emitter (including into blocks it creates) is located there at push time.
+    /// Instructions pushed with an explicit location (`emit_located_instruction`) keep theirs,
+    /// as do instructions emitted by a nested `emit_with_location` scope.
     pub fn emit_with_location<R>(
         &mut self,
         source_location: SourceLocation,
         emit: impl FnOnce(&mut Self) -> R,
     ) -> R {
-        let start_block = self.block_id;
-        let start_len = self.block.instruction_count();
-        let next_block_before = self.function.next_block_id_bound();
-
-        let previous_source_location = self.source_location.replace(source_location.clone());
+        let previous_source_location = self.source_location.replace(source_location);
         let result = emit(self);
         self.source_location = previous_source_location;
-
-        if self.block_id == start_block && self.function.next_block_id_bound() == next_block_before
-        {
-            self.block
-                .stamp_source_location_from(start_len, source_location);
-            return result;
-        };
-
-        if self.block_id == start_block {
-            self.block
-                .stamp_source_location_from(start_len, source_location.clone());
-        } else {
-            self.function
-                .get_block_mut(start_block)
-                .stamp_source_location_from(start_len, source_location.clone());
-        }
-
-        for (block_id, block) in self.function.get_blocks_mut() {
-            if block_id.0 >= next_block_before {
-                block.stamp_source_location_from(0, source_location.clone());
-            }
-        }
-
-        if self.block_id.0 >= next_block_before {
-            self.block.stamp_source_location_from(0, source_location);
-        }
-
         result
     }
 

--- a/compiler/src/compiler/ssa/builder.rs
+++ b/compiler/src/compiler/ssa/builder.rs
@@ -37,7 +37,7 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> InstrBuilde
     }
 
     pub fn push(&mut self, instruction: Op) {
-        self.push_located(Located::with(instruction, self.source_location.clone()));
+        self.push_located(Located::new(instruction, self.source_location.clone()));
     }
 }
 
@@ -85,6 +85,13 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash>
     /// Get a BlockEmitter for a specific block.
     pub fn block(&mut self, id: BlockId) -> BlockEmitter<'_, Op, Ty, C> {
         BlockEmitter::new(self.function, self.ssa, id)
+    }
+
+    /// Get a BlockEmitter whose ambient location is the shared test location. Test-only sugar so
+    /// hand-built SSA fixtures don't have to set a location per emitter.
+    #[cfg(test)]
+    pub fn test_block(&mut self, id: BlockId) -> BlockEmitter<'_, Op, Ty, C> {
+        self.block(id).with_source_location(SourceLocation::test())
     }
 }
 
@@ -223,7 +230,7 @@ impl<'a, Op: Instruction, Ty: SSAType, C: Clone + Debug + Eq + Hash> BlockEmitte
             .clone()
             .expect("ICE: emit_instruction called without a source location");
         self.block
-            .push_instruction(Located::with(instruction, source_location));
+            .push_instruction(Located::new(instruction, source_location));
     }
 
     pub fn emit_located_instruction(&mut self, instruction: Located<Op>) {
@@ -521,10 +528,8 @@ mod tests {
             let mut sb = HLSSABuilder::new(&mut ssa);
             sb.modify_function(main_id, |fb| {
                 let entry_id = fb.function.get_entry_id();
-                let mut block = fb
-                    .block(entry_id)
-                    .with_source_location(SourceLocation::test());
-                block.emit_located(Located::with(
+                let mut block = fb.test_block(entry_id);
+                block.emit_located(Located::new(
                     OpCode::Not {
                         result: ValueId(1),
                         value: ValueId(0),
@@ -548,7 +553,7 @@ mod tests {
         {
             let mut builder =
                 InstrBuilder::new(&mut function, &mut ssa, &mut instructions, loc.clone());
-            builder.emit_located(Located::with(
+            builder.emit_located(Located::new(
                 OpCode::Not {
                     result: ValueId(1),
                     value: ValueId(0),
@@ -558,7 +563,7 @@ mod tests {
         }
 
         assert_eq!(instructions.len(), 1);
-        assert_eq!(instructions[0].get_location(), &loc);
+        assert_eq!(instructions[0].location(), &loc);
     }
 
     #[test]
@@ -571,9 +576,7 @@ mod tests {
             let mut sb = HLSSABuilder::new(&mut ssa);
             sb.modify_function(main_id, |fb| {
                 let entry_id = fb.function.get_entry_id();
-                let mut block = fb
-                    .block(entry_id)
-                    .with_source_location(SourceLocation::test());
+                let mut block = fb.test_block(entry_id);
                 block.emit_with_location(loc.clone(), |block| {
                     let cond = block.not(ValueId(0));
                     block.build_if_else(

--- a/compiler/src/compiler/ssa/hlssa/builder.rs
+++ b/compiler/src/compiler/ssa/hlssa/builder.rs
@@ -13,7 +13,8 @@ use crate::compiler::ssa::{
 
 pub trait HLEmitter {
     fn fresh_value(&mut self) -> ValueId;
-    fn emit(&mut self, instruction: impl Into<LocatedOpCode>);
+    fn emit(&mut self, instruction: OpCode);
+    fn emit_located(&mut self, instruction: LocatedOpCode);
 
     /// Intern a constant value into the SSA's constants side-table, returning the `ValueId` that
     /// names it. Identical `Constant`s collapse to the same `ValueId`.
@@ -641,8 +642,12 @@ impl HLEmitter for HLInstrBuilder<'_> {
         self.ssa.fresh_value()
     }
 
-    fn emit(&mut self, instruction: impl Into<LocatedOpCode>) {
+    fn emit(&mut self, instruction: OpCode) {
         self.push(instruction);
+    }
+
+    fn emit_located(&mut self, instruction: LocatedOpCode) {
+        self.push_located(instruction);
     }
 
     fn emit_constant(&mut self, value: Constant) -> ValueId {
@@ -655,8 +660,12 @@ impl HLEmitter for HLBlockEmitter<'_> {
         self.ssa.fresh_value()
     }
 
-    fn emit(&mut self, instruction: impl Into<LocatedOpCode>) {
+    fn emit(&mut self, instruction: OpCode) {
         self.emit_instruction(instruction);
+    }
+
+    fn emit_located(&mut self, instruction: LocatedOpCode) {
+        self.emit_located_instruction(instruction);
     }
 
     fn emit_constant(&mut self, value: Constant) -> ValueId {

--- a/compiler/src/compiler/ssa/hlssa/mod.rs
+++ b/compiler/src/compiler/ssa/hlssa/mod.rs
@@ -7,8 +7,8 @@ use itertools::Itertools;
 use std::fmt::Display;
 
 use crate::compiler::ssa::{
-    Block, Function, FunctionId, Instruction, Located, Location, SSA, SSAConstants,
-    SSAConstantsSnapshot, ValueId,
+    Block, Function, FunctionId, Instruction, Located, SSA, SSAConstants, SSAConstantsSnapshot,
+    SourceLocation, ValueId,
 };
 
 pub use type_system::{MAX_SUPPORTED_SIGNED_BITS, MAX_SUPPORTED_UNSIGNED_BITS, Type, TypeExpr};
@@ -23,7 +23,7 @@ pub type HLSSA = SSA<OpCode, Type, Constant>;
 pub type LocatedOpCode = Located<OpCode>;
 
 impl OpCode {
-    pub fn locate(self, location: Location) -> LocatedOpCode {
+    pub fn locate(self, location: SourceLocation) -> LocatedOpCode {
         LocatedOpCode::new(self, location)
     }
 }

--- a/compiler/src/compiler/ssa/hlssa_to_llssa.rs
+++ b/compiler/src/compiler/ssa/hlssa_to_llssa.rs
@@ -15,7 +15,7 @@ use crate::{
         },
         codegen::CodeGenOptions,
         ssa::{
-            BlockId, FunctionId, Instruction, Terminator, ValueId,
+            BlockId, FunctionId, Instruction, SourceLocation, Terminator, ValueId,
             hlssa::{
                 BinaryArithOpKind, CmpKind, Constant, DMatrix, Endianness, HLFunction, HLSSA,
                 HLSSAConstantsSnapshot, MAX_SUPPORTED_SIGNED_BITS, MAX_SUPPORTED_UNSIGNED_BITS,
@@ -580,11 +580,15 @@ fn lower_constants_llssa(
     val_map: &mut HashMap<ValueId, ValueId>,
 ) {
     let mut referenced = HashSet::default();
+    let mut source_locations = HashMap::<ValueId, SourceLocation>::default();
     for (_, block) in function.get_blocks() {
-        for instr in block.get_instructions() {
+        for (instr, source_location) in block.get_instructions_with_source_locations() {
             for vid in instr.get_inputs() {
                 if constants.contains_key(vid) {
                     referenced.insert(*vid);
+                    source_locations
+                        .entry(*vid)
+                        .or_insert_with(|| source_location.clone());
                 }
             }
         }
@@ -627,7 +631,13 @@ fn lower_constants_llssa(
                 val_map.insert(vid, null_ptr);
             }
             Constant::Blob(blob) => {
-                let data_ptr = e.const_data_ptr(elem_struct(&blob.elem_type), ll_val);
+                let source_location = source_locations
+                    .get(&vid)
+                    .expect("ICE: blob constant lowered without a source location")
+                    .clone();
+                let data_ptr = e.emit_with_location(source_location, |e| {
+                    e.const_data_ptr(elem_struct(&blob.elem_type), ll_val)
+                });
                 val_map.insert(vid, data_ptr);
             }
             _ => {
@@ -741,7 +751,7 @@ fn lower_function(
 
         // Lower instructions
         for (instruction, source_location) in block.get_instructions_with_source_locations() {
-            emitter.emit_with_location(source_location.cloned(), |emitter| {
+            emitter.emit_with_location(source_location.clone(), |emitter| {
                 lower_instruction(
                     instruction,
                     emitter,
@@ -4317,8 +4327,8 @@ fn generate_drngchk_ad_call(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compiler::ssa::DefaultSSAAnnotator;
     use crate::compiler::ssa::llssa::builder::LLSSABuilder;
+    use crate::compiler::ssa::{DefaultSSAAnnotator, SourceLocation};
 
     /// A guarded refcount mutation must compare against `RC_IMMORTAL_OBJECT`
     /// before touching the refcount word.
@@ -4336,7 +4346,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry);
+            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
             let arr = e.heap_alloc(rc_array.clone(), None);
             let hdr = e.struct_field_ptr(arr, rc_array.clone(), 0);
             let rc_ptr = e.struct_field_ptr(hdr, rc_header, 0);
@@ -4373,7 +4383,7 @@ mod tests {
         let mut hb = HLSSABuilder::new(&mut hlssa);
         hb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry);
+            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
             let c = e.field_const(ark_bn254::Fr::from(7u64));
             e.terminate_return(vec![c]);
         });
@@ -4422,7 +4432,7 @@ mod tests {
         let mut hb = HLSSABuilder::new(&mut hlssa);
         hb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry);
+            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
             let blob = e.emit_constant(HLConstant::Blob(HLBlob::new(
                 HLType::u(8),
                 vec![

--- a/compiler/src/compiler/ssa/hlssa_to_llssa.rs
+++ b/compiler/src/compiler/ssa/hlssa_to_llssa.rs
@@ -4340,8 +4340,8 @@ fn generate_drngchk_ad_call(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compiler::ssa::DefaultSSAAnnotator;
     use crate::compiler::ssa::llssa::builder::LLSSABuilder;
-    use crate::compiler::ssa::{DefaultSSAAnnotator, SourceLocation};
 
     /// A guarded refcount mutation must compare against `RC_IMMORTAL_OBJECT`
     /// before touching the refcount word.
@@ -4359,7 +4359,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
+            let mut e = fb.test_block(entry);
             let arr = e.heap_alloc(rc_array.clone(), None);
             let hdr = e.struct_field_ptr(arr, rc_array.clone(), 0);
             let rc_ptr = e.struct_field_ptr(hdr, rc_header, 0);
@@ -4396,7 +4396,7 @@ mod tests {
         let mut hb = HLSSABuilder::new(&mut hlssa);
         hb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
+            let mut e = fb.test_block(entry);
             let c = e.field_const(ark_bn254::Fr::from(7u64));
             e.terminate_return(vec![c]);
         });
@@ -4445,7 +4445,7 @@ mod tests {
         let mut hb = HLSSABuilder::new(&mut hlssa);
         hb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
+            let mut e = fb.test_block(entry);
             let blob = e.emit_constant(HLConstant::Blob(HLBlob::new(
                 HLType::u(8),
                 vec![

--- a/compiler/src/compiler/ssa/hlssa_to_llssa.rs
+++ b/compiler/src/compiler/ssa/hlssa_to_llssa.rs
@@ -24,7 +24,7 @@ use crate::{
             llssa::{
                 Blob as LLBlob, Constant as LLConstant, FieldArithOp, IntArithOp, IntCmpOp,
                 LLFieldType, LLFunction, LLOp, LLSSA, LLStruct, RC_IMMORTAL_OBJECT, Type as LLType,
-                builder::{LLBlockEmitter, LLEmitter},
+                builder::{LLBlockEditor, LLBlockEmitter, LLEmitter},
             },
         },
         util::ice_non_elided_tuple,
@@ -618,7 +618,11 @@ fn lower_constants_llssa(
     referenced.sort_by_key(|v| v.0);
 
     let entry_id = ll_func.get_entry_id();
-    let mut e = LLBlockEmitter::new(ll_func, llssa, entry_id);
+    // Constants referenced only by terminators (e.g. a blob that is directly
+    // returned) have no instruction to inherit a location from.
+    let fallback_location = SourceLocation::synthetic("const_lowering");
+    let mut e =
+        LLBlockEditor::new(ll_func, llssa, entry_id).with_source_location(fallback_location);
     for vid in referenced {
         let constant = constants.get(&vid).expect("vid is in constants");
         let ll_constant = lower_constant_to_ll_constant(constant.as_ref());
@@ -631,15 +635,12 @@ fn lower_constants_llssa(
                 val_map.insert(vid, null_ptr);
             }
             Constant::Blob(blob) => {
-                // Constants referenced only by terminators (e.g. a blob that is directly
-                // returned) have no instruction to inherit a location from.
-                let source_location = source_locations
-                    .get(&vid)
-                    .cloned()
-                    .unwrap_or_else(|| SourceLocation::synthetic("const_lowering"));
-                let data_ptr = e.emit_with_location(source_location, |e| {
-                    e.const_data_ptr(elem_struct(&blob.elem_type), ll_val)
-                });
+                let data_ptr = match source_locations.get(&vid) {
+                    Some(source_location) => e.emit_with_location(source_location.clone(), |e| {
+                        e.const_data_ptr(elem_struct(&blob.elem_type), ll_val)
+                    }),
+                    None => e.const_data_ptr(elem_struct(&blob.elem_type), ll_val),
+                };
                 val_map.insert(vid, data_ptr);
             }
             _ => {
@@ -748,8 +749,10 @@ fn lower_function(
         let block = function.get_block(block_id);
         let ll_block_id = block_map[&block_id];
 
-        // Create a BlockEmitter for this block
-        let mut emitter = LLBlockEmitter::new(&mut ll_func, llssa, ll_block_id);
+        // Create a BlockEmitter for this block. Every instruction is emitted under its HL
+        // instruction's location below; emitting outside those scopes is an ICE.
+        let mut emitter = LLBlockEditor::new(&mut ll_func, llssa, ll_block_id)
+            .with_scoped_source_locations("hlssa_to_llssa");
 
         // Lower instructions
         for (instruction, source_location) in block.get_instructions_with_source_locations() {
@@ -799,7 +802,7 @@ fn new_helper_block_emitter<'a>(
     block_id: BlockId,
 ) -> LLBlockEmitter<'a> {
     let location = SourceLocation::synthetic(func.get_name());
-    LLBlockEmitter::new(func, llssa, block_id).with_source_location(location)
+    LLBlockEditor::new(func, llssa, block_id).with_source_location(location)
 }
 
 fn add_vm_parameter(func: &mut LLFunction, llssa: &mut LLSSA) -> ValueId {
@@ -2918,7 +2921,7 @@ fn generate_drop_function_for_ref(
 
 fn lower_terminator(
     terminator: &Terminator,
-    e: &mut LLBlockEmitter<'_>,
+    e: &mut LLBlockEditor<'_>,
     val_map: &HashMap<ValueId, ValueId>,
     block_map: &HashMap<BlockId, BlockId>,
     fn_type_info: &FunctionTypeInfo,

--- a/compiler/src/compiler/ssa/hlssa_to_llssa.rs
+++ b/compiler/src/compiler/ssa/hlssa_to_llssa.rs
@@ -631,10 +631,12 @@ fn lower_constants_llssa(
                 val_map.insert(vid, null_ptr);
             }
             Constant::Blob(blob) => {
+                // Constants referenced only by terminators (e.g. a blob that is directly
+                // returned) have no instruction to inherit a location from.
                 let source_location = source_locations
                     .get(&vid)
-                    .expect("ICE: blob constant lowered without a source location")
-                    .clone();
+                    .cloned()
+                    .unwrap_or_else(|| SourceLocation::synthetic("const_lowering"));
                 let data_ptr = e.emit_with_location(source_location, |e| {
                     e.const_data_ptr(elem_struct(&blob.elem_type), ll_val)
                 });
@@ -787,6 +789,17 @@ fn new_ll_function(llssa: &mut LLSSA, name: impl Into<String>) -> LLFunction {
     let mut func = LLFunction::empty(name.into());
     add_vm_parameter(&mut func, llssa);
     func
+}
+
+/// Block emitter for a compiler-generated helper function: every instruction it emits is located
+/// at the helper's synthetic source, named after the function.
+fn new_helper_block_emitter<'a>(
+    func: &'a mut LLFunction,
+    llssa: &'a mut LLSSA,
+    block_id: BlockId,
+) -> LLBlockEmitter<'a> {
+    let location = SourceLocation::synthetic(func.get_name());
+    LLBlockEmitter::new(func, llssa, block_id).with_source_location(location)
 }
 
 fn add_vm_parameter(func: &mut LLFunction, llssa: &mut LLSSA) -> ValueId {
@@ -2523,7 +2536,7 @@ fn generate_ad_bump_function(llssa: &mut LLSSA, matrix: DMatrix) -> LLFunction {
     let mut func = new_ll_function(llssa, name.to_string());
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
+    let mut e = new_helper_block_emitter(&mut func, llssa, entry);
     let node = e.add_parameter(LLType::Ptr);
     let amount = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
 
@@ -2621,7 +2634,7 @@ fn generate_ad_drop_function(
     let bump_db = bumps.db;
     let bump_dc = bumps.dc;
 
-    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
+    let mut e = new_helper_block_emitter(&mut func, llssa, entry);
     let node = e.add_parameter(LLType::Ptr);
 
     // Decrement RC
@@ -2783,7 +2796,7 @@ fn generate_drop_function_for_array(
     let mut func = new_ll_function(llssa, format!("drop_{}", ty));
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
+    let mut e = new_helper_block_emitter(&mut func, llssa, entry);
 
     let ptr = e.add_parameter(LLType::Ptr);
 
@@ -2852,7 +2865,7 @@ fn generate_drop_function_for_ref(
     let mut func = new_ll_function(llssa, format!("drop_{}", ty));
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
+    let mut e = new_helper_block_emitter(&mut func, llssa, entry);
     let ptr = e.add_parameter(LLType::Ptr);
 
     let hdr = e.struct_field_ptr(ptr, rc_struct.clone(), 0);
@@ -3559,7 +3572,7 @@ fn generate_array_lookup_function(llssa: &mut LLSSA, array_type: &HLType) -> LLF
     let mut func = new_ll_function(llssa, format!("__array_lookup_{}", array_type));
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
+    let mut e = new_helper_block_emitter(&mut func, llssa, entry);
     let array = e.add_parameter(LLType::Ptr);
     let key_field = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
     let result_field = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
@@ -3624,7 +3637,7 @@ fn generate_spread_lookup_function(
     let mut func = new_ll_function(llssa, format!("__spread_{}_lookup", bits));
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
+    let mut e = new_helper_block_emitter(&mut func, llssa, entry);
     let key_field = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
     let result_field = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
     let flag_field = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
@@ -3701,7 +3714,7 @@ fn generate_rngchk_function(llssa: &mut LLSSA, bits: u8, table_idx_global: usize
     let mut func = new_ll_function(llssa, format!("__rngchk_{}", bits));
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
+    let mut e = new_helper_block_emitter(&mut func, llssa, entry);
     let val = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
     let flag = e.add_parameter(LLType::Struct(LLStruct::field_elem()));
 
@@ -4111,7 +4124,7 @@ fn generate_darray_ad_call(
     let mut func = new_ll_function(llssa, format!("__darray_lookup_{}_ad_call", array_type));
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
+    let mut e = new_helper_block_emitter(&mut func, llssa, entry);
     let array = e.add_parameter(LLType::Ptr);
     let key_ptr = e.add_parameter(LLType::Ptr);
     let result_ptr = e.add_parameter(LLType::Ptr);
@@ -4172,7 +4185,7 @@ fn generate_dspread_ad_call(
     let mut func = new_ll_function(llssa, format!("__dspread_{}_ad_call", bits));
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
+    let mut e = new_helper_block_emitter(&mut func, llssa, entry);
     let key_ptr = e.add_parameter(LLType::Ptr);
     let result_ptr = e.add_parameter(LLType::Ptr);
     let flag_ptr = e.add_parameter(LLType::Ptr);
@@ -4248,7 +4261,7 @@ fn generate_drngchk_ad_call(
     let mut func = new_ll_function(llssa, format!("__drngchk_{}_ad_call", bits));
     let entry = func.get_entry_id();
 
-    let mut e = LLBlockEmitter::new(&mut func, llssa, entry);
+    let mut e = new_helper_block_emitter(&mut func, llssa, entry);
     let val_ptr = e.add_parameter(LLType::Ptr);
     let flag_ptr = e.add_parameter(LLType::Ptr);
 

--- a/compiler/src/compiler/ssa/llssa/builder.rs
+++ b/compiler/src/compiler/ssa/llssa/builder.rs
@@ -11,7 +11,8 @@ use crate::compiler::ssa::{
 
 pub trait LLEmitter {
     fn fresh_value(&mut self) -> ValueId;
-    fn emit_ll(&mut self, instruction: impl Into<LocatedLLOp>);
+    fn emit_ll(&mut self, instruction: LLOp);
+    fn emit_located_ll(&mut self, instruction: LocatedLLOp);
     fn vm_ptr(&mut self) -> ValueId;
     fn emit_constant(&mut self, value: Constant) -> ValueId;
 
@@ -423,8 +424,12 @@ impl LLEmitter for LLInstrBuilder<'_> {
         self.ssa.fresh_value()
     }
 
-    fn emit_ll(&mut self, instruction: impl Into<LocatedLLOp>) {
+    fn emit_ll(&mut self, instruction: LLOp) {
         self.push(instruction);
+    }
+
+    fn emit_located_ll(&mut self, instruction: LocatedLLOp) {
+        self.push_located(instruction);
     }
 
     fn vm_ptr(&mut self) -> ValueId {
@@ -446,8 +451,12 @@ impl LLEmitter for LLBlockEmitter<'_> {
         self.ssa.fresh_value()
     }
 
-    fn emit_ll(&mut self, instruction: impl Into<LocatedLLOp>) {
+    fn emit_ll(&mut self, instruction: LLOp) {
         self.emit_instruction(instruction);
+    }
+
+    fn emit_located_ll(&mut self, instruction: LocatedLLOp) {
+        self.emit_located_instruction(instruction);
     }
 
     fn vm_ptr(&mut self) -> ValueId {

--- a/compiler/src/compiler/ssa/llssa/builder.rs
+++ b/compiler/src/compiler/ssa/llssa/builder.rs
@@ -1,6 +1,6 @@
 use crate::compiler::ssa::{
     FunctionId, ValueId,
-    builder::{BlockEmitter, FunctionBuilder, InstrBuilder, SSABuilder},
+    builder::{BlockEditor, BlockEmitter, FunctionBuilder, InstrBuilder, SSABuilder},
     hlssa::DMatrix,
     llssa::{Constant, FieldArithOp, IntArithOp, IntCmpOp, LLOp, LLStruct, LocatedLLOp, Type},
 };
@@ -412,6 +412,7 @@ fn ad_out_field(matrix: DMatrix) -> usize {
 
 pub type LLInstrBuilder<'a> = InstrBuilder<'a, LLOp, Type, Constant>;
 pub type LLFunctionBuilder<'a> = FunctionBuilder<'a, LLOp, Type, Constant>;
+pub type LLBlockEditor<'a> = BlockEditor<'a, LLOp, Type, Constant>;
 pub type LLBlockEmitter<'a> = BlockEmitter<'a, LLOp, Type, Constant>;
 pub type LLSSABuilder<'a> = SSABuilder<'a, LLOp, Type, Constant>;
 

--- a/compiler/src/compiler/ssa/llssa/mod.rs
+++ b/compiler/src/compiler/ssa/llssa/mod.rs
@@ -1169,8 +1169,8 @@ impl Display for FieldArithOp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compiler::ssa::DefaultSSAAnnotator;
     use crate::compiler::ssa::llssa::builder::{LLEmitter, LLSSABuilder};
+    use crate::compiler::ssa::{DefaultSSAAnnotator, SourceLocation};
 
     #[test]
     fn field_elem_is_value_safe() {
@@ -1283,7 +1283,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry);
+            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
             // Only three values for a four-limb field-element layout.
             let values = vec![
                 Constant::Int { bits: 64, value: 0 },
@@ -1342,7 +1342,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry);
+            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
             let x = e.emit_int_const(64, 42);
             let y = e.emit_int_const(64, 7);
             let z = e.int_add(x, y);
@@ -1372,7 +1372,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry);
+            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
             let l0 = e.emit_int_const(64, 1);
             let l1 = e.emit_int_const(64, 0);
             let l2 = e.emit_int_const(64, 0);
@@ -1407,7 +1407,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry);
+            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
             let arr = e.heap_alloc(rc_array.clone(), None);
             let rc_ptr = e.struct_field_ptr(arr, rc_array.clone(), 0);
             let rc_word = e.struct_field_ptr(rc_ptr, rc_header, 0);
@@ -1439,7 +1439,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry);
+            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
             let a = e.emit_int_const(64, 1);
             let b = e.emit_int_const(64, 2);
             let results = e.call(helper_id, vec![a, b], 1);
@@ -1469,7 +1469,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry);
+            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
             let l0 = e.emit_int_const(64, 1);
             let l1 = e.emit_int_const(64, 0);
             let l2 = e.emit_int_const(64, 0);
@@ -1500,7 +1500,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry);
+            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
             let x = e.emit_int_const(64, 256);
             let narrow = e.truncate(x, 8);
             let wide = e.zext(narrow, 64);
@@ -1528,19 +1528,23 @@ mod tests {
             let merge_blk = fb.function.add_block();
 
             {
-                let mut e = fb.block(entry);
+                let mut e = fb.block(entry).with_source_location(SourceLocation::test());
                 let x = e.emit_int_const(64, 42);
                 let zero = e.emit_int_const(64, 0);
                 let cond = e.int_eq(x, zero);
                 e.terminate_jmp_if(cond, then_blk, else_blk);
             }
             {
-                let mut e = fb.block(then_blk);
+                let mut e = fb
+                    .block(then_blk)
+                    .with_source_location(SourceLocation::test());
                 let one = e.emit_int_const(64, 1);
                 e.terminate_jmp(merge_blk, vec![one]);
             }
             {
-                let mut e = fb.block(else_blk);
+                let mut e = fb
+                    .block(else_blk)
+                    .with_source_location(SourceLocation::test());
                 let two = e.emit_int_const(64, 2);
                 e.terminate_jmp(merge_blk, vec![two]);
             }
@@ -1563,7 +1567,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry);
+            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
             let dst = e.emit_nullptr_const();
             let src = e.emit_nullptr_const();
             let count = e.emit_int_const(64, 10);

--- a/compiler/src/compiler/ssa/llssa/mod.rs
+++ b/compiler/src/compiler/ssa/llssa/mod.rs
@@ -1169,8 +1169,8 @@ impl Display for FieldArithOp {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compiler::ssa::DefaultSSAAnnotator;
     use crate::compiler::ssa::llssa::builder::{LLEmitter, LLSSABuilder};
-    use crate::compiler::ssa::{DefaultSSAAnnotator, SourceLocation};
 
     #[test]
     fn field_elem_is_value_safe() {
@@ -1283,7 +1283,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
+            let mut e = fb.test_block(entry);
             // Only three values for a four-limb field-element layout.
             let values = vec![
                 Constant::Int { bits: 64, value: 0 },
@@ -1342,7 +1342,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
+            let mut e = fb.test_block(entry);
             let x = e.emit_int_const(64, 42);
             let y = e.emit_int_const(64, 7);
             let z = e.int_add(x, y);
@@ -1372,7 +1372,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
+            let mut e = fb.test_block(entry);
             let l0 = e.emit_int_const(64, 1);
             let l1 = e.emit_int_const(64, 0);
             let l2 = e.emit_int_const(64, 0);
@@ -1407,7 +1407,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
+            let mut e = fb.test_block(entry);
             let arr = e.heap_alloc(rc_array.clone(), None);
             let rc_ptr = e.struct_field_ptr(arr, rc_array.clone(), 0);
             let rc_word = e.struct_field_ptr(rc_ptr, rc_header, 0);
@@ -1439,7 +1439,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
+            let mut e = fb.test_block(entry);
             let a = e.emit_int_const(64, 1);
             let b = e.emit_int_const(64, 2);
             let results = e.call(helper_id, vec![a, b], 1);
@@ -1469,7 +1469,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
+            let mut e = fb.test_block(entry);
             let l0 = e.emit_int_const(64, 1);
             let l1 = e.emit_int_const(64, 0);
             let l2 = e.emit_int_const(64, 0);
@@ -1500,7 +1500,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
+            let mut e = fb.test_block(entry);
             let x = e.emit_int_const(64, 256);
             let narrow = e.truncate(x, 8);
             let wide = e.zext(narrow, 64);
@@ -1528,23 +1528,19 @@ mod tests {
             let merge_blk = fb.function.add_block();
 
             {
-                let mut e = fb.block(entry).with_source_location(SourceLocation::test());
+                let mut e = fb.test_block(entry);
                 let x = e.emit_int_const(64, 42);
                 let zero = e.emit_int_const(64, 0);
                 let cond = e.int_eq(x, zero);
                 e.terminate_jmp_if(cond, then_blk, else_blk);
             }
             {
-                let mut e = fb
-                    .block(then_blk)
-                    .with_source_location(SourceLocation::test());
+                let mut e = fb.test_block(then_blk);
                 let one = e.emit_int_const(64, 1);
                 e.terminate_jmp(merge_blk, vec![one]);
             }
             {
-                let mut e = fb
-                    .block(else_blk)
-                    .with_source_location(SourceLocation::test());
+                let mut e = fb.test_block(else_blk);
                 let two = e.emit_int_const(64, 2);
                 e.terminate_jmp(merge_blk, vec![two]);
             }
@@ -1567,7 +1563,7 @@ mod tests {
         let mut sb = LLSSABuilder::new(&mut ssa);
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
-            let mut e = fb.block(entry).with_source_location(SourceLocation::test());
+            let mut e = fb.test_block(entry);
             let dst = e.emit_nullptr_const();
             let src = e.emit_nullptr_const();
             let count = e.emit_int_const(64, 10);

--- a/compiler/src/compiler/ssa/mod.rs
+++ b/compiler/src/compiler/ssa/mod.rs
@@ -1198,7 +1198,6 @@ mod tests {
         let mut located = Located::new(ValueId(1), location.clone());
 
         assert_eq!(located.location(), &location);
-        assert_eq!(located.location(), &location);
         *located.location_mut() = location.clone();
         assert_eq!(AsRef::<ValueId>::as_ref(&located), &ValueId(1));
 

--- a/compiler/src/compiler/ssa/mod.rs
+++ b/compiler/src/compiler/ssa/mod.rs
@@ -782,10 +782,6 @@ impl<Op: Instruction, Ty: SSAType> Function<Op, Ty> {
         (new_id, block)
     }
 
-    pub fn next_block_id_bound(&self) -> u64 {
-        self.next_block
-    }
-
     pub fn add_return_type(&mut self, typ: Ty) {
         self.returns.push(typ);
     }
@@ -1039,12 +1035,6 @@ impl<Op: Instruction, Ty: SSAType> Block<Op, Ty> {
 
     pub fn instruction_count(&self) -> usize {
         self.instructions.len()
-    }
-
-    pub fn stamp_source_location_from(&mut self, start: usize, source_location: SourceLocation) {
-        for instruction in self.instructions.iter_mut().skip(start) {
-            *instruction.location_mut() = source_location.clone();
-        }
     }
 
     pub fn get_instructions(&self) -> impl DoubleEndedIterator<Item = &Op> {

--- a/compiler/src/compiler/ssa/mod.rs
+++ b/compiler/src/compiler/ssa/mod.rs
@@ -943,7 +943,7 @@ impl<Op: Instruction, Ty: SSAType> Block<Op, Ty> {
             .iter()
             .map(|i| {
                 let instruction = i.display_instruction(func_name, &annotate_value);
-                format!("    {} @ {}", instruction, i.get_location())
+                format!("    {} @ {}", instruction, i.location())
             })
             .join("\n");
         let terminator = match &self.terminator {
@@ -990,7 +990,24 @@ impl<Op: Instruction, Ty: SSAType> Block<Op, Ty> {
         source_location: SourceLocation,
     ) {
         self.instructions
-            .push(Located::with(instruction, source_location));
+            .push(Located::new(instruction, source_location));
+    }
+
+    /// Push an instruction located at the shared test location. Test-only sugar so hand-built
+    /// SSA fixtures don't have to spell out a `Located` wrapper per instruction.
+    #[cfg(test)]
+    pub fn push_test_instruction(&mut self, instruction: Op) {
+        self.push_instruction(Located::new(instruction, SourceLocation::test()));
+    }
+
+    /// The location of the first instruction, if the block has any.
+    pub fn first_location(&self) -> Option<&SourceLocation> {
+        self.instructions.first().map(Located::location)
+    }
+
+    /// The location of the last instruction, if the block has any.
+    pub fn last_location(&self) -> Option<&SourceLocation> {
+        self.instructions.last().map(Located::location)
     }
 
     pub fn set_terminator(&mut self, terminator: Terminator) {
@@ -1026,7 +1043,7 @@ impl<Op: Instruction, Ty: SSAType> Block<Op, Ty> {
     }
 
     pub fn get_instruction_source_location(&self, i: usize) -> &SourceLocation {
-        self.instructions[i].get_location()
+        self.instructions[i].location()
     }
 
     pub fn set_instruction_source_location(&mut self, i: usize, source_location: SourceLocation) {
@@ -1046,7 +1063,7 @@ impl<Op: Instruction, Ty: SSAType> Block<Op, Ty> {
     ) -> impl DoubleEndedIterator<Item = (&Op, &SourceLocation)> {
         self.instructions
             .iter()
-            .map(|instruction| (&**instruction, instruction.get_location()))
+            .map(|instruction| (&**instruction, instruction.location()))
     }
 
     pub fn get_instructions_mut(&mut self) -> impl Iterator<Item = &mut Op> {
@@ -1159,13 +1176,10 @@ mod tests {
         let mut ssa = HLSSA::with_main("main".to_string());
         let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
 
-        entry.push_instruction(Located::with(
-            OpCode::Not {
-                result: ValueId(0),
-                value: ValueId(1),
-            },
-            SourceLocation::test(),
-        ));
+        entry.push_test_instruction(OpCode::Not {
+            result: ValueId(0),
+            value: ValueId(1),
+        });
 
         assert_eq!(
             entry.get_instruction_source_location(0),
@@ -1181,16 +1195,16 @@ mod tests {
     #[test]
     fn located_exposes_location_ref_and_take() {
         let location = test_location();
-        let mut located = Located::with(ValueId(1), location.clone());
+        let mut located = Located::new(ValueId(1), location.clone());
 
         assert_eq!(located.location(), &location);
-        assert_eq!(located.get_location(), &location);
+        assert_eq!(located.location(), &location);
         *located.location_mut() = location.clone();
         assert_eq!(AsRef::<ValueId>::as_ref(&located), &ValueId(1));
 
         let located_ref = located.to_ref();
         assert_eq!(*located_ref, &ValueId(1));
-        assert_eq!(located_ref.get_location(), &location);
+        assert_eq!(located_ref.location(), &location);
 
         assert_eq!(located.take(), (ValueId(1), location));
     }
@@ -1233,7 +1247,7 @@ mod tests {
             .take_instructions()
             .into_iter()
             .map(|instruction| instruction.payload())
-            .map(|instruction| Located::with(instruction, SourceLocation::test()))
+            .map(|instruction| Located::new(instruction, SourceLocation::test()))
             .collect();
         entry.put_instructions(instructions);
 
@@ -1249,7 +1263,7 @@ mod tests {
         let location = test_location();
         let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
 
-        entry.push_instruction(Located::with(
+        entry.push_instruction(Located::new(
             OpCode::Not {
                 result: ValueId(0),
                 value: ValueId(1),

--- a/compiler/src/compiler/ssa/mod.rs
+++ b/compiler/src/compiler/ssa/mod.rs
@@ -22,7 +22,7 @@ use std::{
 
 use crate::collections::HashMap;
 
-pub use super::located::{Located, Location, SourceLocation, SourcePosition};
+pub use super::located::{Located, SourceLocation, SourcePosition};
 pub use id::{BlockId, FunctionId, ValueId};
 pub use traits::{Instruction, SSAAnotator, SSAType};
 
@@ -947,10 +947,7 @@ impl<Op: Instruction, Ty: SSAType> Block<Op, Ty> {
             .iter()
             .map(|i| {
                 let instruction = i.display_instruction(func_name, &annotate_value);
-                match i.get_location() {
-                    Some(source_location) => format!("    {} @ {}", instruction, source_location),
-                    None => format!("    {}", instruction),
-                }
+                format!("    {} @ {}", instruction, i.get_location())
             })
             .join("\n");
         let terminator = match &self.terminator {
@@ -979,21 +976,16 @@ impl<Op: Instruction, Ty: SSAType> Block<Op, Ty> {
         }
     }
 
-    // TODO: Once locations become non-optional, make the internal representation store
-    // `SourceLocation` directly.
     pub fn take_instructions(&mut self) -> Vec<Located<Op>> {
         std::mem::take(&mut self.instructions)
     }
 
-    pub fn put_instructions(&mut self, instructions: Vec<impl Into<Located<Op>>>) {
-        self.instructions = instructions
-            .into_iter()
-            .map(|instruction| instruction.into())
-            .collect();
+    pub fn put_instructions(&mut self, instructions: Vec<Located<Op>>) {
+        self.instructions = instructions;
     }
 
-    pub fn push_instruction(&mut self, instruction: impl Into<Located<Op>>) {
-        self.instructions.push(instruction.into());
+    pub fn push_instruction(&mut self, instruction: Located<Op>) {
+        self.instructions.push(instruction);
     }
 
     pub fn push_instruction_with_source_location(
@@ -1037,15 +1029,11 @@ impl<Op: Instruction, Ty: SSAType> Block<Op, Ty> {
         &self.instructions[i]
     }
 
-    pub fn get_instruction_source_location(&self, i: usize) -> Option<&SourceLocation> {
+    pub fn get_instruction_source_location(&self, i: usize) -> &SourceLocation {
         self.instructions[i].get_location()
     }
 
-    pub fn set_instruction_source_location(
-        &mut self,
-        i: usize,
-        source_location: Option<SourceLocation>,
-    ) {
+    pub fn set_instruction_source_location(&mut self, i: usize, source_location: SourceLocation) {
         *self.instructions[i].location_mut() = source_location;
     }
 
@@ -1053,19 +1041,9 @@ impl<Op: Instruction, Ty: SSAType> Block<Op, Ty> {
         self.instructions.len()
     }
 
-    pub fn stamp_source_location_from(
-        &mut self,
-        start: usize,
-        source_location: Option<SourceLocation>,
-    ) {
-        let Some(source_location) = source_location else {
-            return;
-        };
-
+    pub fn stamp_source_location_from(&mut self, start: usize, source_location: SourceLocation) {
         for instruction in self.instructions.iter_mut().skip(start) {
-            if instruction.get_location().is_none() {
-                *instruction.location_mut() = Some(source_location.clone());
-            }
+            *instruction.location_mut() = source_location.clone();
         }
     }
 
@@ -1075,7 +1053,7 @@ impl<Op: Instruction, Ty: SSAType> Block<Op, Ty> {
 
     pub fn get_instructions_with_source_locations(
         &self,
-    ) -> impl DoubleEndedIterator<Item = (&Op, Option<&SourceLocation>)> {
+    ) -> impl DoubleEndedIterator<Item = (&Op, &SourceLocation)> {
         self.instructions
             .iter()
             .map(|instruction| (&**instruction, instruction.get_location()))
@@ -1089,7 +1067,7 @@ impl<Op: Instruction, Ty: SSAType> Block<Op, Ty> {
 
     pub fn get_instruction_source_locations_mut(
         &mut self,
-    ) -> impl Iterator<Item = &mut Option<SourceLocation>> {
+    ) -> impl Iterator<Item = &mut SourceLocation> {
         self.instructions
             .iter_mut()
             .map(|instruction| instruction.location_mut())
@@ -1187,22 +1165,26 @@ mod tests {
     }
 
     #[test]
-    fn block_instructions_default_to_no_source_location() {
+    fn test_block_instructions_default_to_test_source_location() {
         let mut ssa = HLSSA::with_main("main".to_string());
         let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
 
-        entry.push_instruction(OpCode::Not {
-            result: ValueId(0),
-            value: ValueId(1),
-        });
+        entry.push_instruction(Located::with(
+            OpCode::Not {
+                result: ValueId(0),
+                value: ValueId(1),
+            },
+            SourceLocation::test(),
+        ));
 
-        assert_eq!(entry.get_instruction_source_location(0), None);
         assert_eq!(
+            entry.get_instruction_source_location(0),
+            &SourceLocation::test()
+        );
+        assert!(
             entry
                 .get_instructions_with_source_locations()
-                .map(|(_, location)| location)
-                .collect::<Vec<_>>(),
-            vec![None]
+                .all(|(_, location)| location == &SourceLocation::test())
         );
     }
 
@@ -1211,16 +1193,16 @@ mod tests {
         let location = test_location();
         let mut located = Located::with(ValueId(1), location.clone());
 
-        assert_eq!(located.location(), &Some(location.clone()));
-        assert_eq!(located.get_location(), Some(&location));
-        *located.location_mut() = Some(location.clone());
+        assert_eq!(located.location(), &location);
+        assert_eq!(located.get_location(), &location);
+        *located.location_mut() = location.clone();
         assert_eq!(AsRef::<ValueId>::as_ref(&located), &ValueId(1));
 
         let located_ref = located.to_ref();
         assert_eq!(*located_ref, &ValueId(1));
-        assert_eq!(located_ref.get_location(), Some(&location));
+        assert_eq!(located_ref.get_location(), &location);
 
-        assert_eq!(located.take(), (ValueId(1), Some(location)));
+        assert_eq!(located.take(), (ValueId(1), location));
     }
 
     #[test]
@@ -1237,7 +1219,7 @@ mod tests {
             location.clone(),
         );
 
-        assert_eq!(entry.get_instruction_source_location(0), Some(&location));
+        assert_eq!(entry.get_instruction_source_location(0), &location);
         assert!(
             ssa.to_string(&DefaultSSAAnnotator)
                 .contains("@ src/main.nr:3:5")
@@ -1245,7 +1227,7 @@ mod tests {
     }
 
     #[test]
-    fn raw_instruction_replacement_clears_source_locations() {
+    fn instruction_replacement_requires_explicit_source_location() {
         let mut ssa = HLSSA::with_main("main".to_string());
         let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
 
@@ -1261,10 +1243,14 @@ mod tests {
             .take_instructions()
             .into_iter()
             .map(|instruction| instruction.payload())
+            .map(|instruction| Located::with(instruction, SourceLocation::test()))
             .collect();
         entry.put_instructions(instructions);
 
-        assert_eq!(entry.get_instruction_source_location(0), None);
+        assert_eq!(
+            entry.get_instruction_source_location(0),
+            &SourceLocation::test()
+        );
     }
 
     #[test]
@@ -1284,6 +1270,6 @@ mod tests {
         let instructions = entry.take_instructions();
         entry.put_instructions(instructions);
 
-        assert_eq!(entry.get_instruction_source_location(0), Some(&location));
+        assert_eq!(entry.get_instruction_source_location(0), &location);
     }
 }

--- a/compiler/src/compiler/untaint_control_flow.rs
+++ b/compiler/src/compiler/untaint_control_flow.rs
@@ -403,10 +403,11 @@ impl UntaintControlFlow {
         let block_taint = *block_taint_vars.get(&block_id).unwrap();
 
         let old_instructions = block.take_instructions();
+        // Blocks holding only a terminator have no location to anchor the taint plumbing to.
         let block_source_location = old_instructions
             .last()
             .map(|instruction| instruction.location().clone())
-            .expect("ICE: terminator rewrite needs a block source location");
+            .unwrap_or_else(|| SourceLocation::synthetic("untaint_control_flow"));
         let mut new_instructions = Vec::new();
 
         for instruction in old_instructions {

--- a/compiler/src/compiler/untaint_control_flow.rs
+++ b/compiler/src/compiler/untaint_control_flow.rs
@@ -455,7 +455,7 @@ impl UntaintControlFlow {
                         let then_taint = match block_taint {
                             Some(tnt) => {
                                 let result_val = ssa.fresh_value();
-                                new_instructions.push(LocatedOpCode::with(
+                                new_instructions.push(LocatedOpCode::new(
                                     OpCode::BinaryArithOp {
                                         kind: BinaryArithOpKind::And,
                                         result: result_val,
@@ -470,7 +470,7 @@ impl UntaintControlFlow {
                         };
                         let not_cond = {
                             let nv = ssa.fresh_value();
-                            new_instructions.push(LocatedOpCode::with(
+                            new_instructions.push(LocatedOpCode::new(
                                 OpCode::Not {
                                     result: nv,
                                     value: cond,
@@ -482,7 +482,7 @@ impl UntaintControlFlow {
                         let else_taint = match block_taint {
                             Some(tnt) => {
                                 let result_val = ssa.fresh_value();
-                                new_instructions.push(LocatedOpCode::with(
+                                new_instructions.push(LocatedOpCode::new(
                                     OpCode::BinaryArithOp {
                                         kind: BinaryArithOpKind::And,
                                         result: result_val,

--- a/compiler/src/compiler/untaint_control_flow.rs
+++ b/compiler/src/compiler/untaint_control_flow.rs
@@ -12,7 +12,7 @@ use crate::{
             witness_taint_inference::WitnessTaintInference,
         },
         ssa::{
-            BlockId, FunctionId, Location, Terminator, ValueId,
+            BlockId, FunctionId, SourceLocation, Terminator, ValueId,
             hlssa::{
                 BinaryArithOpKind, CallTarget, CastTarget, HLBlock, HLFunction, HLSSA,
                 LocatedOpCode, OpCode, SequenceTargetType, Type, TypeExpr,
@@ -43,7 +43,7 @@ fn maybe_guard(
     instrs: &mut Vec<LocatedOpCode>,
     taint: Option<ValueId>,
     instr: OpCode,
-    location: &Location,
+    location: &SourceLocation,
 ) {
     let instruction = match taint {
         Some(taint) => OpCode::Guard {
@@ -250,14 +250,16 @@ impl UntaintControlFlow {
                     );
                     let mut cast_instructions = Vec::new();
                     let converted = {
-                        let mut builder =
-                            HLInstrBuilder::new(&mut function, ssa, &mut cast_instructions);
+                        let mut builder = HLInstrBuilder::new(
+                            &mut function,
+                            ssa,
+                            &mut cast_instructions,
+                            location.clone(),
+                        );
                         convert_if_needed(value, &cell_type, func_type_info, &mut builder)
                     };
                     for mut cast_instruction in cast_instructions {
-                        if cast_instruction.get_location().is_none() {
-                            *cast_instruction.location_mut() = location.clone();
-                        }
+                        *cast_instruction.location_mut() = location.clone();
                         new_instructions.push(cast_instruction);
                     }
                     new_instructions.push(
@@ -401,6 +403,10 @@ impl UntaintControlFlow {
         let block_taint = *block_taint_vars.get(&block_id).unwrap();
 
         let old_instructions = block.take_instructions();
+        let block_source_location = old_instructions
+            .last()
+            .map(|instruction| instruction.location().clone())
+            .expect("ICE: terminator rewrite needs a block source location");
         let mut new_instructions = Vec::new();
 
         for instruction in old_instructions {
@@ -448,13 +454,14 @@ impl UntaintControlFlow {
                         let then_taint = match block_taint {
                             Some(tnt) => {
                                 let result_val = ssa.fresh_value();
-                                new_instructions.push(LocatedOpCode::without(
+                                new_instructions.push(LocatedOpCode::with(
                                     OpCode::BinaryArithOp {
                                         kind: BinaryArithOpKind::And,
                                         result: result_val,
                                         lhs: tnt,
                                         rhs: cond,
                                     },
+                                    block_source_location.clone(),
                                 ));
                                 result_val
                             }
@@ -462,22 +469,26 @@ impl UntaintControlFlow {
                         };
                         let not_cond = {
                             let nv = ssa.fresh_value();
-                            new_instructions.push(LocatedOpCode::without(OpCode::Not {
-                                result: nv,
-                                value: cond,
-                            }));
+                            new_instructions.push(LocatedOpCode::with(
+                                OpCode::Not {
+                                    result: nv,
+                                    value: cond,
+                                },
+                                block_source_location.clone(),
+                            ));
                             nv
                         };
                         let else_taint = match block_taint {
                             Some(tnt) => {
                                 let result_val = ssa.fresh_value();
-                                new_instructions.push(LocatedOpCode::without(
+                                new_instructions.push(LocatedOpCode::with(
                                     OpCode::BinaryArithOp {
                                         kind: BinaryArithOpKind::And,
                                         result: result_val,
                                         lhs: tnt,
                                         rhs: not_cond,
                                     },
+                                    block_source_location.clone(),
                                 ));
                                 result_val
                             }
@@ -568,8 +579,12 @@ impl UntaintControlFlow {
                             if !args_passed_from_lhs.is_empty() {
                                 let mut instrs = Vec::new();
                                 {
-                                    let mut builder =
-                                        HLInstrBuilder::new(function, ssa, &mut instrs);
+                                    let mut builder = HLInstrBuilder::new(
+                                        function,
+                                        ssa,
+                                        &mut instrs,
+                                        block_source_location.clone(),
+                                    );
                                     for ((res, typ), (lhs, rhs)) in merge_params.iter().zip(
                                         args_passed_from_lhs
                                             .iter()
@@ -606,7 +621,12 @@ impl UntaintControlFlow {
                 if let (Some(ti), Some(param_types)) = (type_info, block_param_types.get(&target)) {
                     let mut cast_instrs = Vec::new();
                     let new_args: Vec<_> = {
-                        let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
+                        let mut builder = HLInstrBuilder::new(
+                            function,
+                            ssa,
+                            &mut cast_instrs,
+                            block_source_location.clone(),
+                        );
                         args.iter()
                             .zip(param_types.iter())
                             .map(|(arg, expected_type)| {
@@ -618,7 +638,6 @@ impl UntaintControlFlow {
                         &mut new_instructions,
                         block_taint,
                         cast_instrs,
-                        &None,
                     );
                     block.set_terminator(Terminator::Jmp(target, new_args));
                 }
@@ -627,7 +646,12 @@ impl UntaintControlFlow {
                 if let Some(ti) = type_info {
                     let mut cast_instrs = Vec::new();
                     let new_values: Vec<_> = {
-                        let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
+                        let mut builder = HLInstrBuilder::new(
+                            function,
+                            ssa,
+                            &mut cast_instrs,
+                            block_source_location.clone(),
+                        );
                         values
                             .iter()
                             .zip(return_types.iter())
@@ -640,7 +664,6 @@ impl UntaintControlFlow {
                         &mut new_instructions,
                         block_taint,
                         cast_instrs,
-                        &None,
                     );
                     block.set_terminator(Terminator::Return(new_values));
                 }
@@ -660,7 +683,7 @@ impl UntaintControlFlow {
         ssa: &mut HLSSA,
         type_info: Option<&FunctionTypeInfo>,
         block_taint: Option<ValueId>,
-        location: &Location,
+        location: &SourceLocation,
         new_instructions: &mut Vec<LocatedOpCode>,
     ) {
         match instruction {
@@ -694,7 +717,8 @@ impl UntaintControlFlow {
                 if let Some(ti) = type_info {
                     let mut cast_instrs = Vec::new();
                     let new_args: Vec<_> = {
-                        let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
+                        let mut builder =
+                            HLInstrBuilder::new(function, ssa, &mut cast_instrs, location.clone());
                         args.into_iter()
                             .map(|arg| {
                                 let arg_type = ti.get_value_type(arg);
@@ -707,12 +731,7 @@ impl UntaintControlFlow {
                             })
                             .collect()
                     };
-                    flush_conversion_instrs_located(
-                        new_instructions,
-                        block_taint,
-                        cast_instrs,
-                        location,
-                    );
+                    flush_conversion_instrs_located(new_instructions, block_taint, cast_instrs);
                     new_instructions.push(
                         OpCode::Call {
                             results,
@@ -751,17 +770,13 @@ impl UntaintControlFlow {
                 let target_elem_type = tp.clone();
                 let mut cast_instrs = Vec::new();
                 let new_vs: Vec<_> = {
-                    let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
+                    let mut builder =
+                        HLInstrBuilder::new(function, ssa, &mut cast_instrs, location.clone());
                     vs.iter()
                         .map(|v| convert_if_needed(*v, &target_elem_type, ti, &mut builder))
                         .collect()
                 };
-                flush_conversion_instrs_located(
-                    new_instructions,
-                    block_taint,
-                    cast_instrs,
-                    location,
-                );
+                flush_conversion_instrs_located(new_instructions, block_taint, cast_instrs);
                 maybe_guard(
                     new_instructions,
                     block_taint,
@@ -786,15 +801,11 @@ impl UntaintControlFlow {
                 let target_elem_type = tp.clone();
                 let mut cast_instrs = Vec::new();
                 let new_element = {
-                    let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
+                    let mut builder =
+                        HLInstrBuilder::new(function, ssa, &mut cast_instrs, location.clone());
                     convert_if_needed(element, &target_elem_type, ti, &mut builder)
                 };
-                flush_conversion_instrs_located(
-                    new_instructions,
-                    block_taint,
-                    cast_instrs,
-                    location,
-                );
+                flush_conversion_instrs_located(new_instructions, block_taint, cast_instrs);
                 maybe_guard(
                     new_instructions,
                     block_taint,
@@ -824,17 +835,13 @@ impl UntaintControlFlow {
                 };
                 let mut cast_instrs = Vec::new();
                 let (converted_array, converted_value) = {
-                    let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
+                    let mut builder =
+                        HLInstrBuilder::new(function, ssa, &mut cast_instrs, location.clone());
                     let ca = convert_if_needed(array, result_type, ti, &mut builder);
                     let cv = convert_if_needed(value, &expected_elem_type, ti, &mut builder);
                     (ca, cv)
                 };
-                flush_conversion_instrs_located(
-                    new_instructions,
-                    block_taint,
-                    cast_instrs,
-                    location,
-                );
+                flush_conversion_instrs_located(new_instructions, block_taint, cast_instrs);
                 maybe_guard(
                     new_instructions,
                     block_taint,
@@ -862,7 +869,8 @@ impl UntaintControlFlow {
                 };
                 let mut cast_instrs = Vec::new();
                 let (new_slice, new_values) = {
-                    let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
+                    let mut builder =
+                        HLInstrBuilder::new(function, ssa, &mut cast_instrs, location.clone());
                     let new_slice = convert_if_needed(slice, result_slice_type, ti, &mut builder);
                     let new_values: Vec<_> = values
                         .iter()
@@ -870,12 +878,7 @@ impl UntaintControlFlow {
                         .collect();
                     (new_slice, new_values)
                 };
-                flush_conversion_instrs_located(
-                    new_instructions,
-                    block_taint,
-                    cast_instrs,
-                    location,
-                );
+                flush_conversion_instrs_located(new_instructions, block_taint, cast_instrs);
                 maybe_guard(
                     new_instructions,
                     block_taint,
@@ -895,15 +898,11 @@ impl UntaintControlFlow {
                 let target_type = ptr_type.get_pointed();
                 let mut cast_instrs = Vec::new();
                 let converted = {
-                    let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
+                    let mut builder =
+                        HLInstrBuilder::new(function, ssa, &mut cast_instrs, location.clone());
                     convert_if_needed(value, &target_type, ti, &mut builder)
                 };
-                flush_conversion_instrs_located(
-                    new_instructions,
-                    block_taint,
-                    cast_instrs,
-                    location,
-                );
+                flush_conversion_instrs_located(new_instructions, block_taint, cast_instrs);
                 maybe_guard(
                     new_instructions,
                     block_taint,
@@ -927,17 +926,13 @@ impl UntaintControlFlow {
                 let target_type = if_t_type.get_arithmetic_result_type(if_f_type);
                 let mut cast_instrs = Vec::new();
                 let (new_if_t, new_if_f) = {
-                    let mut builder = HLInstrBuilder::new(function, ssa, &mut cast_instrs);
+                    let mut builder =
+                        HLInstrBuilder::new(function, ssa, &mut cast_instrs, location.clone());
                     let t = convert_if_needed(if_t, &target_type, ti, &mut builder);
                     let f = convert_if_needed(if_f, &target_type, ti, &mut builder);
                     (t, f)
                 };
-                flush_conversion_instrs_located(
-                    new_instructions,
-                    block_taint,
-                    cast_instrs,
-                    location,
-                );
+                flush_conversion_instrs_located(new_instructions, block_taint, cast_instrs);
                 maybe_guard(
                     new_instructions,
                     block_taint,
@@ -1016,11 +1011,9 @@ fn flush_conversion_instrs_located(
     instrs: &mut Vec<LocatedOpCode>,
     taint: Option<ValueId>,
     cast_instrs: Vec<LocatedOpCode>,
-    fallback_location: &Location,
 ) {
     for instr in cast_instrs {
         let (instr, location) = instr.take();
-        let location = location.or_else(|| fallback_location.clone());
         maybe_guard(instrs, taint, instr, &location);
     }
 }


### PR DESCRIPTION
- Located<T> stores SourceLocation directly instead of Option
- Emitting requires with_source_location(loc) — enforced by the type system, not runtime panics
- Generated code gets synthetic <origin> locations; rewrite drivers ICE if an emission escapes its instruction's scope
- Bulk of the diff is mechanical test churn