### PR TITLE
Split debug info into a separate sidecar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,6 +2262,7 @@ dependencies = [
  "mavros-artifacts",
  "mavros-opcode-gen",
  "serde",
+ "serde_json",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,6 +2261,7 @@ dependencies = [
  "ark-ff",
  "mavros-artifacts",
  "mavros-opcode-gen",
+ "serde",
  "tracing",
 ]
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ This will produce the following two files inside the project's `target/` directo
 | `target/basic.json` | ABI and the program binary (`binary`) containing the witgen and AD entry points |
 | `target/r1cs.bin`   | Serialised R1CS constraint system (bincode)                                     |
 
+Pass `--include-debug-info` to additionally write `target/basic.debug.json`. This standalone,
+versioned source map records VM bytecode word offsets, function names, and Noir source locations;
+the executable bytecode in `basic.json` remains byte-for-byte unchanged.
+
 For advanced usage and the CLI options, run `mavros --help`. To output the witness generation binary
 for WASM-capable platforms, please see the [WASM output](./docs/CONTRIBUTING.md#WASM%20Output)
 section in our contributing docs.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ This will produce the following two files inside the project's `target/` directo
 
 Pass `--include-debug-info` to additionally write `target/basic.debug.json`. This standalone,
 versioned source map records VM bytecode word offsets, function names, and Noir source locations;
-the executable bytecode in `basic.json` remains byte-for-byte unchanged.
+the executable bytecode in `basic.json` remains byte-for-byte unchanged. Source paths are relative
+to the Noir package root by default; pass `--absolute-paths` to retain absolute paths.
 
 For advanced usage and the CLI options, run `mavros --help`. To output the witness generation binary
 for WASM-capable platforms, please see the [WASM output](./docs/CONTRIBUTING.md#WASM%20Output)

--- a/compiler/src/api.rs
+++ b/compiler/src/api.rs
@@ -8,7 +8,7 @@ use crate::{
     abi_helpers::ordered_params_from_btreemap,
     compiler::{Field, codegen::hlssa_to_r1cs::R1CS},
     driver::Driver,
-    vm::interpreter,
+    vm::{bytecode::DebugInfo, interpreter},
 };
 use mavros_artifacts::InputValueOrdered;
 use noirc_abi::input_parser::Format;
@@ -54,17 +54,9 @@ pub fn run_witgen_from_binary(
     binary: &mut [u64],
     r1cs: &R1CS,
     params: &[InputValueOrdered],
+    debug_info: Option<DebugInfo>,
 ) -> Result<interpreter::WitgenResult, interpreter::TrapError> {
-    interpreter::run(binary, r1cs.witness_layout, r1cs.constraints_layout, params)
-}
-
-pub fn run_witgen_from_binary_with_debug_info(
-    binary: &mut [u64],
-    r1cs: &R1CS,
-    params: &[InputValueOrdered],
-    debug_info: crate::vm::bytecode::DebugInfo,
-) -> Result<interpreter::WitgenResult, interpreter::TrapError> {
-    interpreter::run_with_debug_info(
+    interpreter::run(
         binary,
         r1cs.witness_layout,
         r1cs.constraints_layout,
@@ -79,8 +71,15 @@ pub fn run_witgen_phase1(
     binary: &mut [u64],
     r1cs: &R1CS,
     params: &[InputValueOrdered],
+    debug_info: Option<DebugInfo>,
 ) -> Result<interpreter::Phase1Result, interpreter::TrapError> {
-    interpreter::run_phase1(binary, r1cs.witness_layout, r1cs.constraints_layout, params)
+    interpreter::run_phase1(
+        binary,
+        r1cs.witness_layout,
+        r1cs.constraints_layout,
+        params,
+        debug_info,
+    )
 }
 
 /// Phase 2: given real Fiat-Shamir challenges, complete witness generation.
@@ -117,6 +116,7 @@ pub fn run_ad_from_binary(
     binary: &mut [u64],
     r1cs: &R1CS,
     coeffs: &[Field],
+    debug_info: Option<DebugInfo>,
 ) -> Result<
     (
         Vec<Field>,
@@ -126,24 +126,7 @@ pub fn run_ad_from_binary(
     ),
     interpreter::TrapError,
 > {
-    interpreter::run_ad(binary, coeffs, r1cs.witness_layout, r1cs.constraints_layout)
-}
-
-pub fn run_ad_from_binary_with_debug_info(
-    binary: &mut [u64],
-    r1cs: &R1CS,
-    coeffs: &[Field],
-    debug_info: crate::vm::bytecode::DebugInfo,
-) -> Result<
-    (
-        Vec<Field>,
-        Vec<Field>,
-        Vec<Field>,
-        crate::vm::bytecode::AllocationInstrumenter,
-    ),
-    interpreter::TrapError,
-> {
-    interpreter::run_ad_with_debug_info(
+    interpreter::run_ad(
         binary,
         coeffs,
         r1cs.witness_layout,

--- a/compiler/src/api.rs
+++ b/compiler/src/api.rs
@@ -58,6 +58,21 @@ pub fn run_witgen_from_binary(
     interpreter::run(binary, r1cs.witness_layout, r1cs.constraints_layout, params)
 }
 
+pub fn run_witgen_from_binary_with_debug_info(
+    binary: &mut [u64],
+    r1cs: &R1CS,
+    params: &[InputValueOrdered],
+    debug_info: crate::vm::bytecode::DebugInfo,
+) -> Result<interpreter::WitgenResult, interpreter::TrapError> {
+    interpreter::run_with_debug_info(
+        binary,
+        r1cs.witness_layout,
+        r1cs.constraints_layout,
+        params,
+        debug_info,
+    )
+}
+
 /// Phase 1: execute the VM and produce the pre-commitment witness. Returns
 /// intermediate state needed by [`run_witgen_phase2`].
 pub fn run_witgen_phase1(
@@ -90,6 +105,14 @@ pub fn compile_bytecode(
     Ok(driver.compile_bytecode(options)?)
 }
 
+/// Compile compact VM bytecode plus optional standalone debug metadata.
+pub fn compile_bytecode_artifact(
+    driver: &mut Driver,
+    options: crate::compiler::codegen::CodeGenOptions,
+) -> Result<crate::driver::BytecodeArtifact, Error> {
+    Ok(driver.compile_bytecode_artifact(options)?)
+}
+
 pub fn run_ad_from_binary(
     binary: &mut [u64],
     r1cs: &R1CS,
@@ -104,6 +127,29 @@ pub fn run_ad_from_binary(
     interpreter::TrapError,
 > {
     interpreter::run_ad(binary, coeffs, r1cs.witness_layout, r1cs.constraints_layout)
+}
+
+pub fn run_ad_from_binary_with_debug_info(
+    binary: &mut [u64],
+    r1cs: &R1CS,
+    coeffs: &[Field],
+    debug_info: crate::vm::bytecode::DebugInfo,
+) -> Result<
+    (
+        Vec<Field>,
+        Vec<Field>,
+        Vec<Field>,
+        crate::vm::bytecode::AllocationInstrumenter,
+    ),
+    interpreter::TrapError,
+> {
+    interpreter::run_ad_with_debug_info(
+        binary,
+        coeffs,
+        r1cs.witness_layout,
+        r1cs.constraints_layout,
+        debug_info,
+    )
 }
 
 pub fn random_ad_coeffs(r1cs: &R1CS) -> Vec<Field> {

--- a/compiler/src/bin/main.rs
+++ b/compiler/src/bin/main.rs
@@ -48,7 +48,7 @@ pub struct ProgramOptions {
     #[arg(long, action = clap::ArgAction::SetTrue)]
     pub absolute_paths: bool,
 
-    /// Include source metadata in bytecode and WASM artifacts.
+    /// Emit standalone debug-information sidecars for VM and WASM artifacts.
     #[arg(long, global = true, action = clap::ArgAction::SetTrue)]
     pub include_debug_info: bool,
 }
@@ -98,6 +98,7 @@ fn main() -> ExitCode {
             binary_output,
             *draw_graphs,
             args.include_debug_info,
+            args.absolute_paths,
         ),
         None => run(&args),
     };
@@ -128,17 +129,19 @@ pub fn run_compile(
     binary_output: &PathBuf,
     draw_graphs: bool,
     include_debug_info: bool,
+    absolute_paths: bool,
 ) -> Result<ExitCode, Error> {
     info!(message = %"Compiling Noir project", root = ?path, r1cs_output = ?r1cs_output, binary_output = ?binary_output);
 
     let (mut driver, r1cs) = compile_to_r1cs(path.clone(), draw_graphs)?;
-    let binary = api::compile_bytecode(
+    let artifact = api::compile_bytecode_artifact(
         &mut driver,
         CodeGenOptions {
             include_debug_info,
             ..CodeGenOptions::default()
         },
     )?;
+    let binary = artifact.binary;
 
     // Ensure output directories exist
     if let Some(parent) = r1cs_output.parent() {
@@ -162,6 +165,17 @@ pub fn run_compile(
     });
     let basic_json = serde_json::to_string_pretty(&basic)?;
     fs::write(binary_output, basic_json)?;
+
+    let debug_output = binary_output.with_extension("debug.json");
+    if let Some(mut debug_info) = artifact.debug_info {
+        if !absolute_paths {
+            debug_info.relativize_source_paths(&std::env::current_dir()?.canonicalize()?);
+        }
+        fs::write(&debug_output, serde_json::to_string_pretty(&debug_info)?)?;
+        info!(message = %"VM debug info generated", path = %debug_output.display());
+    } else if debug_output.exists() {
+        fs::remove_file(debug_output)?;
+    }
 
     info!(
         message = %"Artifacts saved successfully",
@@ -229,15 +243,22 @@ pub fn run(args: &ProgramOptions) -> Result<ExitCode, Error> {
     }
 
     let params = api::read_prover_inputs(driver.package_root(), driver.abi())?;
-    let mut binary = api::compile_bytecode(&mut driver, codegen_options)?;
+    let artifact = api::compile_bytecode_artifact(&mut driver, codegen_options)?;
+    let mut binary = artifact.binary;
+    let vm_debug_info = artifact.debug_info;
 
-    let witgen_result =
-        api::run_witgen_from_binary(&mut binary, &r1cs, &params).map_err(|mut error| {
-            if let Some(root) = &source_path_root {
-                error.relativize_source_paths(root);
-            }
-            error
-        })?;
+    let witgen_result = match vm_debug_info.clone() {
+        Some(debug_info) => {
+            api::run_witgen_from_binary_with_debug_info(&mut binary, &r1cs, &params, debug_info)
+        }
+        None => api::run_witgen_from_binary(&mut binary, &r1cs, &params),
+    }
+    .map_err(|mut error| {
+        if let Some(root) = &source_path_root {
+            error.relativize_source_paths(root);
+        }
+        error
+    })?;
 
     let correct = api::check_witgen(&r1cs, &witgen_result);
     if !correct {
@@ -299,8 +320,12 @@ pub fn run(args: &ProgramOptions) -> Result<ExitCode, Error> {
 
     let ad_coeffs: Vec<Field> = api::random_ad_coeffs(&r1cs);
 
-    let (ad_a, ad_b, ad_c, ad_instrumenter) =
-        api::run_ad_from_binary(&mut binary, &r1cs, &ad_coeffs)?;
+    let (ad_a, ad_b, ad_c, ad_instrumenter) = match vm_debug_info {
+        Some(debug_info) => {
+            api::run_ad_from_binary_with_debug_info(&mut binary, &r1cs, &ad_coeffs, debug_info)
+        }
+        None => api::run_ad_from_binary(&mut binary, &r1cs, &ad_coeffs),
+    }?;
 
     let leftover_memory = plotting::plot_memory_chart(
         &ad_instrumenter,

--- a/compiler/src/bin/main.rs
+++ b/compiler/src/bin/main.rs
@@ -247,18 +247,15 @@ pub fn run(args: &ProgramOptions) -> Result<ExitCode, Error> {
     let mut binary = artifact.binary;
     let vm_debug_info = artifact.debug_info;
 
-    let witgen_result = match vm_debug_info.clone() {
-        Some(debug_info) => {
-            api::run_witgen_from_binary_with_debug_info(&mut binary, &r1cs, &params, debug_info)
-        }
-        None => api::run_witgen_from_binary(&mut binary, &r1cs, &params),
-    }
-    .map_err(|mut error| {
-        if let Some(root) = &source_path_root {
-            error.relativize_source_paths(root);
-        }
-        error
-    })?;
+    let witgen_result =
+        api::run_witgen_from_binary(&mut binary, &r1cs, &params, vm_debug_info.clone()).map_err(
+            |mut error| {
+                if let Some(root) = &source_path_root {
+                    error.relativize_source_paths(root);
+                }
+                error
+            },
+        )?;
 
     let correct = api::check_witgen(&r1cs, &witgen_result);
     if !correct {
@@ -320,12 +317,8 @@ pub fn run(args: &ProgramOptions) -> Result<ExitCode, Error> {
 
     let ad_coeffs: Vec<Field> = api::random_ad_coeffs(&r1cs);
 
-    let (ad_a, ad_b, ad_c, ad_instrumenter) = match vm_debug_info {
-        Some(debug_info) => {
-            api::run_ad_from_binary_with_debug_info(&mut binary, &r1cs, &ad_coeffs, debug_info)
-        }
-        None => api::run_ad_from_binary(&mut binary, &r1cs, &ad_coeffs),
-    }?;
+    let (ad_a, ad_b, ad_c, ad_instrumenter) =
+        api::run_ad_from_binary(&mut binary, &r1cs, &ad_coeffs, vm_debug_info)?;
 
     let leftover_memory = plotting::plot_memory_chart(
         &ad_instrumenter,

--- a/compiler/src/bin/main.rs
+++ b/compiler/src/bin/main.rs
@@ -1,4 +1,8 @@
-use std::{fs, path::PathBuf, process::ExitCode};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::ExitCode,
+};
 
 use clap::{Parser, Subcommand};
 use mavros_compiler::Project;
@@ -44,7 +48,7 @@ pub struct ProgramOptions {
     #[arg(long, action = clap::ArgAction::SetTrue)]
     pub skip_vm: bool,
 
-    /// Print absolute paths in VM stack traces and WASM debug info instead of paths relative to the current directory.
+    /// Print absolute paths in VM stack traces and WASM debug info instead of paths relative to the Noir package root.
     #[arg(long, action = clap::ArgAction::SetTrue)]
     pub absolute_paths: bool,
 
@@ -121,6 +125,14 @@ pub fn compile_to_r1cs(root: PathBuf, draw_graphs: bool) -> Result<(Driver, R1CS
     Ok((driver, r1cs))
 }
 
+fn debug_path_root(driver: &Driver, absolute_paths: bool) -> Option<&Path> {
+    if absolute_paths {
+        None
+    } else {
+        Some(driver.package_root())
+    }
+}
+
 /// Compile phase: compile the Noir project and save R1CS and binary artifacts
 /// to separate files.
 pub fn run_compile(
@@ -168,8 +180,8 @@ pub fn run_compile(
 
     let debug_output = binary_output.with_extension("debug.json");
     if let Some(mut debug_info) = artifact.debug_info {
-        if !absolute_paths {
-            debug_info.relativize_source_paths(&std::env::current_dir()?.canonicalize()?);
+        if let Some(root) = debug_path_root(&driver, absolute_paths) {
+            debug_info.relativize_source_paths(root);
         }
         fs::write(&debug_output, serde_json::to_string_pretty(&debug_info)?)?;
         info!(message = %"VM debug info generated", path = %debug_output.display());
@@ -196,11 +208,7 @@ pub fn run(args: &ProgramOptions) -> Result<ExitCode, Error> {
         include_debug_info: args.include_debug_info,
         ..CodeGenOptions::default()
     };
-    let source_path_root = if args.absolute_paths {
-        None
-    } else {
-        Some(std::env::current_dir()?.canonicalize()?)
-    };
+    let source_path_root = debug_path_root(&driver, args.absolute_paths).map(Path::to_path_buf);
     if args.pprint_r1cs {
         use std::io::Write;
         let mut r1cs_file =

--- a/compiler/src/bin/test_runner.rs
+++ b/compiler/src/bin/test_runner.rs
@@ -16,7 +16,11 @@ use ark_ff::UniformRand as _;
 use mavros_compiler::{
     Project, abi_helpers,
     compiler::Field,
-    compiler::codegen::{CodeGenOptions, hlssa_to_r1cs::R1CS, llssa_to_llvm::WasmCompileOpts},
+    compiler::codegen::{
+        CodeGenOptions,
+        hlssa_to_r1cs::R1CS,
+        llssa_to_llvm::{WasmCompileOpts, wasm_debug_info_path},
+    },
     driver::{Driver, Error as DriverError},
     vm::{TableKind, bytecode::TableInfo, interpreter},
     wasm_runtime,
@@ -37,7 +41,7 @@ use mavros_wasm_layout::{
 };
 use noirc_abi::input_parser::Format;
 use rand::SeedableRng;
-use wasmtime::{Config, Engine, Linker, Memory, Module, Store, WasmBacktraceDetails};
+use wasmtime::{Config, Engine, Linker, Memory, Store, WasmBacktraceDetails};
 
 fn wasm_engine() -> wasmtime::Result<Engine> {
     let mut config = Config::new();
@@ -145,7 +149,7 @@ fn emit(line: &str) {
 fn run_single(root: PathBuf, expect_failure: bool) {
     let checking_codegen = CodeGenOptions {
         check_constraints: true,
-        ..CodeGenOptions::default()
+        include_debug_info: true,
     };
 
     // 1. Compile
@@ -207,15 +211,23 @@ fn run_single(root: PathBuf, expect_failure: bool) {
         }
     };
 
-    // 3. Compile bytecode: a single binary holding both the witgen and AD entry points
-    //    (depends on R1CS).
+    // 3. Compile bytecode: a single binary holding both the witgen and AD entry points, plus its
+    //    standalone debug sidecar (depends on R1CS).
     let program_binary = r1cs.as_ref().and_then(|_| {
         emit("START:COMPILE");
-        match driver.compile_bytecode(checking_codegen) {
-            Ok(b) => {
-                let bytes = b.len() * 8;
-                emit(&format!("END:COMPILE:ok:{bytes}"));
-                Some(b)
+        match driver.compile_bytecode_artifact(checking_codegen) {
+            Ok(artifact) => {
+                let bytes = artifact.binary.len() * 8;
+                let debug_bytes = serde_json::to_vec_pretty(
+                    artifact
+                        .debug_info
+                        .as_ref()
+                        .expect("debug info was requested for the VM test artifact"),
+                )
+                .expect("VM debug info must serialize")
+                .len();
+                emit(&format!("END:COMPILE:ok:{bytes}:{debug_bytes}"));
+                Some(artifact.binary)
             }
             Err(_) => {
                 emit("END:COMPILE:fail");
@@ -336,7 +348,8 @@ fn run_single(root: PathBuf, expect_failure: bool) {
         let tmpdir = tempfile::tempdir().ok()?;
         let wasm_path = tmpdir.keep().join("program.wasm");
         let wasm_opts = WasmCompileOpts::fast(wasm_runtime::locate_or_build())
-            .with_debug_path_root(&source_path_root);
+            .with_debug_path_root(&source_path_root)
+            .with_debug_info();
         match driver.compile_llvm_targets(
             false,
             r1cs,
@@ -345,7 +358,17 @@ fn run_single(root: PathBuf, expect_failure: bool) {
         ) {
             Ok(_) if wasm_path.exists() => {
                 let bytes = fs::metadata(&wasm_path).map(|m| m.len()).unwrap_or(0);
-                emit(&format!("END:WASM_COMPILE:ok:{bytes}"));
+                let debug_path = wasm_debug_info_path(&wasm_path);
+                let Ok(debug_metadata) = fs::metadata(&debug_path) else {
+                    eprintln!(
+                        "WASM compile succeeded but debug sidecar was not found at {:?}",
+                        debug_path
+                    );
+                    emit("END:WASM_COMPILE:fail");
+                    return None;
+                };
+                let debug_bytes = debug_metadata.len();
+                emit(&format!("END:WASM_COMPILE:ok:{bytes}:{debug_bytes}"));
                 Some(wasm_path)
             }
             Ok(_) => {
@@ -583,8 +606,7 @@ fn run_wasm(
     let mut store = Store::new(&engine, ());
 
     // Load the WASM module
-    let wasm_bytes = fs::read(wasm_path)?;
-    let module = Module::new(&engine, &wasm_bytes)?;
+    let module = wasm_runtime::load_wasmtime_module(&engine, wasm_path)?;
 
     // Estimate initial memory: linker-reserved stack + module static data + our buffers.
     let initial_estimate = WASM_STACK_SIZE_BYTES + WASM_STATIC_DATA_BYTES + our_data_size;
@@ -895,8 +917,7 @@ fn run_ad_wasm(
     let engine = wasm_engine()?;
     let mut store = Store::new(&engine, ());
 
-    let wasm_bytes = fs::read(wasm_path)?;
-    let module = Module::new(&engine, &wasm_bytes)?;
+    let module = wasm_runtime::load_wasmtime_module(&engine, wasm_path)?;
 
     let initial_estimate = WASM_STACK_SIZE_BYTES + WASM_STATIC_DATA_BYTES + our_data_size;
     let pages = ((initial_estimate as usize + 65535) / 65536) as u32;
@@ -1065,7 +1086,9 @@ struct TestResult {
     rows: Option<usize>,
     cols: Option<usize>,
     binary_bytes: Option<usize>,
+    vm_debug_bytes: Option<usize>,
     wasm_bytes: Option<usize>,
+    wasm_debug_bytes: Option<usize>,
 }
 
 /// Determined purely from child output:
@@ -1290,7 +1313,9 @@ fn ignored_test_result(name: &str) -> TestResult {
         rows: None,
         cols: None,
         binary_bytes: None,
+        vm_debug_bytes: None,
         wasm_bytes: None,
+        wasm_debug_bytes: None,
     }
 }
 
@@ -1301,7 +1326,9 @@ fn parse_child_output(name: &str, expectation: TestExpectation, lines: &[String]
     let mut rows = None;
     let mut cols = None;
     let mut binary_bytes = None;
+    let mut vm_debug_bytes = None;
     let mut wasm_bytes = None;
+    let mut wasm_debug_bytes = None;
 
     for line in lines {
         let parts: Vec<&str> = line.split(':').collect();
@@ -1317,9 +1344,11 @@ fn parse_child_output(name: &str, expectation: TestExpectation, lines: &[String]
                 }
                 if *key == "COMPILE" && parts.len() >= 4 {
                     binary_bytes = parts[3].parse().ok();
+                    vm_debug_bytes = parts.get(4).and_then(|value| value.parse().ok());
                 }
                 if *key == "WASM_COMPILE" && parts.len() >= 4 {
                     wasm_bytes = parts[3].parse().ok();
+                    wasm_debug_bytes = parts.get(4).and_then(|value| value.parse().ok());
                 }
             }
             ["END", key, "reject"] => {
@@ -1357,7 +1386,9 @@ fn parse_child_output(name: &str, expectation: TestExpectation, lines: &[String]
         rows,
         cols,
         binary_bytes,
+        vm_debug_bytes,
         wasm_bytes,
+        wasm_debug_bytes,
     }
 }
 
@@ -1721,33 +1752,112 @@ struct ParsedRow {
     rows: Option<usize>,
     cols: Option<usize>,
     size_bytes: Option<usize>,
+    vm_debug_size_bytes: Option<usize>,
     wasm_size_bytes: Option<usize>,
+    wasm_debug_size_bytes: Option<usize>,
+}
+
+const STATUS_COLUMNS: &[&str] = &[
+    "Test",
+    "Compiled",
+    "R1CS",
+    "Rows",
+    "Cols",
+    "Bytecode Size",
+    "VM Debug Sidecar Size",
+    "WASM Size",
+    "WASM Debug Sidecar Size",
+    "Compile",
+    "Witgen Run VM",
+    "Witgen Correct",
+    "Witgen No Leak",
+    "AD Run VM",
+    "AD Correct",
+    "AD No Leak",
+    "WASM Compile",
+    "Witgen WASM Run",
+    "Witgen WASM Correct",
+    "Witgen WASM No Leak",
+    "AD WASM Run",
+    "AD WASM Correct",
+    "AD WASM No Leak",
+];
+
+const LEGACY_STATUS_COLUMNS: &[&str] = &[
+    "Test",
+    "Compiled",
+    "R1CS",
+    "Rows",
+    "Cols",
+    "Bytecode Size",
+    "WASM Size",
+    "Compile",
+    "Witgen Run VM",
+    "Witgen Correct",
+    "Witgen No Leak",
+    "AD Run VM",
+    "AD Correct",
+    "AD No Leak",
+    "WASM Compile",
+    "Witgen WASM Run",
+    "Witgen WASM Correct",
+    "Witgen WASM No Leak",
+    "AD WASM Run",
+    "AD WASM Correct",
+    "AD WASM No Leak",
+];
+
+fn markdown_cells(line: &str) -> Vec<String> {
+    line.split('|')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
 }
 
 fn parse_status_rows(path: &Path) -> Vec<ParsedRow> {
     let content =
         fs::read_to_string(path).unwrap_or_else(|_| panic!("Cannot read {}", path.display()));
+    let header = content
+        .lines()
+        .next()
+        .map(markdown_cells)
+        .unwrap_or_default();
     let mut result = Vec::new();
     for line in content.lines().skip(2) {
-        let cells: Vec<String> = line
-            .split('|')
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-            .collect();
-        if cells.len() < 21 {
+        let source_cells = markdown_cells(line);
+        if source_cells.len() < header.len() {
             continue;
         }
+        // Normalize both the current schema and the immediately preceding schema into the current
+        // column order. This lets the first PR adding sidecar metrics compare against an older
+        // baseline; the absent baseline metrics become `-` and start participating in growth
+        // reports once both sides have measured values.
+        let cells: Vec<String> = STATUS_COLUMNS
+            .iter()
+            .map(|column| {
+                header
+                    .iter()
+                    .position(|candidate| candidate == column)
+                    .and_then(|index| source_cells.get(index))
+                    .cloned()
+                    .unwrap_or_else(|| "-".to_string())
+            })
+            .collect();
         let rows = cells[3].parse().ok();
         let cols = cells[4].parse().ok();
         let size_bytes = cells[5].parse().ok();
-        let wasm_size_bytes = cells[6].parse().ok();
+        let vm_debug_size_bytes = cells[6].parse().ok();
+        let wasm_size_bytes = cells[7].parse().ok();
+        let wasm_debug_size_bytes = cells[8].parse().ok();
         result.push(ParsedRow {
             name: cells[0].clone(),
             cells,
             rows,
             cols,
             size_bytes,
+            vm_debug_size_bytes,
             wasm_size_bytes,
+            wasm_debug_size_bytes,
         });
     }
     result
@@ -1756,47 +1866,45 @@ fn parse_status_rows(path: &Path) -> Vec<ParsedRow> {
 const REGRESSION_COLS: &[(usize, &str)] = &[
     (1, "Compiled"),
     (2, "R1CS"),
-    (7, "Compile"),
-    (8, "Witgen Run VM"),
-    (9, "Witgen Correct"),
-    (10, "Witgen No Leak"),
-    (11, "AD Run VM"),
-    (12, "AD Correct"),
-    (13, "AD No Leak"),
-    (14, "WASM Compile"),
-    (15, "Witgen WASM Run"),
-    (16, "Witgen WASM Correct"),
-    (17, "Witgen WASM No Leak"),
-    (18, "AD WASM Run"),
-    (19, "AD WASM Correct"),
-    (20, "AD WASM No Leak"),
+    (9, "Compile"),
+    (10, "Witgen Run VM"),
+    (11, "Witgen Correct"),
+    (12, "Witgen No Leak"),
+    (13, "AD Run VM"),
+    (14, "AD Correct"),
+    (15, "AD No Leak"),
+    (16, "WASM Compile"),
+    (17, "Witgen WASM Run"),
+    (18, "Witgen WASM Correct"),
+    (19, "Witgen WASM No Leak"),
+    (20, "AD WASM Run"),
+    (21, "AD WASM Correct"),
+    (22, "AD WASM No Leak"),
 ];
 
-/// Verify the table's header matches the column layout the index-based checks assume. Without
-/// this, a stale-format status file (e.g. a baseline from before a column change) still has enough
-/// cells to parse, so the checks would silently compare misaligned columns.
+/// Accept the current table layout and the immediately preceding layout, which the parser
+/// normalizes by column name. Reject anything else instead of silently comparing misaligned data.
 fn validate_layout(path: &Path) {
     let content =
         fs::read_to_string(path).unwrap_or_else(|_| panic!("Cannot read {}", path.display()));
-    let header: Vec<String> = content
+    let header = content
         .lines()
         .next()
-        .unwrap_or_default()
-        .split('|')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
+        .map(markdown_cells)
+        .unwrap_or_default();
+    let current: Vec<String> = STATUS_COLUMNS
+        .iter()
+        .map(|value| value.to_string())
         .collect();
-    for &(col, name) in REGRESSION_COLS {
-        let found = header.get(col).map(String::as_str).unwrap_or("<missing>");
-        assert_eq!(
-            found,
-            name,
-            "Status table {} has an unexpected layout (column {col} is {found:?}, expected {name:?}). \
-             Regenerate the baseline — the regression/growth checks compare columns by position and \
-             cannot align mismatched layouts.",
-            path.display(),
-        );
-    }
+    let legacy: Vec<String> = LEGACY_STATUS_COLUMNS
+        .iter()
+        .map(|value| value.to_string())
+        .collect();
+    assert!(
+        header == current || header == legacy,
+        "Status table {} has an unsupported layout. Regenerate it with this test runner.",
+        path.display(),
+    );
 }
 
 /// A cell counts as "handled" if it passed (✅) or the stage legitimately did not apply (N/A).
@@ -1871,7 +1979,9 @@ fn check_growth(baseline_path: &Path, current_path: &Path) {
     let mut constraint_changes = MetricChanges::new("Constraints");
     let mut witness_changes = MetricChanges::new("Witnesses");
     let mut bytecode_changes = MetricChanges::new("Bytecode Size (bytes)");
+    let mut vm_debug_changes = MetricChanges::new("VM Debug Sidecar Size (bytes)");
     let mut wasm_changes = MetricChanges::new("WASM Size (bytes)");
+    let mut wasm_debug_changes = MetricChanges::new("WASM Debug Sidecar Size (bytes)");
 
     for cur in &current {
         // Success rate counts handled cells (✅ or N/A) over every cell. N/A is a legitimate
@@ -1918,8 +2028,14 @@ fn check_growth(baseline_path: &Path, current_path: &Path) {
         if let (Some(bs), Some(cs)) = (base.size_bytes, cur.size_bytes) {
             bytecode_changes.record(&cur.name, bs, cs);
         }
+        if let (Some(bs), Some(cs)) = (base.vm_debug_size_bytes, cur.vm_debug_size_bytes) {
+            vm_debug_changes.record(&cur.name, bs, cs);
+        }
         if let (Some(bw), Some(cw)) = (base.wasm_size_bytes, cur.wasm_size_bytes) {
             wasm_changes.record(&cur.name, bw, cw);
+        }
+        if let (Some(bw), Some(cw)) = (base.wasm_debug_size_bytes, cur.wasm_debug_size_bytes) {
+            wasm_debug_changes.record(&cur.name, bw, cw);
         }
     }
 
@@ -1954,7 +2070,9 @@ fn check_growth(baseline_path: &Path, current_path: &Path) {
         &constraint_changes,
         &witness_changes,
         &bytecode_changes,
+        &vm_debug_changes,
         &wasm_changes,
+        &wasm_debug_changes,
     ];
     let any_decreases = metrics.iter().any(|m| !m.decreases.is_empty());
     let any_increases = metrics.iter().any(|m| !m.increases.is_empty());
@@ -2069,29 +2187,36 @@ impl MetricChanges {
     }
 }
 
-// The program is a single artifact with both the witgen and AD entry points, so it has one
-// `Size` column and one `Compile` / `WASM Compile` column each. The run/correctness/leak columns
-// stay split because witgen and AD are distinct executions of their respective entry points.
+// The program is a single artifact with both the witgen and AD entry points, so each target has
+// one executable size, one debug-sidecar size, and one compile column. The run/correctness/leak
+// columns stay split because witgen and AD are distinct executions of their respective entry
+// points.
 fn render_markdown(results: &[TestResult]) -> String {
     let mut md = String::new();
-    md.push_str("| Test | Compiled | R1CS | Rows | Cols | Bytecode Size | WASM Size | Compile | Witgen Run VM | Witgen Correct | Witgen No Leak | AD Run VM | AD Correct | AD No Leak | WASM Compile | Witgen WASM Run | Witgen WASM Correct | Witgen WASM No Leak | AD WASM Run | AD WASM Correct | AD WASM No Leak |\n");
-    md.push_str("|------|----------|------|------|------|---------------|-----------|---------|---------------|----------------|----------------|-----------|------------|------------|--------------|-----------------|---------------------|---------------------|-------------|---------------------|---------------------|\n");
+    md.push_str("| Test | Compiled | R1CS | Rows | Cols | Bytecode Size | VM Debug Sidecar Size | WASM Size | WASM Debug Sidecar Size | Compile | Witgen Run VM | Witgen Correct | Witgen No Leak | AD Run VM | AD Correct | AD No Leak | WASM Compile | Witgen WASM Run | Witgen WASM Correct | Witgen WASM No Leak | AD WASM Run | AD WASM Correct | AD WASM No Leak |\n");
+    md.push_str("|------|----------|------|------|------|---------------|-----------------------|-----------|-------------------------|---------|---------------|----------------|----------------|-----------|------------|------------|--------------|-----------------|---------------------|---------------------|-------------|---------------------|---------------------|\n");
 
     for r in results {
         let s = |key: &str| r.steps.get(key).copied().unwrap_or(Status::Skip).emoji();
         let rows = r.rows.map_or("-".to_string(), |v| v.to_string());
         let cols = r.cols.map_or("-".to_string(), |v| v.to_string());
         let size = r.binary_bytes.map_or("-".to_string(), |v| v.to_string());
+        let vm_debug_size = r.vm_debug_bytes.map_or("-".to_string(), |v| v.to_string());
         let wasm_size = r.wasm_bytes.map_or("-".to_string(), |v| v.to_string());
+        let wasm_debug_size = r
+            .wasm_debug_bytes
+            .map_or("-".to_string(), |v| v.to_string());
         md.push_str(&format!(
-            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n",
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n",
             r.name,
             s("COMPILED"),
             s("R1CS"),
             rows,
             cols,
             size,
+            vm_debug_size,
             wasm_size,
+            wasm_debug_size,
             s("COMPILE"),
             s("WITGEN_RUN"),
             s("WITGEN_CORRECT"),
@@ -2130,6 +2255,63 @@ mod tests {
 
         assert_eq!(result.steps["COMPILED"], Status::Pass);
         assert_eq!(result.steps["R1CS"], Status::Skip);
+    }
+
+    #[test]
+    fn parses_executable_and_debug_sidecar_sizes() {
+        let result = parse_child_output(
+            "sizes",
+            TestExpectation::ExecutionSuccess,
+            &lines(&[
+                "START:COMPILE",
+                "END:COMPILE:ok:128:456",
+                "START:WASM_COMPILE",
+                "END:WASM_COMPILE:ok:789:1234",
+            ]),
+        );
+
+        assert_eq!(result.binary_bytes, Some(128));
+        assert_eq!(result.vm_debug_bytes, Some(456));
+        assert_eq!(result.wasm_bytes, Some(789));
+        assert_eq!(result.wasm_debug_bytes, Some(1234));
+
+        let markdown = render_markdown(&[result]);
+        let mut rendered_lines = markdown.lines();
+        assert_eq!(
+            markdown_cells(rendered_lines.next().unwrap()),
+            STATUS_COLUMNS
+        );
+        rendered_lines.next();
+        let row = markdown_cells(rendered_lines.next().unwrap());
+        assert_eq!(row.len(), STATUS_COLUMNS.len());
+        assert_eq!(&row[5..9], ["128", "456", "789", "1234"]);
+    }
+
+    #[test]
+    fn legacy_status_rows_are_normalized_for_baseline_comparisons() {
+        let mut status = tempfile::NamedTempFile::new().unwrap();
+        writeln!(status, "| {} |", LEGACY_STATUS_COLUMNS.join(" | ")).unwrap();
+        writeln!(
+            status,
+            "| {} |",
+            vec!["---"; LEGACY_STATUS_COLUMNS.len()].join(" | ")
+        )
+        .unwrap();
+        writeln!(
+            status,
+            "| example | ✅ | ✅ | 10 | 20 | 30 | 40 | ✅ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ | ✅ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |"
+        )
+        .unwrap();
+
+        validate_layout(status.path());
+        let rows = parse_status_rows(status.path());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].size_bytes, Some(30));
+        assert_eq!(rows[0].vm_debug_size_bytes, None);
+        assert_eq!(rows[0].wasm_size_bytes, Some(40));
+        assert_eq!(rows[0].wasm_debug_size_bytes, None);
+        assert_eq!(rows[0].cells[9], "✅");
+        assert_eq!(rows[0].cells[16], "✅");
     }
 
     #[test]

--- a/compiler/src/bin/test_runner.rs
+++ b/compiler/src/bin/test_runner.rs
@@ -213,7 +213,7 @@ fn run_single(root: PathBuf, expect_failure: bool) {
 
     // 3. Compile bytecode: a single binary holding both the witgen and AD entry points, plus its
     //    standalone debug sidecar (depends on R1CS).
-    let program_binary = r1cs.as_ref().and_then(|_| {
+    let program_artifact = r1cs.as_ref().and_then(|_| {
         emit("START:COMPILE");
         match driver.compile_bytecode_artifact(checking_codegen) {
             Ok(artifact) => {
@@ -227,7 +227,7 @@ fn run_single(root: PathBuf, expect_failure: bool) {
                 .expect("VM debug info must serialize")
                 .len();
                 emit(&format!("END:COMPILE:ok:{bytes}:{debug_bytes}"));
-                Some(artifact.binary)
+                Some(artifact)
             }
             Err(_) => {
                 emit("END:COMPILE:fail");
@@ -242,11 +242,17 @@ fn run_single(root: PathBuf, expect_failure: bool) {
     let ordered_params = load_inputs(&driver.package_root().join("Prover.toml"), &driver);
 
     // 4. Run witgen  (depends on COMPILE)
-    let witgen_result = program_binary.as_ref().and_then(|binary| {
+    let witgen_result = program_artifact.as_ref().and_then(|artifact| {
         emit("START:WITGEN_RUN");
         let r1cs = r1cs.as_ref().unwrap();
         let params = ordered_params.as_ref().map(|v| v.as_slice()).unwrap_or(&[]);
-        match interpreter::run(binary, r1cs.witness_layout, r1cs.constraints_layout, params) {
+        match interpreter::run(
+            &artifact.binary,
+            r1cs.witness_layout,
+            r1cs.constraints_layout,
+            params,
+            artifact.debug_info.clone(),
+        ) {
             Ok(result) => {
                 emit("END:WITGEN_RUN:ok");
                 Some(result)
@@ -290,10 +296,10 @@ fn run_single(root: PathBuf, expect_failure: bool) {
 
     // 7. Run AD  (depends on COMPILE, independent of witgen). Skipped for expected-failure
     //    tests, so the native AD steps report as not-applicable.
-    let ad_result = program_binary
+    let ad_result = program_artifact
         .as_ref()
         .filter(|_| !expect_failure)
-        .and_then(|binary| {
+        .and_then(|artifact| {
             emit("START:AD_RUN");
             let r1cs = r1cs.as_ref().unwrap();
             let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -301,10 +307,11 @@ fn run_single(root: PathBuf, expect_failure: bool) {
                 .map(|_| ark_bn254::Fr::rand(&mut rng))
                 .collect();
             match interpreter::run_ad(
-                binary,
+                &artifact.binary,
                 &ad_coeffs,
                 r1cs.witness_layout,
                 r1cs.constraints_layout,
+                artifact.debug_info.clone(),
             ) {
                 Ok((ad_a, ad_b, ad_c, ad_instrumenter)) => {
                     emit("END:AD_RUN:ok");
@@ -1783,6 +1790,8 @@ const STATUS_COLUMNS: &[&str] = &[
     "AD WASM No Leak",
 ];
 
+/// Frozen schema for baselines generated before debug-sidecar size columns were added. Do not
+/// modify it; add a new compatibility schema if the report layout changes again.
 const LEGACY_STATUS_COLUMNS: &[&str] = &[
     "Test",
     "Compiled",
@@ -2193,8 +2202,11 @@ impl MetricChanges {
 // points.
 fn render_markdown(results: &[TestResult]) -> String {
     let mut md = String::new();
-    md.push_str("| Test | Compiled | R1CS | Rows | Cols | Bytecode Size | VM Debug Sidecar Size | WASM Size | WASM Debug Sidecar Size | Compile | Witgen Run VM | Witgen Correct | Witgen No Leak | AD Run VM | AD Correct | AD No Leak | WASM Compile | Witgen WASM Run | Witgen WASM Correct | Witgen WASM No Leak | AD WASM Run | AD WASM Correct | AD WASM No Leak |\n");
-    md.push_str("|------|----------|------|------|------|---------------|-----------------------|-----------|-------------------------|---------|---------------|----------------|----------------|-----------|------------|------------|--------------|-----------------|---------------------|---------------------|-------------|---------------------|---------------------|\n");
+    md.push_str(&format!("| {} |\n", STATUS_COLUMNS.join(" | ")));
+    md.push_str(&format!(
+        "| {} |\n",
+        vec!["---"; STATUS_COLUMNS.len()].join(" | ")
+    ));
 
     for r in results {
         let s = |key: &str| r.steps.get(key).copied().unwrap_or(Status::Skip).emoji();

--- a/compiler/src/compiler/codegen/llssa_to_llvm.rs
+++ b/compiler/src/compiler/codegen/llssa_to_llvm.rs
@@ -50,7 +50,7 @@ pub struct WasmCompileOpts {
     pub runtime_lib: std::path::PathBuf,
     /// Strip this prefix from source paths embedded in DWARF.
     pub debug_path_root: Option<std::path::PathBuf>,
-    /// Retain DWARF sections in the linked WASM artifact.
+    /// Emit DWARF sections into a standalone debug WASM beside the stripped executable.
     pub include_debug_info: bool,
 }
 
@@ -1622,8 +1622,42 @@ impl<'ctx> LLVMCodeGen<'ctx> {
             panic!("wasm-ld failed with status: {}", output.status);
         }
 
+        let debug_path = wasm_debug_info_path(path);
+        if opts.include_debug_info {
+            let linked = std::fs::read(path).unwrap_or_else(|error| {
+                panic!("failed to read linked WASM {}: {error}", path.display())
+            });
+            let external_url = debug_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .expect("WASM debug sidecar path must have a UTF-8 filename");
+            let (stripped, debug) = crate::wasm_debug::split_debug_info(&linked, external_url)
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "failed to split WASM debug info from {}: {error}",
+                        path.display()
+                    )
+                });
+            std::fs::write(path, stripped).unwrap_or_else(|error| {
+                panic!("failed to write stripped WASM {}: {error}", path.display())
+            });
+            std::fs::write(&debug_path, debug).unwrap_or_else(|error| {
+                panic!(
+                    "failed to write WASM debug sidecar {}: {error}",
+                    debug_path.display()
+                )
+            });
+        } else {
+            std::fs::remove_file(debug_path).ok();
+        }
+
         std::fs::remove_file(&obj_path).ok();
     }
+}
+
+/// Path used for a WASM module's standalone DWARF sidecar.
+pub fn wasm_debug_info_path(wasm_path: &Path) -> std::path::PathBuf {
+    wasm_path.with_extension("debug.wasm")
 }
 
 #[cfg(test)]
@@ -1639,6 +1673,14 @@ mod tests {
             },
         },
     };
+
+    #[test]
+    fn wasm_debug_sidecar_has_a_wasm_extension() {
+        assert_eq!(
+            wasm_debug_info_path(Path::new("target/program.wasm")),
+            Path::new("target/program.debug.wasm")
+        );
+    }
 
     #[test]
     fn emits_instruction_source_locations_as_llvm_debug_info() {

--- a/compiler/src/driver.rs
+++ b/compiler/src/driver.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use ark_ff::AdditiveGroup as _;
+use mavros_vm::bytecode::DebugInfo;
 use noirc_frontend::{
     debug::DebugInstrumenter,
     monomorphization::{Monomorphizer, debug_types::DebugTypeTracker},
@@ -67,6 +68,12 @@ use crate::{
         untaint_control_flow::UntaintControlFlow,
     },
 };
+
+/// Executable VM bytecode plus optional standalone source metadata.
+pub struct BytecodeArtifact {
+    pub binary: Vec<u64>,
+    pub debug_info: Option<DebugInfo>,
+}
 
 pub struct Driver {
     project: Project,
@@ -481,6 +488,15 @@ impl Driver {
 
     /// Compiles the program (both the witgen and AD entry points) into a single VM binary.
     pub fn compile_bytecode(&mut self, options: CodeGenOptions) -> Result<Vec<u64>, Error> {
+        Ok(self.compile_bytecode_artifact(options)?.binary)
+    }
+
+    /// Compiles VM bytecode and, when requested, returns debug information as a separate value.
+    /// The executable `binary` is identical regardless of `include_debug_info`.
+    pub fn compile_bytecode_artifact(
+        &mut self,
+        options: CodeGenOptions,
+    ) -> Result<BytecodeArtifact, Error> {
         self.prepare_program_ssa();
         let ssa = self.program_ssa.as_ref().unwrap();
 
@@ -494,15 +510,16 @@ impl Driver {
             format!("{}", program),
         );
 
-        let binary = if options.include_debug_info {
-            program.to_binary()
+        let (binary, debug_info) = if options.include_debug_info {
+            let (binary, debug_info) = program.to_binary_and_debug_info();
+            (binary, Some(debug_info))
         } else {
-            program.to_binary_without_debug_info()
+            (program.to_binary(), None)
         };
 
         info!(message = %"Program binary generated", binary_size = binary.len() * 8);
 
-        Ok(binary)
+        Ok(BytecodeArtifact { binary, debug_info })
     }
 
     pub fn abi(&self) -> &noirc_abi::Abi {
@@ -661,8 +678,14 @@ impl Driver {
 
         if let Some((wasm_path, wasm_opts)) = wasm_config {
             codegen.write_ir(&wasm_path.with_extension("ll"));
+            let debug_path = wasm_opts
+                .include_debug_info
+                .then(|| crate::compiler::codegen::llssa_to_llvm::wasm_debug_info_path(&wasm_path));
             codegen.compile_to_wasm(&wasm_path, wasm_opts);
             info!(message = %"WASM object generated", path = %wasm_path.display());
+            if let Some(debug_path) = debug_path {
+                info!(message = %"WASM debug info generated", path = %debug_path.display());
+            }
             self.write_wasm_metadata(&wasm_path, r1cs)?;
         }
 

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -5,6 +5,7 @@ pub mod driver;
 pub mod error;
 pub mod plotting;
 pub mod project;
+pub mod wasm_debug;
 pub mod wasm_runtime;
 
 pub use mavros_artifacts as artifacts;

--- a/compiler/src/wasm_debug.rs
+++ b/compiler/src/wasm_debug.rs
@@ -1,0 +1,225 @@
+//! Utilities for external WebAssembly DWARF sidecars.
+
+const WASM_HEADER: &[u8; 8] = b"\0asm\x01\0\0\0";
+const EXTERNAL_DEBUG_INFO: &str = "external_debug_info";
+
+struct Section<'a> {
+    id: u8,
+    bytes: &'a [u8],
+    custom_name: Option<&'a str>,
+    custom_data: Option<&'a [u8]>,
+}
+
+fn read_u32(bytes: &[u8], mut offset: usize) -> Result<(u32, usize), String> {
+    let mut value = 0u32;
+    for shift in (0..35).step_by(7) {
+        let byte = *bytes
+            .get(offset)
+            .ok_or_else(|| "truncated unsigned LEB128 value".to_string())?;
+        offset += 1;
+        value |= u32::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Ok((value, offset));
+        }
+    }
+    Err("invalid unsigned LEB128 value".to_string())
+}
+
+fn write_u32(mut value: u32, output: &mut Vec<u8>) {
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        output.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+}
+
+fn sections(bytes: &[u8]) -> Result<Vec<Section<'_>>, String> {
+    if !bytes.starts_with(WASM_HEADER) {
+        return Err("invalid WebAssembly header".to_string());
+    }
+
+    let mut result = Vec::new();
+    let mut offset = WASM_HEADER.len();
+    while offset < bytes.len() {
+        let section_start = offset;
+        let id = bytes[offset];
+        offset += 1;
+        let (payload_len, payload_start) = read_u32(bytes, offset)?;
+        let section_end = payload_start
+            .checked_add(payload_len as usize)
+            .filter(|end| *end <= bytes.len())
+            .ok_or_else(|| "section extends beyond end of WebAssembly module".to_string())?;
+
+        let (custom_name, custom_data) = if id == 0 {
+            let (name_len, name_start) = read_u32(bytes, payload_start)?;
+            let name_end = name_start
+                .checked_add(name_len as usize)
+                .filter(|end| *end <= section_end)
+                .ok_or_else(|| "custom-section name extends beyond its payload".to_string())?;
+            let name = std::str::from_utf8(&bytes[name_start..name_end])
+                .map_err(|_| "custom-section name is not UTF-8".to_string())?;
+            (Some(name), Some(&bytes[name_end..section_end]))
+        } else {
+            (None, None)
+        };
+
+        result.push(Section {
+            id,
+            bytes: &bytes[section_start..section_end],
+            custom_name,
+            custom_data,
+        });
+        offset = section_end;
+    }
+    Ok(result)
+}
+
+fn is_dwarf_section(name: &str) -> bool {
+    name.starts_with(".debug_") || name.starts_with(".zdebug_") || name.starts_with("reloc..debug_")
+}
+
+fn append_custom_section(output: &mut Vec<u8>, name: &str, contents: &[u8]) {
+    output.push(0);
+    let name_len = u32::try_from(name.len()).expect("WASM custom-section name is too large");
+    let mut payload = Vec::new();
+    write_u32(name_len, &mut payload);
+    payload.extend_from_slice(name.as_bytes());
+    payload.extend_from_slice(contents);
+    let payload_len = u32::try_from(payload.len()).expect("WASM custom section is too large");
+    write_u32(payload_len, output);
+    output.extend_from_slice(&payload);
+}
+
+/// Strip DWARF from an executable module, add its sidecar URL, and retain the original linked
+/// module as the standalone debug companion. Keeping the module structure in the companion is
+/// compatible with browser DWARF tooling that needs type, function, and code sections.
+pub(crate) fn split_debug_info(
+    bytes: &[u8],
+    external_url: &str,
+) -> Result<(Vec<u8>, Vec<u8>), String> {
+    let mut executable = WASM_HEADER.to_vec();
+    let mut found_dwarf = false;
+    for section in sections(bytes)? {
+        let name = section.custom_name.unwrap_or_default();
+        if is_dwarf_section(name) {
+            found_dwarf = true;
+            continue;
+        }
+        // Replace a stale association rather than emitting duplicate URLs.
+        if section.id == 0 && name == EXTERNAL_DEBUG_INFO {
+            continue;
+        }
+        executable.extend_from_slice(section.bytes);
+    }
+    if !found_dwarf {
+        return Err("linked WebAssembly module contains no DWARF sections".to_string());
+    }
+    append_custom_section(
+        &mut executable,
+        EXTERNAL_DEBUG_INFO,
+        external_url.as_bytes(),
+    );
+    Ok((executable, bytes.to_vec()))
+}
+
+/// Read the relative URL stored in a module's `external_debug_info` custom section.
+pub fn external_debug_info_url(bytes: &[u8]) -> Result<Option<String>, String> {
+    for section in sections(bytes)? {
+        if section.custom_name == Some(EXTERNAL_DEBUG_INFO) {
+            let url = std::str::from_utf8(section.custom_data.unwrap_or_default())
+                .map_err(|_| "external_debug_info URL is not UTF-8".to_string())?;
+            return Ok(Some(url.to_string()));
+        }
+    }
+    Ok(None)
+}
+
+/// Combine a stripped executable and its debug companion in memory for runtimes such as Wasmtime
+/// that consume embedded DWARF but do not follow `external_debug_info` themselves.
+pub fn merge_debug_info(executable: &[u8], debug: &[u8]) -> Result<Vec<u8>, String> {
+    let mut merged = WASM_HEADER.to_vec();
+    for section in sections(executable)? {
+        if !section.custom_name.is_some_and(is_dwarf_section) {
+            merged.extend_from_slice(section.bytes);
+        }
+    }
+
+    let mut found_dwarf = false;
+    for section in sections(debug)? {
+        if section.custom_name.is_some_and(is_dwarf_section) {
+            found_dwarf = true;
+            merged.extend_from_slice(section.bytes);
+        }
+    }
+    if !found_dwarf {
+        return Err("debug companion contains no DWARF sections".to_string());
+    }
+    Ok(merged)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn custom_section(name: &str, contents: &[u8]) -> Vec<u8> {
+        let mut section = WASM_HEADER.to_vec();
+        append_custom_section(&mut section, name, contents);
+        section.drain(..WASM_HEADER.len());
+        section
+    }
+
+    #[test]
+    fn split_module_links_to_full_debug_companion() {
+        let mut module = WASM_HEADER.to_vec();
+        module.extend_from_slice(&[1, 1, 0]);
+        module.extend(custom_section("name", &[1, 2]));
+        module.extend(custom_section(".debug_info", &[3, 4, 5]));
+        module.extend(custom_section(".debug_line", &[6, 7]));
+
+        let (executable, debug) = split_debug_info(&module, "program.debug.wasm").unwrap();
+
+        assert_eq!(
+            external_debug_info_url(&executable).unwrap().as_deref(),
+            Some("program.debug.wasm")
+        );
+        assert!(
+            !executable
+                .windows(11)
+                .any(|window| window == b".debug_info")
+        );
+        assert!(debug.windows(11).any(|window| window == b".debug_info"));
+        assert!(debug.windows(4).any(|window| window == b"name"));
+        assert!(debug.windows(3).any(|window| window == [1, 1, 0]));
+    }
+
+    #[test]
+    fn merged_runtime_module_restores_dwarf_without_duplicate_code() {
+        let mut module = WASM_HEADER.to_vec();
+        module.extend_from_slice(&[1, 1, 0]);
+        module.extend(custom_section(".debug_info", &[3, 4, 5]));
+        let (executable, debug) = split_debug_info(&module, "program.debug.wasm").unwrap();
+
+        let merged = merge_debug_info(&executable, &debug).unwrap();
+
+        assert_eq!(
+            merged
+                .windows(3)
+                .filter(|window| *window == [1, 1, 0])
+                .count(),
+            1
+        );
+        assert_eq!(
+            merged
+                .windows(11)
+                .filter(|window| *window == b".debug_info")
+                .count(),
+            1
+        );
+    }
+}

--- a/compiler/src/wasm_runtime.rs
+++ b/compiler/src/wasm_runtime.rs
@@ -5,12 +5,86 @@
 //! and never invokes cargo itself. Binaries (the CLI, the test runner) resolve the runtime up
 //! front and thread the path through.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Environment variable pointing at a pre-built wasm-runtime static library. When set,
 /// [`locate_or_build`] uses it directly instead of invoking cargo.
 pub const WASM_RUNTIME_LIB_ENV: &str = "MAVROS_WASM_RUNTIME_LIB";
+
+/// Build a Wasmtime module from compact executable bytes and a separate DWARF companion.
+///
+/// Wasmtime 31 consumes embedded DWARF but does not follow the browser-oriented
+/// `external_debug_info` section itself, so this reconstructs an in-memory module for compilation.
+/// The executable file on disk remains stripped.
+pub fn wasmtime_module_with_debug_info(
+    engine: &wasmtime::Engine,
+    executable: &[u8],
+    debug: &[u8],
+) -> wasmtime::Result<wasmtime::Module> {
+    let merged =
+        crate::wasm_debug::merge_debug_info(executable, debug).map_err(wasmtime::Error::msg)?;
+    wasmtime::Module::new(engine, merged)
+}
+
+/// Load a Wasmtime module from explicitly supplied executable and debug-sidecar paths.
+pub fn load_wasmtime_module_with_debug_info(
+    engine: &wasmtime::Engine,
+    wasm_path: impl AsRef<Path>,
+    debug_path: impl AsRef<Path>,
+) -> wasmtime::Result<wasmtime::Module> {
+    let wasm_path = wasm_path.as_ref();
+    let debug_path = debug_path.as_ref();
+    let executable = std::fs::read(wasm_path).map_err(|error| {
+        wasmtime::Error::msg(format!(
+            "failed to read WASM executable {}: {error}",
+            wasm_path.display()
+        ))
+    })?;
+    let debug = std::fs::read(debug_path).map_err(|error| {
+        wasmtime::Error::msg(format!(
+            "failed to read WASM debug sidecar {}: {error}",
+            debug_path.display()
+        ))
+    })?;
+    wasmtime_module_with_debug_info(engine, &executable, &debug)
+}
+
+/// Load a Wasmtime module, automatically following a local `external_debug_info` sidecar when the
+/// executable names one. Modules without an external-debug section load normally.
+pub fn load_wasmtime_module(
+    engine: &wasmtime::Engine,
+    wasm_path: impl AsRef<Path>,
+) -> wasmtime::Result<wasmtime::Module> {
+    let wasm_path = wasm_path.as_ref();
+    let executable = std::fs::read(wasm_path).map_err(|error| {
+        wasmtime::Error::msg(format!(
+            "failed to read WASM executable {}: {error}",
+            wasm_path.display()
+        ))
+    })?;
+    let Some(url) =
+        crate::wasm_debug::external_debug_info_url(&executable).map_err(wasmtime::Error::msg)?
+    else {
+        return wasmtime::Module::new(engine, executable);
+    };
+    if url.contains("://") {
+        return Err(wasmtime::Error::msg(format!(
+            "Wasmtime loader cannot fetch remote external debug URL {url:?}"
+        )));
+    }
+    let debug_path = wasm_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(url);
+    let debug = std::fs::read(&debug_path).map_err(|error| {
+        wasmtime::Error::msg(format!(
+            "failed to read referenced WASM debug sidecar {}: {error}",
+            debug_path.display()
+        ))
+    })?;
+    wasmtime_module_with_debug_info(engine, &executable, &debug)
+}
 
 /// Locate (via [`WASM_RUNTIME_LIB_ENV`]) or build the wasm-runtime static library.
 ///
@@ -60,4 +134,38 @@ pub fn locate_or_build() -> PathBuf {
     }
 
     lib_path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_module_with_empty_dwarf() -> Vec<u8> {
+        let mut module = b"\0asm\x01\0\0\0".to_vec();
+        // () -> () type, one function of that type, and an empty function body.
+        module.extend_from_slice(&[1, 4, 1, 0x60, 0, 0]);
+        module.extend_from_slice(&[3, 2, 1, 0]);
+        module.extend_from_slice(&[10, 4, 1, 2, 0, 0x0b]);
+        module.extend_from_slice(&[0, 12, 11]);
+        module.extend_from_slice(b".debug_info");
+        module
+    }
+
+    #[test]
+    fn wasmtime_loaders_accept_explicit_and_referenced_sidecars() {
+        let dir = tempfile::tempdir().unwrap();
+        let executable_path = dir.path().join("program.wasm");
+        let debug_path = dir.path().join("program.debug.wasm");
+        let (executable, debug) = crate::wasm_debug::split_debug_info(
+            &minimal_module_with_empty_dwarf(),
+            "program.debug.wasm",
+        )
+        .unwrap();
+        std::fs::write(&executable_path, executable).unwrap();
+        std::fs::write(&debug_path, debug).unwrap();
+
+        let engine = wasmtime::Engine::default();
+        load_wasmtime_module_with_debug_info(&engine, &executable_path, &debug_path).unwrap();
+        load_wasmtime_module(&engine, &executable_path).unwrap();
+    }
 }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -108,9 +108,28 @@ This works as follows:
 3. A `.wasm.meta.json` sidecar file is written alongside the `.wasm` with the ABI and R1CS layout
    info, so the host knows how to set up the witness generator's inputs and interpret its outputs.
 
-Running with `--emit-wasm` will execute the full compilation pipeline, and _additionall_ emit the
+Running with `--emit-wasm` will execute the full compilation pipeline, and _additionally_ emit the
 `mavros_debug/program.wasm` and `mavros_debug/program.wasm.meta.json`. This can be combined with the
 `--emit-llvm` flag to also save the intermediate LLVM IR as an `.ll` file.
+
+Pass `--include-debug-info` to additionally emit `mavros_debug/program.debug.wasm`. It is a valid,
+standalone WebAssembly debug companion containing the module structure and DWARF custom sections.
+`program.wasm` remains stripped apart from a tiny `external_debug_info` custom section pointing to
+the relative `program.debug.wasm` URL. Browser developer tools can therefore fetch the sidecar
+automatically when both files are served from the same directory.
+
+Wasmtime 31 does not follow `external_debug_info` itself. Rust hosts can use
+`mavros_compiler::wasm_runtime::load_wasmtime_module`, which follows the local reference, or
+`load_wasmtime_module_with_debug_info`, which accepts both paths explicitly. Both reconstruct the
+DWARF-bearing module in memory while leaving the executable artifact stripped on disk.
+
+```rust
+let module = mavros_compiler::wasm_runtime::load_wasmtime_module_with_debug_info(
+    &engine,
+    "mavros_debug/program.wasm",
+    "mavros_debug/program.debug.wasm",
+)?;
+```
 
 > **Note:** WASM output is only currently available via the default command (no subcommand), not via
 > `mavros compile`.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -116,7 +116,8 @@ Pass `--include-debug-info` to additionally emit `mavros_debug/program.debug.was
 standalone WebAssembly debug companion containing the module structure and DWARF custom sections.
 `program.wasm` remains stripped apart from a tiny `external_debug_info` custom section pointing to
 the relative `program.debug.wasm` URL. Browser developer tools can therefore fetch the sidecar
-automatically when both files are served from the same directory.
+automatically when both files are served from the same directory. DWARF source paths are relative to
+the Noir package root by default; pass `--absolute-paths` to retain absolute paths.
 
 Wasmtime 31 does not follow `external_debug_info` itself. Rust hosts can use
 `mavros_compiler::wasm_runtime::load_wasmtime_module`, which follows the local reference, or

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -20,6 +20,7 @@ mavros-opcode-gen.workspace = true
 
 # All other dependencies
 ark-ff.workspace = true
+serde.workspace = true
 tracing.workspace = true
 
 [lints]

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -23,5 +23,8 @@ ark-ff.workspace = true
 serde.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+serde_json = { version = "1.0" }
+
 [lints]
 workspace = true

--- a/vm/src/bytecode.rs
+++ b/vm/src/bytecode.rs
@@ -3,12 +3,12 @@
 use crate::{ConstraintsLayout, Field, TableKind, WitnessLayout};
 use ark_ff::{AdditiveGroup as _, BigInteger as _};
 use mavros_opcode_gen::interpreter;
+use serde::{Deserialize, Serialize};
 
 use crate::array::{BoxedLayout, BoxedValue, StructDescriptor};
 use crate::interpreter::{Frame, Handler};
 
 use crate::array::DataType;
-use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::ptr;
 
@@ -16,7 +16,8 @@ use std::ptr;
 pub const FELT_LIMBS: usize = 4;
 
 /// A user-facing source position attached to generated VM code.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SourceLocation {
     pub file: String,
     pub line: u64,
@@ -56,25 +57,49 @@ impl Display for StackFrame {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+/// A compact, run-length encoded map from VM bytecode word offsets to Noir source locations.
+///
+/// This is serialized separately from the executable bytecode so production programs never pay
+/// for source paths and locations. A location applies from its `code_offset` up to the next
+/// location in the same function.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DebugInfo {
-    functions: Vec<DebugFunction>,
+    pub format_version: u32,
+    pub functions: Vec<DebugFunction>,
 }
 
-#[derive(Clone, Debug)]
-struct DebugFunction {
-    name: String,
-    code_offset: usize,
-    locations: Vec<DebugLocation>,
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugFunction {
+    pub name: String,
+    pub code_offset: usize,
+    pub locations: Vec<DebugLocation>,
 }
 
-#[derive(Clone, Debug)]
-struct DebugLocation {
-    code_offset: usize,
-    location: SourceLocation,
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugLocation {
+    pub code_offset: usize,
+    pub location: SourceLocation,
 }
 
 impl DebugInfo {
+    /// Strip a common root from real source paths while preserving synthetic `<...>` locations.
+    pub fn relativize_source_paths(&mut self, root: &std::path::Path) {
+        for function in &mut self.functions {
+            for location in &mut function.locations {
+                let source = &mut location.location;
+                if source.file.starts_with('<') && source.file.ends_with('>') {
+                    continue;
+                }
+                if let Ok(relative) = std::path::Path::new(&source.file).strip_prefix(root) {
+                    source.file = relative.to_string_lossy().into_owned();
+                }
+            }
+        }
+    }
+
     /// Resolve a word offset in the serialized program to its function and nearest source
     /// location. Callers can pass an address inside an opcode, not only its first word.
     pub fn stack_frame_at(&self, code_offset: usize) -> Option<StackFrame> {
@@ -2441,15 +2466,6 @@ fn decode_struct_field(word: u64) -> (u32, bool) {
 
 const DEBUG_INFO_MAGIC: u64 = u64::from_le_bytes(*b"MAVROSDB");
 
-fn encode_string(binary: &mut Vec<u64>, value: &str) {
-    binary.push(value.len() as u64);
-    for chunk in value.as_bytes().chunks(8) {
-        let mut word = [0u8; 8];
-        word[..chunk.len()].copy_from_slice(chunk);
-        binary.push(u64::from_le_bytes(word));
-    }
-}
-
 fn decode_string(program: &[u64], offset: &mut usize) -> String {
     let byte_len = program[*offset] as usize;
     *offset += 1;
@@ -2464,15 +2480,18 @@ fn decode_string(program: &[u64], offset: &mut usize) -> String {
 }
 
 impl Program {
+    /// Serialize executable VM bytecode. Debug information is never embedded in this output.
     pub fn to_binary(&self) -> Vec<u64> {
-        self.to_binary_with_debug_info(true)
+        self.to_binary_and_debug_info().0
     }
 
+    /// Backwards-compatible alias for [`Program::to_binary`].
     pub fn to_binary_without_debug_info(&self) -> Vec<u64> {
-        self.to_binary_with_debug_info(false)
+        self.to_binary()
     }
 
-    fn to_binary_with_debug_info(&self, include_debug_info: bool) -> Vec<u64> {
+    /// Serialize compact executable bytecode and construct its standalone source map.
+    pub fn to_binary_and_debug_info(&self) -> (Vec<u64>, DebugInfo) {
         let mut binary = Vec::new();
         // Layout-table header: [num_descriptors, ...descriptors...].
         // Each descriptor: [num_fields, field_0_packed, field_1_packed, ...].
@@ -2498,87 +2517,40 @@ impl Program {
         let entry_table_start = binary.len();
         binary.extend(std::iter::repeat(0u64).take(self.entry_points.len()));
 
-        let mut function_debug_slots: Vec<(Option<usize>, Vec<(usize, usize)>)> =
-            (0..self.functions.len())
-                .map(|_| (None, Vec::new()))
-                .collect();
-        if include_debug_info {
-            // Keep debug data in the header so dispatch never steps through it. Source-map records
-            // contain patchable absolute opcode offsets, just like the entry table below.
-            binary.push(DEBUG_INFO_MAGIC);
-            let mut file_indices = BTreeMap::<&str, usize>::new();
-            let mut files = Vec::<&str>::new();
-            for function in &self.functions {
-                assert_eq!(
-                    function.code.len(),
-                    function.source_locations.len(),
-                    "every VM opcode must have a source location"
-                );
-                for location in &function.source_locations {
-                    if !file_indices.contains_key(location.file.as_str()) {
-                        let index = files.len();
-                        file_indices.insert(location.file.as_str(), index);
-                        files.push(location.file.as_str());
-                    }
-                }
-            }
-            binary.push(files.len() as u64);
-            for file in files {
-                encode_string(&mut binary, file);
-            }
-
-            binary.push(self.functions.len() as u64);
-            for (function_index, function) in self.functions.iter().enumerate() {
-                encode_string(&mut binary, &function.name);
-                let function_offset_slot = binary.len();
-                binary.push(0);
-
-                let runs: Vec<(usize, &SourceLocation)> = function
-                    .source_locations
-                    .iter()
-                    .enumerate()
-                    .filter(|(index, location)| {
-                        *index == 0 || function.source_locations[*index - 1] != **location
-                    })
-                    .collect();
-                binary.push(runs.len() as u64);
-                let mut run_slots = Vec::with_capacity(runs.len());
-                for (opcode_index, location) in runs {
-                    let code_offset_slot = binary.len();
-                    binary.push(0);
-                    binary.push(file_indices[location.file.as_str()] as u64);
-                    binary.push(location.line);
-                    binary.push(location.column);
-                    run_slots.push((opcode_index, code_offset_slot));
-                }
-                function_debug_slots[function_index] = (Some(function_offset_slot), run_slots);
-            }
-        }
-
         let mut positions = vec![];
         let mut jumps_to_fix: Vec<(usize, isize)> = vec![];
         let mut function_markers = vec![];
+        let mut debug_functions = Vec::with_capacity(self.functions.len());
 
-        for (function_index, function) in self.functions.iter().enumerate() {
+        for function in &self.functions {
+            assert_eq!(
+                function.code.len(),
+                function.source_locations.len(),
+                "every VM opcode must have a source location"
+            );
             // Function marker
             function_markers.push(binary.len());
-            if let Some(function_offset_slot) = function_debug_slots[function_index].0 {
-                binary[function_offset_slot] = binary.len() as u64;
-            }
+            let function_offset = binary.len();
             binary.push(u64::MAX);
             binary.push(function.frame_size as u64);
 
-            let mut run_slots = function_debug_slots[function_index].1.iter().peekable();
+            let mut locations = Vec::new();
             for (opcode_index, op) in function.code.iter().enumerate() {
-                if let Some((run_opcode_index, patch_slot)) = run_slots.peek()
-                    && *run_opcode_index == opcode_index
-                {
-                    binary[*patch_slot] = binary.len() as u64;
-                    run_slots.next();
+                let location = &function.source_locations[opcode_index];
+                if opcode_index == 0 || function.source_locations[opcode_index - 1] != *location {
+                    locations.push(DebugLocation {
+                        code_offset: binary.len(),
+                        location: location.clone(),
+                    });
                 }
                 positions.push(binary.len());
                 op.to_binary(&mut binary, &mut jumps_to_fix);
             }
+            debug_functions.push(DebugFunction {
+                name: function.name.clone(),
+                code_offset: function_offset,
+                locations,
+            });
         }
 
         for (slot, fn_idx) in self.entry_points.iter().enumerate() {
@@ -2590,7 +2562,13 @@ impl Program {
             binary[jump_position] =
                 (target_pos as isize - (jump_position as isize + add_offset)) as u64;
         }
-        binary
+        (
+            binary,
+            DebugInfo {
+                format_version: 1,
+                functions: debug_functions,
+            },
+        )
     }
 }
 
@@ -2655,7 +2633,10 @@ pub fn parse_program_header(program: &[u64]) -> ProgramHeader {
                 locations,
             });
         }
-        DebugInfo { functions }
+        DebugInfo {
+            format_version: 1,
+            functions,
+        }
     } else {
         DebugInfo::default()
     };
@@ -2721,10 +2702,9 @@ mod tests {
             struct_layouts: Vec::new(),
             constant_pool: Vec::new(),
         };
-        let binary = program.to_binary();
-        let header = parse_program_header(&binary);
-        let main_opcode = header.debug_info.functions[0].locations[0].code_offset;
-        let helper_opcode = header.debug_info.functions[1].locations[0].code_offset;
+        let (binary, debug_info) = program.to_binary_and_debug_info();
+        let main_opcode = debug_info.functions[0].locations[0].code_offset;
+        let helper_opcode = debug_info.functions[1].locations[0].code_offset;
 
         let mut vm = VM::new_witgen(
             ptr::null_mut(),
@@ -2741,7 +2721,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
         );
-        vm.set_debug_context(binary.as_ptr(), binary.len(), header.debug_info);
+        vm.set_debug_context(binary.as_ptr(), binary.len(), debug_info);
 
         let caller = Frame::base_frame(3, &mut vm);
         let callee = Frame::push(3, caller, &mut vm);
@@ -2781,7 +2761,7 @@ mod tests {
     }
 
     #[test]
-    fn bytecode_debug_info_can_be_excluded() {
+    fn bytecode_debug_info_is_always_standalone() {
         let source_location = location("main", 10);
         let program = Program {
             functions: vec![Function {
@@ -2796,19 +2776,20 @@ mod tests {
             constant_pool: Vec::new(),
         };
 
-        let with_debug_info = program.to_binary();
-        let without_debug_info = program.to_binary_without_debug_info();
+        let (binary, debug_info) = program.to_binary_and_debug_info();
 
-        assert!(without_debug_info.len() < with_debug_info.len());
+        assert_eq!(binary, program.to_binary_without_debug_info());
+        assert_eq!(binary, program.to_binary());
         assert!(
-            parse_program_header(&without_debug_info)
+            parse_program_header(&binary)
                 .debug_info
                 .functions
                 .is_empty()
         );
-        assert_eq!(
-            parse_program_header(&without_debug_info).entry_points.len(),
-            1
-        );
+        assert_eq!(debug_info.format_version, 1);
+        assert_eq!(debug_info.functions.len(), 1);
+        assert_eq!(debug_info.functions[0].name, "main");
+        assert_eq!(debug_info.functions[0].locations.len(), 1);
+        assert_eq!(parse_program_header(&binary).entry_points.len(), 1);
     }
 }

--- a/vm/src/bytecode.rs
+++ b/vm/src/bytecode.rs
@@ -3,7 +3,7 @@
 use crate::{ConstraintsLayout, Field, TableKind, WitnessLayout};
 use ark_ff::{AdditiveGroup as _, BigInteger as _};
 use mavros_opcode_gen::interpreter;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::array::{BoxedLayout, BoxedValue, StructDescriptor};
 use crate::interpreter::{Frame, Handler};
@@ -31,6 +31,15 @@ impl SourceLocation {
             line,
             column,
         }
+    }
+}
+
+pub(crate) fn relativize_source_path(path: &mut String, root: &std::path::Path) {
+    if path.starts_with('<') && path.ends_with('>') {
+        return;
+    }
+    if let Ok(relative) = std::path::Path::new(path.as_str()).strip_prefix(root) {
+        *path = relative.to_string_lossy().into_owned();
     }
 }
 
@@ -62,11 +71,38 @@ impl Display for StackFrame {
 /// This is serialized separately from the executable bytecode so production programs never pay
 /// for source paths and locations. A location applies from its `code_offset` up to the next
 /// location in the same function.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub const DEBUG_INFO_FORMAT_VERSION: u32 = 1;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DebugInfo {
-    pub format_version: u32,
+    #[serde(deserialize_with = "deserialize_debug_info_format_version")]
+    format_version: u32,
+    pub files: Vec<String>,
     pub functions: Vec<DebugFunction>,
+}
+
+fn deserialize_debug_info_format_version<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let version = u32::deserialize(deserializer)?;
+    if version != DEBUG_INFO_FORMAT_VERSION {
+        return Err(serde::de::Error::custom(format!(
+            "unsupported VM debug info format version {version}; expected {DEBUG_INFO_FORMAT_VERSION}"
+        )));
+    }
+    Ok(version)
+}
+
+impl Default for DebugInfo {
+    fn default() -> Self {
+        Self {
+            format_version: DEBUG_INFO_FORMAT_VERSION,
+            files: Vec::new(),
+            functions: Vec::new(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -81,22 +117,20 @@ pub struct DebugFunction {
 #[serde(rename_all = "camelCase")]
 pub struct DebugLocation {
     pub code_offset: usize,
-    pub location: SourceLocation,
+    pub file_index: usize,
+    pub line: u64,
+    pub column: u64,
 }
 
 impl DebugInfo {
+    pub fn format_version(&self) -> u32 {
+        self.format_version
+    }
+
     /// Strip a common root from real source paths while preserving synthetic `<...>` locations.
     pub fn relativize_source_paths(&mut self, root: &std::path::Path) {
-        for function in &mut self.functions {
-            for location in &mut function.locations {
-                let source = &mut location.location;
-                if source.file.starts_with('<') && source.file.ends_with('>') {
-                    continue;
-                }
-                if let Ok(relative) = std::path::Path::new(&source.file).strip_prefix(root) {
-                    source.file = relative.to_string_lossy().into_owned();
-                }
-            }
+        for file in &mut self.files {
+            relativize_source_path(file, root);
         }
     }
 
@@ -113,9 +147,14 @@ impl DebugInfo {
             .partition_point(|location| location.code_offset <= code_offset)
             .checked_sub(1)?;
 
+        let location = &function.locations[location_index];
         Some(StackFrame {
             function: function.name.clone(),
-            location: function.locations[location_index].location.clone(),
+            location: SourceLocation::new(
+                self.files.get(location.file_index)?.clone(),
+                location.line,
+                location.column,
+            ),
         })
     }
 }
@@ -2464,25 +2503,10 @@ fn decode_struct_field(word: u64) -> (u32, bool) {
     (size, refcounted)
 }
 
-const DEBUG_INFO_MAGIC: u64 = u64::from_le_bytes(*b"MAVROSDB");
-
-fn decode_string(program: &[u64], offset: &mut usize) -> String {
-    let byte_len = program[*offset] as usize;
-    *offset += 1;
-    let word_len = byte_len.div_ceil(8);
-    let mut bytes = Vec::with_capacity(word_len * 8);
-    for word in &program[*offset..*offset + word_len] {
-        bytes.extend_from_slice(&word.to_le_bytes());
-    }
-    *offset += word_len;
-    bytes.truncate(byte_len);
-    String::from_utf8(bytes).expect("source-map strings must be UTF-8")
-}
-
 impl Program {
     /// Serialize executable VM bytecode. Debug information is never embedded in this output.
     pub fn to_binary(&self) -> Vec<u64> {
-        self.to_binary_and_debug_info().0
+        self.to_binary_impl(false).0
     }
 
     /// Backwards-compatible alias for [`Program::to_binary`].
@@ -2492,6 +2516,14 @@ impl Program {
 
     /// Serialize compact executable bytecode and construct its standalone source map.
     pub fn to_binary_and_debug_info(&self) -> (Vec<u64>, DebugInfo) {
+        let (binary, debug_info) = self.to_binary_impl(true);
+        (
+            binary,
+            debug_info.expect("debug info was requested while serializing VM bytecode"),
+        )
+    }
+
+    fn to_binary_impl(&self, include_debug_info: bool) -> (Vec<u64>, Option<DebugInfo>) {
         let mut binary = Vec::new();
         // Layout-table header: [num_descriptors, ...descriptors...].
         // Each descriptor: [num_fields, field_0_packed, field_1_packed, ...].
@@ -2520,37 +2552,58 @@ impl Program {
         let mut positions = vec![];
         let mut jumps_to_fix: Vec<(usize, isize)> = vec![];
         let mut function_markers = vec![];
-        let mut debug_functions = Vec::with_capacity(self.functions.len());
+        let mut debug_info = include_debug_info.then(|| DebugInfo {
+            functions: Vec::with_capacity(self.functions.len()),
+            ..DebugInfo::default()
+        });
 
         for function in &self.functions {
-            assert_eq!(
-                function.code.len(),
-                function.source_locations.len(),
-                "every VM opcode must have a source location"
-            );
+            if include_debug_info {
+                assert_eq!(
+                    function.code.len(),
+                    function.source_locations.len(),
+                    "every VM opcode must have a source location"
+                );
+            }
             // Function marker
             function_markers.push(binary.len());
             let function_offset = binary.len();
             binary.push(u64::MAX);
             binary.push(function.frame_size as u64);
 
-            let mut locations = Vec::new();
+            let mut locations = debug_info.as_ref().map(|_| Vec::new());
             for (opcode_index, op) in function.code.iter().enumerate() {
-                let location = &function.source_locations[opcode_index];
-                if opcode_index == 0 || function.source_locations[opcode_index - 1] != *location {
-                    locations.push(DebugLocation {
-                        code_offset: binary.len(),
-                        location: location.clone(),
-                    });
+                if let Some(locations) = &mut locations {
+                    let location = &function.source_locations[opcode_index];
+                    if opcode_index == 0 || function.source_locations[opcode_index - 1] != *location
+                    {
+                        let debug_info = debug_info.as_mut().unwrap();
+                        let file_index = debug_info
+                            .files
+                            .iter()
+                            .position(|file| file == &location.file)
+                            .unwrap_or_else(|| {
+                                debug_info.files.push(location.file.clone());
+                                debug_info.files.len() - 1
+                            });
+                        locations.push(DebugLocation {
+                            code_offset: binary.len(),
+                            file_index,
+                            line: location.line,
+                            column: location.column,
+                        });
+                    }
                 }
                 positions.push(binary.len());
                 op.to_binary(&mut binary, &mut jumps_to_fix);
             }
-            debug_functions.push(DebugFunction {
-                name: function.name.clone(),
-                code_offset: function_offset,
-                locations,
-            });
+            if let Some(locations) = locations {
+                debug_info.as_mut().unwrap().functions.push(DebugFunction {
+                    name: function.name.clone(),
+                    code_offset: function_offset,
+                    locations,
+                });
+            }
         }
 
         for (slot, fn_idx) in self.entry_points.iter().enumerate() {
@@ -2562,13 +2615,7 @@ impl Program {
             binary[jump_position] =
                 (target_pos as isize - (jump_position as isize + add_offset)) as u64;
         }
-        (
-            binary,
-            DebugInfo {
-                format_version: 1,
-                functions: debug_functions,
-            },
-        )
+        (binary, debug_info)
     }
 }
 
@@ -2582,7 +2629,6 @@ pub struct ProgramHeader {
     /// ([`ENTRY_WITGEN`], [`ENTRY_AD`], ...). The entry's frame size lives at `offset + 1` and
     /// its first opcode at `offset + 2`.
     pub entry_points: Vec<usize>,
-    pub debug_info: DebugInfo,
     /// Word offset of the first function marker, i.e. where the opcode stream begins.
     pub code_start: usize,
 }
@@ -2599,53 +2645,12 @@ pub fn parse_program_header(program: &[u64]) -> ProgramHeader {
     let entry_points: Vec<usize> = (0..num_entries)
         .map(|i| program[off + 2 + i] as usize)
         .collect();
-    let mut code_start = off + 2 + num_entries;
-    let debug_info = if program.get(code_start) == Some(&DEBUG_INFO_MAGIC) {
-        code_start += 1;
-        let num_files = program[code_start] as usize;
-        code_start += 1;
-        let files: Vec<String> = (0..num_files)
-            .map(|_| decode_string(program, &mut code_start))
-            .collect();
-        let num_functions = program[code_start] as usize;
-        code_start += 1;
-        let mut functions = Vec::with_capacity(num_functions);
-        for _ in 0..num_functions {
-            let name = decode_string(program, &mut code_start);
-            let function_offset = program[code_start] as usize;
-            let num_locations = program[code_start + 1] as usize;
-            code_start += 2;
-            let mut locations = Vec::with_capacity(num_locations);
-            for _ in 0..num_locations {
-                let location_offset = program[code_start] as usize;
-                let file_index = program[code_start + 1] as usize;
-                let line = program[code_start + 2];
-                let column = program[code_start + 3];
-                code_start += 4;
-                locations.push(DebugLocation {
-                    code_offset: location_offset,
-                    location: SourceLocation::new(files[file_index].clone(), line, column),
-                });
-            }
-            functions.push(DebugFunction {
-                name,
-                code_offset: function_offset,
-                locations,
-            });
-        }
-        DebugInfo {
-            format_version: 1,
-            functions,
-        }
-    } else {
-        DebugInfo::default()
-    };
+    let code_start = off + 2 + num_entries;
     ProgramHeader {
         struct_layouts,
         constant_pool,
         global_frame_size,
         entry_points,
-        debug_info,
         code_start,
     }
 }
@@ -2750,14 +2755,13 @@ mod tests {
     }
 
     #[test]
-    fn binaries_without_debug_header_still_parse() {
+    fn compact_binary_header_parses_without_debug_metadata() {
         // Empty header: no struct layouts, constants, globals, or entries, then code starts.
         let binary = [0, 0, 0, 0, u64::MAX, 0];
         let header = parse_program_header(&binary);
 
         assert_eq!(header.code_start, 4);
         assert!(header.constant_pool.is_empty());
-        assert!(header.debug_info.functions.is_empty());
     }
 
     #[test]
@@ -2780,16 +2784,53 @@ mod tests {
 
         assert_eq!(binary, program.to_binary_without_debug_info());
         assert_eq!(binary, program.to_binary());
-        assert!(
-            parse_program_header(&binary)
-                .debug_info
-                .functions
-                .is_empty()
-        );
-        assert_eq!(debug_info.format_version, 1);
+        assert_eq!(debug_info.format_version(), DEBUG_INFO_FORMAT_VERSION);
+        assert_eq!(debug_info.files, vec!["src/main.nr"]);
         assert_eq!(debug_info.functions.len(), 1);
         assert_eq!(debug_info.functions[0].name, "main");
         assert_eq!(debug_info.functions[0].locations.len(), 1);
+        assert_eq!(debug_info.functions[0].locations[0].file_index, 0);
         assert_eq!(parse_program_header(&binary).entry_points.len(), 1);
+    }
+
+    #[test]
+    fn debug_info_serialization_interns_files_and_validates_the_version() {
+        let source_location = location("shared", 10);
+        let program = Program {
+            functions: vec![Function {
+                name: "main".to_string(),
+                frame_size: 3,
+                code: vec![OpCode::Nop {}, OpCode::Ret {}],
+                source_locations: vec![
+                    source_location.clone(),
+                    SourceLocation::new(source_location.file.clone(), 11, 7),
+                ],
+            }],
+            entry_points: vec![0],
+            global_frame_size: 0,
+            struct_layouts: Vec::new(),
+            constant_pool: Vec::new(),
+        };
+
+        let (_, debug_info) = program.to_binary_and_debug_info();
+        assert_eq!(debug_info.files, vec!["src/shared.nr"]);
+        assert!(
+            debug_info.functions[0]
+                .locations
+                .iter()
+                .all(|location| location.file_index == 0)
+        );
+
+        let json = serde_json::to_string(&debug_info).unwrap();
+        assert_eq!(json.matches("src/shared.nr").count(), 1);
+        let unsupported = json.replace(
+            &format!("\"formatVersion\":{DEBUG_INFO_FORMAT_VERSION}"),
+            "\"formatVersion\":2",
+        );
+        assert!(serde_json::from_str::<DebugInfo>(&unsupported).is_err());
+        assert_eq!(
+            DebugInfo::default().format_version(),
+            DEBUG_INFO_FORMAT_VERSION
+        );
     }
 }

--- a/vm/src/interpreter.rs
+++ b/vm/src/interpreter.rs
@@ -309,7 +309,41 @@ pub fn run_phase1(
     constraints_layout: ConstraintsLayout,
     ordered_inputs: &[InputValueOrdered],
 ) -> Result<Phase1Result, TrapError> {
+    run_phase1_impl(
+        program,
+        witness_layout,
+        constraints_layout,
+        ordered_inputs,
+        None,
+    )
+}
+
+/// Run phase 1 with source metadata loaded from a standalone debug sidecar.
+pub fn run_phase1_with_debug_info(
+    program: &[u64],
+    witness_layout: WitnessLayout,
+    constraints_layout: ConstraintsLayout,
+    ordered_inputs: &[InputValueOrdered],
+    debug_info: bytecode::DebugInfo,
+) -> Result<Phase1Result, TrapError> {
+    run_phase1_impl(
+        program,
+        witness_layout,
+        constraints_layout,
+        ordered_inputs,
+        Some(debug_info),
+    )
+}
+
+fn run_phase1_impl(
+    program: &[u64],
+    witness_layout: WitnessLayout,
+    constraints_layout: ConstraintsLayout,
+    ordered_inputs: &[InputValueOrdered],
+    external_debug_info: Option<bytecode::DebugInfo>,
+) -> Result<Phase1Result, TrapError> {
     let header = parse_program_header(program);
+    let debug_info = external_debug_info.unwrap_or_else(|| header.debug_info.clone());
     let entry = *header
         .entry_points
         .get(ENTRY_WITGEN)
@@ -367,7 +401,7 @@ pub fn run_phase1(
 
     let mut program = program.to_vec();
     prepare_dispatch(&mut program, header.code_start);
-    vm.set_debug_context(program.as_ptr(), program.len(), header.debug_info);
+    vm.set_debug_context(program.as_ptr(), program.len(), debug_info);
 
     let pc = unsafe { program.as_mut_ptr().add(entry + 2) };
 
@@ -684,6 +718,29 @@ pub fn run(
     ))
 }
 
+/// Execute witness generation with source metadata loaded from a standalone debug sidecar.
+pub fn run_with_debug_info(
+    program: &[u64],
+    witness_layout: WitnessLayout,
+    constraints_layout: ConstraintsLayout,
+    ordered_inputs: &[InputValueOrdered],
+    debug_info: bytecode::DebugInfo,
+) -> Result<WitgenResult, TrapError> {
+    let phase1 = run_phase1_with_debug_info(
+        program,
+        witness_layout,
+        constraints_layout,
+        ordered_inputs,
+        debug_info,
+    )?;
+
+    Ok(run_phase2_with_fake_challenges(
+        phase1,
+        witness_layout,
+        constraints_layout,
+    ))
+}
+
 #[instrument(skip_all, name = "Interpreter::run_ad")]
 pub fn run_ad(
     program: &[u64],
@@ -691,7 +748,35 @@ pub fn run_ad(
     witness_layout: WitnessLayout,
     constraints_layout: ConstraintsLayout,
 ) -> Result<(Vec<Field>, Vec<Field>, Vec<Field>, AllocationInstrumenter), TrapError> {
+    run_ad_impl(program, coeffs, witness_layout, constraints_layout, None)
+}
+
+/// Execute AD with source metadata loaded from a standalone debug sidecar.
+pub fn run_ad_with_debug_info(
+    program: &[u64],
+    coeffs: &[Field],
+    witness_layout: WitnessLayout,
+    constraints_layout: ConstraintsLayout,
+    debug_info: bytecode::DebugInfo,
+) -> Result<(Vec<Field>, Vec<Field>, Vec<Field>, AllocationInstrumenter), TrapError> {
+    run_ad_impl(
+        program,
+        coeffs,
+        witness_layout,
+        constraints_layout,
+        Some(debug_info),
+    )
+}
+
+fn run_ad_impl(
+    program: &[u64],
+    coeffs: &[Field],
+    witness_layout: WitnessLayout,
+    constraints_layout: ConstraintsLayout,
+    external_debug_info: Option<bytecode::DebugInfo>,
+) -> Result<(Vec<Field>, Vec<Field>, Vec<Field>, AllocationInstrumenter), TrapError> {
     let header = parse_program_header(program);
+    let debug_info = external_debug_info.unwrap_or_else(|| header.debug_info.clone());
     let entry = *header
         .entry_points
         .get(ENTRY_AD)
@@ -723,7 +808,7 @@ pub fn run_ad(
 
     let mut program = program.to_vec();
     prepare_dispatch(&mut program, header.code_start);
-    vm.set_debug_context(program.as_ptr(), program.len(), header.debug_info);
+    vm.set_debug_context(program.as_ptr(), program.len(), debug_info);
 
     let pc = unsafe { program.as_mut_ptr().add(entry + 2) };
 

--- a/vm/src/interpreter.rs
+++ b/vm/src/interpreter.rs
@@ -248,10 +248,7 @@ impl TrapError {
 
     pub fn relativize_source_paths(&mut self, root: &std::path::Path) {
         for frame in &mut self.stack_trace {
-            let path = std::path::Path::new(&frame.location.file);
-            if let Ok(relative) = path.strip_prefix(root) {
-                frame.location.file = relative.to_string_lossy().into_owned();
-            }
+            bytecode::relativize_source_path(&mut frame.location.file, root);
         }
     }
 }
@@ -308,42 +305,10 @@ pub fn run_phase1(
     witness_layout: WitnessLayout,
     constraints_layout: ConstraintsLayout,
     ordered_inputs: &[InputValueOrdered],
-) -> Result<Phase1Result, TrapError> {
-    run_phase1_impl(
-        program,
-        witness_layout,
-        constraints_layout,
-        ordered_inputs,
-        None,
-    )
-}
-
-/// Run phase 1 with source metadata loaded from a standalone debug sidecar.
-pub fn run_phase1_with_debug_info(
-    program: &[u64],
-    witness_layout: WitnessLayout,
-    constraints_layout: ConstraintsLayout,
-    ordered_inputs: &[InputValueOrdered],
-    debug_info: bytecode::DebugInfo,
-) -> Result<Phase1Result, TrapError> {
-    run_phase1_impl(
-        program,
-        witness_layout,
-        constraints_layout,
-        ordered_inputs,
-        Some(debug_info),
-    )
-}
-
-fn run_phase1_impl(
-    program: &[u64],
-    witness_layout: WitnessLayout,
-    constraints_layout: ConstraintsLayout,
-    ordered_inputs: &[InputValueOrdered],
-    external_debug_info: Option<bytecode::DebugInfo>,
+    debug_info: Option<bytecode::DebugInfo>,
 ) -> Result<Phase1Result, TrapError> {
     let header = parse_program_header(program);
-    let debug_info = external_debug_info.unwrap_or_else(|| header.debug_info.clone());
+    let debug_info = debug_info.unwrap_or_default();
     let entry = *header
         .entry_points
         .get(ENTRY_WITGEN)
@@ -708,25 +673,9 @@ pub fn run(
     witness_layout: WitnessLayout,
     constraints_layout: ConstraintsLayout,
     ordered_inputs: &[InputValueOrdered],
+    debug_info: Option<bytecode::DebugInfo>,
 ) -> Result<WitgenResult, TrapError> {
-    let phase1 = run_phase1(program, witness_layout, constraints_layout, ordered_inputs)?;
-
-    Ok(run_phase2_with_fake_challenges(
-        phase1,
-        witness_layout,
-        constraints_layout,
-    ))
-}
-
-/// Execute witness generation with source metadata loaded from a standalone debug sidecar.
-pub fn run_with_debug_info(
-    program: &[u64],
-    witness_layout: WitnessLayout,
-    constraints_layout: ConstraintsLayout,
-    ordered_inputs: &[InputValueOrdered],
-    debug_info: bytecode::DebugInfo,
-) -> Result<WitgenResult, TrapError> {
-    let phase1 = run_phase1_with_debug_info(
+    let phase1 = run_phase1(
         program,
         witness_layout,
         constraints_layout,
@@ -747,36 +696,10 @@ pub fn run_ad(
     coeffs: &[Field],
     witness_layout: WitnessLayout,
     constraints_layout: ConstraintsLayout,
-) -> Result<(Vec<Field>, Vec<Field>, Vec<Field>, AllocationInstrumenter), TrapError> {
-    run_ad_impl(program, coeffs, witness_layout, constraints_layout, None)
-}
-
-/// Execute AD with source metadata loaded from a standalone debug sidecar.
-pub fn run_ad_with_debug_info(
-    program: &[u64],
-    coeffs: &[Field],
-    witness_layout: WitnessLayout,
-    constraints_layout: ConstraintsLayout,
-    debug_info: bytecode::DebugInfo,
-) -> Result<(Vec<Field>, Vec<Field>, Vec<Field>, AllocationInstrumenter), TrapError> {
-    run_ad_impl(
-        program,
-        coeffs,
-        witness_layout,
-        constraints_layout,
-        Some(debug_info),
-    )
-}
-
-fn run_ad_impl(
-    program: &[u64],
-    coeffs: &[Field],
-    witness_layout: WitnessLayout,
-    constraints_layout: ConstraintsLayout,
-    external_debug_info: Option<bytecode::DebugInfo>,
+    debug_info: Option<bytecode::DebugInfo>,
 ) -> Result<(Vec<Field>, Vec<Field>, Vec<Field>, AllocationInstrumenter), TrapError> {
     let header = parse_program_header(program);
-    let debug_info = external_debug_info.unwrap_or_else(|| header.debug_info.clone());
+    let debug_info = debug_info.unwrap_or_default();
     let entry = *header
         .entry_points
         .get(ENTRY_AD)

--- a/wasm-runner/README.md
+++ b/wasm-runner/README.md
@@ -46,6 +46,7 @@ node dist/index.js ./my-noir-project
   mavros_debug/
     program.wasm                    # Generated WASM artifact
     program.wasm.meta.json          # Metadata
+    program.debug.wasm              # Optional external DWARF (--include-debug-info)
 ```
 
 ## Input Format

--- a/wasm-runner/src/index.ts
+++ b/wasm-runner/src/index.ts
@@ -21,6 +21,7 @@ Expected project structure:
     mavros_debug/
       program.wasm                    # Generated WASM artifact
       program.wasm.meta.json          # Metadata
+      program.debug.wasm              # Optional external DWARF (--include-debug-info)
 
 Output is written to: <project-root>/mavros_debug/output.json
 `);


### PR DESCRIPTION
- Emit VM and WASM debug information as optional standalone sidecar files
- Add automatic sidecar loading and report sidecar sizes in STATUS.md