### PR TITLE
Pool constants in the bytecode

### DIFF
--- a/compiler/src/compiler/codegen/bytecode/layout.rs
+++ b/compiler/src/compiler/codegen/bytecode/layout.rs
@@ -7,13 +7,17 @@ use crate::{
         ssa::{
             ValueId,
             hlssa::{
-                HLSSA, MAX_SUPPORTED_SIGNED_BITS, MAX_SUPPORTED_UNSIGNED_BITS, Type, TypeExpr,
+                Constant, HLSSA, MAX_SUPPORTED_SIGNED_BITS, MAX_SUPPORTED_UNSIGNED_BITS, Type,
+                TypeExpr,
             },
         },
         util::ice_non_elided_tuple,
     },
     vm::{self, bytecode},
 };
+
+// FRAME LAYOUTER
+// ================================================================================================
 
 /// Assists in computing the layout for a single virtual machine stack frame.
 pub struct FrameLayouter {
@@ -120,6 +124,9 @@ impl FrameLayouter {
     }
 }
 
+// STRUCT LAYOUT INTERNER
+// ================================================================================================
+
 /// Interns unique struct shapes during codegen and returns a stable index into the resulting
 /// descriptor table.
 pub struct StructLayoutInterner {
@@ -150,6 +157,89 @@ impl StructLayoutInterner {
         self.table
     }
 }
+
+// CONSTANT POOL INTERNER
+// ================================================================================================
+
+/// Interns multi-cell constants during codegen into a program-global pool and returns a stable
+/// word offset into it.
+///
+/// The pool stores each distinct constant's words once, in the exact frame layout that
+/// `spill_constant_to_frame` would have written, so a `mov_const_pool` memcpy into a frame slot is
+/// byte-identical to the equivalent `MovConst` chain. Constants are keyed by their interned
+/// `ValueId` (bijective with the constant's value), which is cheaper than hashing the value and
+/// gives program-global deduplication for free.
+pub struct ConstantPoolInterner {
+    pub pool: Vec<u64>,
+    pub index: HashMap<ValueId, usize>,
+}
+
+impl ConstantPoolInterner {
+    pub fn new() -> Self {
+        Self {
+            pool: Vec::new(),
+            index: HashMap::default(),
+        }
+    }
+
+    /// Intern `constant` (identified by `vid`) and return its word offset in the pool. On a miss
+    /// the constant's words are appended in frame order.
+    pub fn intern(&mut self, vid: ValueId, constant: &Constant) -> usize {
+        if let Some(&off) = self.index.get(&vid) {
+            return off;
+        }
+        let off = self.pool.len();
+        let pool = &mut self.pool;
+        for_each_constant_word(constant, &mut |word| pool.push(word));
+        self.index.insert(vid, off);
+        off
+    }
+
+    pub fn into_pool(self) -> Vec<u64> {
+        self.pool
+    }
+}
+
+/// Visit the `u64` words of `constant` in frame order — the order in which both the constant pool
+/// and a `MovConst` spill lay them out.
+///
+/// This is the single source of truth for constant word ordering: [`ConstantPoolInterner`], the
+/// `spill_constant_to_frame` inline path, and `constant_cell_count` (which just counts the visits)
+/// all drive it, so the pooled and inline representations — and the memcpy size — cannot drift out
+/// of sync. Adding a new [`Constant`] variant only requires updating this function.
+pub fn for_each_constant_word(constant: &Constant, visit: &mut impl FnMut(u64)) {
+    match constant {
+        Constant::U(size, val) => match size {
+            bits if *bits <= 64 => visit(*val as u64),
+            128 => {
+                visit(*val as u64);
+                visit((*val >> 64) as u64);
+            }
+            bits => panic!("unsupported unsigned integer width: {bits}"),
+        },
+        Constant::I(size, val) => {
+            assert!(
+                *size <= MAX_SUPPORTED_SIGNED_BITS,
+                "signed integers wider than i{MAX_SUPPORTED_SIGNED_BITS} are unsupported"
+            );
+            visit(*val as u64);
+        }
+        Constant::Field(val) => {
+            for i in 0..bytecode::FELT_LIMBS {
+                visit(val.0.0[i]);
+            }
+        }
+        Constant::Blob(blob) => {
+            for element in &blob.elements {
+                for_each_constant_word(element, visit);
+            }
+        }
+        Constant::FnPtr(_) => panic!("FnPtr constants not supported in codegen"),
+    }
+}
+
+// GLOBAL FRAME LAYOUTER
+// ================================================================================================
 
 pub struct GlobalFrameLayouter {
     pub offsets: Vec<usize>,

--- a/compiler/src/compiler/codegen/bytecode/mod.rs
+++ b/compiler/src/compiler/codegen/bytecode/mod.rs
@@ -12,7 +12,8 @@ use crate::{
         codegen::{
             CodeGenOptions,
             bytecode::layout::{
-                FrameLayouter, GlobalFrameLayouter, StructLayoutInterner, int_cell_count,
+                ConstantPoolInterner, FrameLayouter, GlobalFrameLayouter, StructLayoutInterner,
+                for_each_constant_word,
             },
         },
         ssa::{
@@ -31,11 +32,14 @@ use crate::{
 /// Materialize every constant `ValueId` referenced by `function` into the function's frame at
 /// entry.
 ///
-/// This can likely be improved in the future by handling constants specially in the VM, but for now
-/// this is the simplest solution that maintains semantic correctness.
+/// Multi-cell constants are interned into the program-global constant pool (`pool`) and loaded with
+/// a single `MovConstPool`, so one copy is shared across every function that references them.
+/// Single-cell scalars are spilled inline as a `MovConst`, which is already as compact as a pool
+/// load.
 fn materialize_constants(
     function: &HLFunction,
     constants: &HLSSAConstantsSnapshot,
+    pool: &mut ConstantPoolInterner,
     layouter: &mut FrameLayouter,
     emitter: &mut EmitterState,
 ) {
@@ -74,87 +78,58 @@ fn materialize_constants(
 
     for vid in referenced {
         let constant = constants.get(&vid).expect("vid is in constants").as_ref();
+        let cells = constant_cell_count(constant);
         let res = match constant {
             hlssa::Constant::U(size, _) => layouter.alloc_int(vid, *size),
             hlssa::Constant::I(size, _) => layouter.alloc_int(vid, *size),
             hlssa::Constant::Field(_) => layouter.alloc_field(vid),
-            hlssa::Constant::Blob(_) => {
-                layouter.alloc_long_data(vid, constant_cell_count(constant))
-            }
+            hlssa::Constant::Blob(_) => layouter.alloc_long_data(vid, cells),
             hlssa::Constant::FnPtr(_) => panic!("FnPtr constants not supported in codegen"),
         };
-        spill_constant_to_frame(constant, res, emitter);
-    }
-}
 
-fn constant_cell_count(value: &hlssa::Constant) -> usize {
-    match value {
-        hlssa::Constant::U(bits, _) => int_cell_count(*bits),
-        hlssa::Constant::I(bits, _) => {
-            assert!(
-                *bits <= MAX_SUPPORTED_SIGNED_BITS,
-                "signed integers wider than i{MAX_SUPPORTED_SIGNED_BITS} are unsupported"
-            );
-            1
+        // Multi-cell constants (fields, u128s, blobs) are interned into the program-global constant
+        // pool and loaded with a single `MovConstPool`, sharing one copy across every function that
+        // references them. Single-cell scalars stay inline: a `MovConst` is already as small as a
+        // pool load, so pooling them would only add indirection.
+        if cells >= 2 {
+            let pool_offset = pool.intern(vid, constant);
+            emitter.push_op(bytecode::OpCode::MovConstPool {
+                res,
+                pool_offset,
+                size: cells,
+            });
+        } else {
+            spill_constant_to_frame(constant, res, emitter);
         }
-        hlssa::Constant::Field(_) => bytecode::FELT_LIMBS,
-        hlssa::Constant::Blob(blob) => blob.elements.iter().map(constant_cell_count).sum(),
-        hlssa::Constant::FnPtr(_) => panic!("FnPtr constants not supported in codegen"),
     }
 }
 
+/// The number of `u64` cells `value` occupies once materialized — i.e. the number of words
+/// [`for_each_constant_word`] emits.
+///
+/// This is both the frame-slot size and the `mov_const_pool` memcpy size, so it is derived from the
+/// same visitor to keep them in lockstep.
+fn constant_cell_count(value: &hlssa::Constant) -> usize {
+    let mut count = 0usize;
+    for_each_constant_word(value, &mut |_| count += 1);
+    count
+}
+
+/// Spill `value` into `res` inline, one `MovConst` per word, in the layout defined by
+/// [`for_each_constant_word`] (the same layout the constant pool uses).
 fn spill_constant_to_frame(
     value: &hlssa::Constant,
     res: bytecode::FramePosition,
     emitter: &mut EmitterState,
 ) {
-    match value {
-        hlssa::Constant::U(size, val) => match size {
-            bits if *bits <= 64 => {
-                emitter.push_op(bytecode::OpCode::MovConst {
-                    res,
-                    val: *val as u64,
-                });
-            }
-            128 => {
-                emitter.push_op(bytecode::OpCode::MovConst {
-                    res,
-                    val: *val as u64,
-                });
-                emitter.push_op(bytecode::OpCode::MovConst {
-                    res: res.offset(1),
-                    val: (*val >> 64) as u64,
-                });
-            }
-            bits => panic!("unsupported unsigned integer width: {bits}"),
-        },
-        hlssa::Constant::I(size, val) => {
-            assert!(
-                *size <= MAX_SUPPORTED_SIGNED_BITS,
-                "signed integers wider than i{MAX_SUPPORTED_SIGNED_BITS} are unsupported"
-            );
-            emitter.push_op(bytecode::OpCode::MovConst {
-                res,
-                val: *val as u64,
-            });
-        }
-        hlssa::Constant::Field(val) => {
-            for i in 0..bytecode::FELT_LIMBS {
-                emitter.push_op(bytecode::OpCode::MovConst {
-                    res: res.offset(i as isize),
-                    val: val.0.0[i],
-                });
-            }
-        }
-        hlssa::Constant::Blob(blob) => {
-            let mut offset = 0usize;
-            for element in &blob.elements {
-                spill_constant_to_frame(element, res.offset(offset as isize), emitter);
-                offset += constant_cell_count(element);
-            }
-        }
-        hlssa::Constant::FnPtr(_) => panic!("FnPtr constants not supported in codegen"),
-    }
+    let mut offset = 0isize;
+    for_each_constant_word(value, &mut |word| {
+        emitter.push_op(bytecode::OpCode::MovConst {
+            res: res.offset(offset),
+            val: word,
+        });
+        offset += 1;
+    });
 }
 
 // CODE GENERATOR
@@ -173,6 +148,7 @@ impl CodeGen {
     pub fn run(&self, ssa: &HLSSA, cfg: &FlowAnalysis, type_info: &TypeInfo) -> bytecode::Program {
         let global_layouter = GlobalFrameLayouter::new(ssa);
         let struct_interner = StructLayoutInterner::new();
+        let mut const_pool = ConstantPoolInterner::new();
         let constants = ssa.const_snapshot();
 
         // Entry points are emitted first, in entry-table order; the remaining functions follow.
@@ -194,6 +170,7 @@ impl CodeGen {
                 type_info.get_function(function_id),
                 &global_layouter,
                 &constants,
+                &mut const_pool,
             );
             function_ids.insert(function_id, cur_fn_begin);
             cur_fn_begin += function.code.len();
@@ -225,6 +202,7 @@ impl CodeGen {
             entry_points: (0..entry_ids.len()).collect(),
             global_frame_size: global_layouter.total_size,
             struct_layouts: struct_interner.into_table(),
+            constant_pool: const_pool.into_pool(),
         }
     }
 
@@ -235,6 +213,7 @@ impl CodeGen {
         type_info: &FunctionTypeInfo,
         global_layouter: &GlobalFrameLayouter,
         constants: &HLSSAConstantsSnapshot,
+        pool: &mut ConstantPoolInterner,
     ) -> bytecode::Function {
         let mut layouter = FrameLayouter::new();
         let entry = function.get_entry();
@@ -246,8 +225,7 @@ impl CodeGen {
             layouter.alloc_value(*param, tp);
         }
 
-        // TODO: Deal with constants better in the bytecode (#201)
-        materialize_constants(function, constants, &mut layouter, &mut emitter);
+        materialize_constants(function, constants, pool, &mut layouter, &mut emitter);
 
         self.run_block_body(
             function,

--- a/compiler/src/compiler/passes/merge_identical_functions.rs
+++ b/compiler/src/compiler/passes/merge_identical_functions.rs
@@ -29,15 +29,31 @@
 //! bisimulation — members call same-group callees at every site — which is what makes merging
 //! chains of clones (and identical self-recursive pairs) sound.
 //!
+//! # Preconditions
+//!
+//! The pass rewrites only `CallTarget::Static` references (via `map_call_targets`); it does not
+//! touch `CallTarget::Dynamic` or `Constant::FnPtr(FunctionId)`. So it may only run once
+//! defunctionalization has removed both — otherwise deleting a folded function could leave a
+//! dangling function-pointer reference. This holds in `program_tail`: both halves are
+//! defunctionalized before the program merge (`driver.rs` asserts no `FnPtr` constant survives).
+//! `do_run` re-checks this with a debug-only assertion so a future pipeline reorder fails loudly
+//! rather than miscompiling.
+//!
 //! # Soundness
 //!
 //! Merging never changes behavior: a call to the deleted copy becomes a call to a function with
 //! an identical body, and the *call itself* is preserved, so per-call effects (witness minting,
 //! constraint emission, globals initialization) happen exactly as before. Entry points are
-//! externally invoked by id and are never deleted; a non-entry duplicate of an entry point
-//! redirects into it, making the entry internally callable — fine today, since both backends
-//! compile entry points as ordinary functions. The pass runs after R1CS generation, so rows/cols
-//! cannot change by construction — the payoff is program size (bytecode and WASM) and downstream
+//! externally invoked by id and are never deleted; they are also never used as a redirect _target_,
+//! because the LLVM/WASM backend gives entry points a distinct calling convention (declared
+//! `fn(VM*)`, with parameters loaded from the public-input region rather than passed as arguments),
+//! so an internal call into an entry would mismatch its signature. Redirect targets are therefore
+//! always non-entry survivors: a group's entry points survive on their own, and a non-entry
+//! duplicate with no non-entry survivor to fold into is kept rather than pointed at an entry.
+//!
+//! The pass operates on the program SSA built by `Driver::prepare_program_ssa`, which R1CS
+//! generation does not consume (R1CS is generated from a separate `witness_spilled_ssa`), so
+//! rows/cols cannot change — the payoff is program size (bytecode and WASM) and downstream
 //! compile time.
 
 use crate::{
@@ -54,13 +70,8 @@ use crate::{
 // MERGE IDENTICAL FUNCTIONS
 // ================================================================================================
 
+#[derive(Default)]
 pub struct MergeIdenticalFunctions {}
-
-impl MergeIdenticalFunctions {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
 
 impl Pass for MergeIdenticalFunctions {
     fn name(&self) -> &'static str {
@@ -73,7 +84,34 @@ impl Pass for MergeIdenticalFunctions {
 }
 
 impl MergeIdenticalFunctions {
+    pub fn new() -> Self {
+        Self {}
+    }
+
     pub fn do_run(&self, ssa: &mut HLSSA) {
+        // Precondition: defunctionalization must have run, so no `Constant::FnPtr` (nor the dynamic
+        // calls it feeds) remains. This pass only rewrites `CallTarget::Static`, so a surviving
+        // function pointer to a folded function would be left dangling. `driver.rs` guarantees this
+        // before the program merge; re-check it here so a future pipeline reorder fails loudly.
+        #[cfg(debug_assertions)]
+        {
+            use crate::compiler::ssa::hlssa::Constant;
+            fn contains_fn_ptr(c: &Constant) -> bool {
+                match c {
+                    Constant::FnPtr(_) => true,
+                    Constant::Blob(blob) => blob.elements.iter().any(contains_fn_ptr),
+                    Constant::U(..) | Constant::I(..) | Constant::Field(_) => false,
+                }
+            }
+            let mut has_fn_ptr = false;
+            ssa.for_each_const(|_, cv| has_fn_ptr = has_fn_ptr || contains_fn_ptr(cv.as_ref()));
+            assert!(
+                !has_fn_ptr,
+                "merge_identical_functions requires defunctionalization first: a FnPtr constant \
+                 survived, which this pass would leave dangling when folding its target"
+            );
+        }
+
         // Constant ids are program-global and shared across the merged halves; they stay raw in the
         // canonical form while every other id is renamed positionally.
         let mut const_ids: HashSet<ValueId> = HashSet::default();
@@ -102,10 +140,20 @@ impl MergeIdenticalFunctions {
             }
             intern.len()
         };
+
+        // The shape strings are only needed for round-0 grouping; refinement and the rewrite below
+        // need just each function's callee list. Drop the strings now to release O(program-text)
+        // memory before the fixpoint. (A digest instead of exact strings would risk a collision =
+        // an unsound false merge, so grouping keeps the full strings for round 0.)
+        let callee_lists: Vec<(FunctionId, Vec<FunctionId>)> = shapes
+            .into_iter()
+            .map(|(fid, _shape, callees)| (fid, callees))
+            .collect();
+
         loop {
             let mut intern: HashMap<(usize, Vec<usize>), usize> = HashMap::default();
             let mut next_group: HashMap<FunctionId, usize> = HashMap::default();
-            for (fid, _, callees) in &shapes {
+            for (fid, callees) in &callee_lists {
                 let key = (group[fid], callees.iter().map(|c| group[c]).collect());
                 let next = intern.len();
                 let id = *intern.entry(key).or_insert(next);
@@ -119,23 +167,42 @@ impl MergeIdenticalFunctions {
             }
         }
 
-        // Per final group: entry points always survive; everything else redirects to the
-        // smallest-id survivor (an entry point if the group has one) and is deleted.
+        // Per final group: entry points always survive on their own; every non-entry duplicate
+        // redirects to the smallest-id *non-entry* survivor and is deleted. An entry point is never
+        // used as a redirect target — the LLVM/WASM backend compiles entries with a distinct
+        // calling convention (declared `fn(VM*)`, parameters loaded from the public-input region
+        // rather than passed as arguments), so an internal call into one would mismatch its
+        // signature. When a group has no non-entry member, or its only non-entry is the survivor,
+        // nothing folds there.
         let entry_points: HashSet<FunctionId> = ssa.get_entry_points().iter().copied().collect();
         let mut members: HashMap<usize, Vec<FunctionId>> = HashMap::default();
         for &fid in &fids {
             members.entry(group[&fid]).or_default().push(fid);
         }
-        let mut redirect: HashMap<FunctionId, FunctionId> = HashMap::default();
-        for &fid in &fids {
-            let mates = &members[&group[&fid]];
+
+        // One survivor per group: the smallest-id non-entry member, else (all-entry group) the
+        // smallest-id member. `members` values are in sorted-`fids` order, so `find`/`first` yield
+        // the smallest id and this stays deterministic regardless of map iteration order.
+        let mut survivor_of: HashMap<usize, FunctionId> = HashMap::default();
+        for (&gid, mates) in &members {
             let survivor = mates
                 .iter()
-                .find(|m| entry_points.contains(m))
+                .find(|m| !entry_points.contains(m))
                 .or_else(|| mates.first())
                 .copied()
                 .unwrap();
-            if fid != survivor && !entry_points.contains(&fid) {
+            survivor_of.insert(gid, survivor);
+        }
+
+        let mut redirect: HashMap<FunctionId, FunctionId> = HashMap::default();
+        for &fid in &fids {
+            if entry_points.contains(&fid) {
+                continue;
+            }
+            // `survivor` is guaranteed non-entry: `fid` is non-entry, so its group has a non-entry
+            // member and `find` picked one.
+            let survivor = survivor_of[&group[&fid]];
+            if fid != survivor {
                 redirect.insert(fid, survivor);
             }
         }
@@ -152,10 +219,10 @@ impl MergeIdenticalFunctions {
             ssa.set_globals_deinit_fn(*survivor);
         }
 
-        for (fid, _, callees) in &shapes {
+        for (fid, callees) in &callee_lists {
             if redirect.contains_key(fid) {
                 ssa.delete_function(*fid)
-                    .expect("function listed in shapes must exist");
+                    .expect("function scheduled for merging must exist");
                 continue;
             }
             if !callees.iter().any(|callee| redirect.contains_key(callee)) {
@@ -167,6 +234,44 @@ impl MergeIdenticalFunctions {
                     instruction
                         .map_call_targets(&mut |callee| *redirect.get(&callee).unwrap_or(&callee));
                 }
+            }
+        }
+
+        // Postcondition (debug only): the delete + rewrite above must leave no reference to a
+        // folded function. The folded (deleted) set is exactly `redirect`'s keys; assert that no
+        // surviving function statically calls one, and that the globals registrations don't either.
+        // `delete_function` validates nothing, so this catches a future edit that forgets a
+        // reference class before it silently ships a dangling call.
+        #[cfg(debug_assertions)]
+        {
+            for (fid, _) in &callee_lists {
+                if redirect.contains_key(fid) {
+                    continue; // deleted above
+                }
+                let function = ssa.get_function(*fid);
+                for (_, block) in function.get_blocks() {
+                    for op in block.get_instructions() {
+                        for callee in op.get_static_call_targets() {
+                            debug_assert!(
+                                !redirect.contains_key(&callee),
+                                "merge_identical_functions left a dangling call from {fid:?} to \
+                                 folded {callee:?}"
+                            );
+                        }
+                    }
+                }
+            }
+            if let Some(f) = ssa.get_globals_init_fn() {
+                debug_assert!(
+                    !redirect.contains_key(&f),
+                    "merge_identical_functions left globals_init at folded {f:?}"
+                );
+            }
+            if let Some(f) = ssa.get_globals_deinit_fn() {
+                debug_assert!(
+                    !redirect.contains_key(&f),
+                    "merge_identical_functions left globals_deinit at folded {f:?}"
+                );
             }
         }
     }
@@ -197,6 +302,13 @@ impl Canonicalizer<'_> {
 /// The canonical serialization of `function` (see the module doc for what it does and does not
 /// include) plus its static call targets in traversal order, which the caller abstracts through the
 /// partition instead of comparing raw.
+///
+/// Identity is decided by exact string equality of this serialization, which relies on `Debug` being
+/// injective over every opcode / type / source-location value that can appear: two *distinct* values
+/// must never format to the same string, or two different functions would be merged (unsound). This
+/// holds today because value-carrying immediates (constants) appear here only as their raw const
+/// `ValueId`s, never as formatted values. A future opcode field or `Type` with a lossy `Debug` would
+/// break it — prefer a purpose-built encoding over a lossy `Debug` if that ever arises.
 fn canonical_form(
     function: &Function<OpCode, Type>,
     const_ids: &HashSet<ValueId>,
@@ -486,7 +598,7 @@ mod tests {
     }
 
     #[test]
-    fn entry_point_survives_its_group() {
+    fn entry_point_is_never_a_redirect_target() {
         let mut ssa = HLSSA::with_main("main".to_string());
         let mut sb = HLSSABuilder::new(&mut ssa);
         let f = add_leaf(&mut sb, "f");
@@ -496,11 +608,12 @@ mod tests {
 
         run(&mut ssa);
 
-        // `g` is an entry point, so it must survive even though `f` has the smaller id;
-        // the non-entry duplicate redirects into it.
-        assert!(has_function(&ssa, g));
-        assert!(!has_function(&ssa, f));
-        assert_eq!(call_targets(&ssa, main_id), vec![g]);
+        // `f` (non-entry) and `g` (entry) are byte-identical and `main` calls `f`. Folding `f` into
+        // the entry `g` would make `g` internally callable, which the LLVM / WASM backend cannot
+        // honor (entries load their params from memory under a `fn(VM*)` signature). So `f` is kept
+        // — an entry is never a redirect target — and `main` keeps calling `f`.
+        assert!(has_function(&ssa, f) && has_function(&ssa, g));
+        assert_eq!(call_targets(&ssa, main_id), vec![f]);
     }
 
     #[test]
@@ -517,6 +630,26 @@ mod tests {
 
         assert!(has_function(&ssa, f) && has_function(&ssa, g));
         assert_eq!(call_targets(&ssa, main_id), vec![f, g]);
+    }
+
+    #[test]
+    fn duplicates_fold_onto_a_non_entry_survivor_not_the_entry() {
+        // Three byte-identical leaves in one group: two non-entry (`a`, `b`) and one entry (`e`).
+        // `b` folds onto the smaller-id non-entry `a` — never onto the entry `e`, which survives on
+        // its own. `main` calls both non-entries, so both call sites end up at `a`.
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let mut sb = HLSSABuilder::new(&mut ssa);
+        let a = add_leaf(&mut sb, "a");
+        let b = add_leaf(&mut sb, "b");
+        let e = add_leaf(&mut sb, "e");
+        let main_id = wire_main(&mut sb, &[a, b]);
+        ssa.add_entry_point(e);
+
+        run(&mut ssa);
+
+        assert!(has_function(&ssa, a) && has_function(&ssa, e));
+        assert!(!has_function(&ssa, b));
+        assert_eq!(call_targets(&ssa, main_id), vec![a, a]);
     }
 
     #[test]

--- a/vm/src/bytecode.rs
+++ b/vm/src/bytecode.rs
@@ -459,6 +459,8 @@ pub struct VM {
     pub spread_tables: [Option<usize>; NUM_TABLE_SIZE_SLOTS],
     pub globals: *mut u64,
     pub struct_layouts: Vec<StructDescriptor>,
+    /// Interned constant pool (flat words), read by the `mov_const_pool` opcode.
+    pub constants: Vec<u64>,
     /// Set when the program executes a trap (e.g. a failed assertion). The
     /// interpreter checks this after dispatch returns to distinguish a clean
     /// halt from a trapped one.
@@ -484,6 +486,7 @@ impl VM {
         elem_inverses_witness_section_offset: usize,
         globals: *mut u64,
         struct_layouts: Vec<StructDescriptor>,
+        constants: Vec<u64>,
     ) -> Self {
         Self {
             data: Arrays {
@@ -507,6 +510,7 @@ impl VM {
             spread_tables: [None; NUM_TABLE_SIZE_SLOTS],
             globals,
             struct_layouts,
+            constants,
             trapped: false,
             #[cfg(feature = "vm-profile")]
             opcode_profile: vec![(0, 0); NUM_OPCODES],
@@ -523,6 +527,7 @@ impl VM {
         constraints_layout: ConstraintsLayout,
         globals: *mut u64,
         struct_layouts: Vec<StructDescriptor>,
+        constants: Vec<u64>,
     ) -> Self {
         Self {
             data: Arrays {
@@ -547,6 +552,7 @@ impl VM {
             spread_tables: [None; NUM_TABLE_SIZE_SLOTS],
             globals,
             struct_layouts,
+            constants,
             trapped: false,
             #[cfg(feature = "vm-profile")]
             opcode_profile: vec![(0, 0); NUM_OPCODES],
@@ -2212,6 +2218,13 @@ mod def {
             boxed.dec_rc(vm);
         }
     }
+
+    #[opcode]
+    fn mov_const_pool(#[out] res: *mut u64, vm: &mut VM, pool_offset: usize, size: usize) {
+        unsafe {
+            std::ptr::copy_nonoverlapping(vm.constants.as_ptr().add(pool_offset), res, size);
+        }
+    }
 }
 
 pub struct Function {
@@ -2242,6 +2255,10 @@ pub struct Program {
     pub entry_points: Vec<usize>,
     pub global_frame_size: usize,
     pub struct_layouts: Vec<StructDescriptor>,
+    /// Interned constant pool: a flat word buffer holding each distinct multi-cell constant
+    /// once. Referenced by `MovConstPool { pool_offset, size }` instead of being re-spilled
+    /// into every function's frame.
+    pub constant_pool: Vec<u64>,
 }
 
 impl Display for Program {
@@ -2294,6 +2311,10 @@ impl Program {
             }
         }
 
+        // Constant pool: [pool_len, ...words...].
+        binary.push(self.constant_pool.len() as u64);
+        binary.extend_from_slice(&self.constant_pool);
+
         binary.push(self.global_frame_size as u64);
 
         // Entry-point table: [num_entries, marker_offset_0, ...]. The offsets are absolute word
@@ -2335,6 +2356,8 @@ impl Program {
 /// The decoded header of a program binary.
 pub struct ProgramHeader {
     pub struct_layouts: Vec<StructDescriptor>,
+    /// Interned constant pool (flat words), read at runtime by `mov_const_pool`.
+    pub constant_pool: Vec<u64>,
     pub global_frame_size: usize,
     /// Absolute word offsets of each entry point's function marker, in entry-table order
     /// ([`ENTRY_WITGEN`], [`ENTRY_AD`], ...). The entry's frame size lives at `offset + 1` and
@@ -2348,6 +2371,9 @@ pub struct ProgramHeader {
 /// table.
 pub fn parse_program_header(program: &[u64]) -> ProgramHeader {
     let (struct_layouts, off) = parse_struct_layouts(program);
+    let pool_len = program[off] as usize;
+    let constant_pool = program[off + 1..off + 1 + pool_len].to_vec();
+    let off = off + 1 + pool_len;
     let global_frame_size = program[off] as usize;
     let num_entries = program[off + 1] as usize;
     let entry_points = (0..num_entries)
@@ -2355,6 +2381,7 @@ pub fn parse_program_header(program: &[u64]) -> ProgramHeader {
         .collect();
     ProgramHeader {
         struct_layouts,
+        constant_pool,
         global_frame_size,
         entry_points,
         code_start: off + 2 + num_entries,

--- a/vm/src/interpreter.rs
+++ b/vm/src/interpreter.rs
@@ -324,6 +324,7 @@ pub fn run_phase1(
         witness_layout.tables_data_start() - witness_layout.challenges_start(),
         global_frame.as_mut_ptr(),
         header.struct_layouts,
+        header.constant_pool,
     );
 
     let frame = Frame::base_frame(program[entry + 1], &mut vm);
@@ -678,6 +679,7 @@ pub fn run_ad(
         constraints_layout,
         global_frame.as_mut_ptr(),
         header.struct_layouts,
+        header.constant_pool,
     );
 
     let frame = Frame::push(


### PR DESCRIPTION
This introduces interning of large constants to the bytecode much akin to what we have in the LLVM backend. This reduces bytecode size across most corpus tests, with significant reductions in heavily constant-reliant code.

This commit also fixes an issue where entry points could be merged in a way that would cause invalid compilation in some circumstances in the WASM backend. We now avoid merging entry points as redirect targets.

Closes #201.