### PR TITLE
Implement the `--logup-soundness` flag

### DIFF
--- a/compiler/src/bin/main.rs
+++ b/compiler/src/bin/main.rs
@@ -11,7 +11,7 @@ use mavros_compiler::compiler::Field;
 use mavros_compiler::compiler::codegen::CodeGenOptions;
 use mavros_compiler::compiler::codegen::hlssa_to_r1cs::R1CS;
 use mavros_compiler::compiler::codegen::llssa_to_llvm::WasmCompileOpts;
-use mavros_compiler::driver::Driver;
+use mavros_compiler::driver::{DEFAULT_LOGUP_SOUNDNESS_BITS, Driver};
 use mavros_compiler::plotting;
 
 type Error = Box<dyn std::error::Error>;
@@ -55,6 +55,12 @@ pub struct ProgramOptions {
     /// Emit standalone debug-information sidecars for VM and WASM artifacts.
     #[arg(long, global = true, action = clap::ArgAction::SetTrue)]
     pub include_debug_info: bool,
+
+    /// Target LogUp lookup-argument soundness, in bits of security. The compiler computes the
+    /// minimum number of challenges needed to reach it and reports the result. On bn254 a
+    /// single challenge suffices for any realistic target.
+    #[arg(long, value_name = "BITS", global = true, default_value_t = DEFAULT_LOGUP_SOUNDNESS_BITS)]
+    pub logup_soundness: u32,
 }
 
 #[derive(Clone, Debug, Subcommand)]
@@ -103,6 +109,7 @@ fn main() -> ExitCode {
             *draw_graphs,
             args.include_debug_info,
             args.absolute_paths,
+            args.logup_soundness,
         ),
         None => run(&args),
     };
@@ -113,9 +120,14 @@ fn main() -> ExitCode {
     })
 }
 
-pub fn compile_to_r1cs(root: PathBuf, draw_graphs: bool) -> Result<(Driver, R1CS), Error> {
+pub fn compile_to_r1cs(
+    root: PathBuf,
+    draw_graphs: bool,
+    logup_soundness: u32,
+) -> Result<(Driver, R1CS), Error> {
     let project = Project::new(root)?;
     let mut driver = Driver::new(project, draw_graphs);
+    driver.set_logup_soundness(logup_soundness);
     driver.run_noir_compiler()?;
     driver.make_struct_access_static()?;
     driver.monomorphize()?;
@@ -142,10 +154,11 @@ pub fn run_compile(
     draw_graphs: bool,
     include_debug_info: bool,
     absolute_paths: bool,
+    logup_soundness: u32,
 ) -> Result<ExitCode, Error> {
     info!(message = %"Compiling Noir project", root = ?path, r1cs_output = ?r1cs_output, binary_output = ?binary_output);
 
-    let (mut driver, r1cs) = compile_to_r1cs(path.clone(), draw_graphs)?;
+    let (mut driver, r1cs) = compile_to_r1cs(path.clone(), draw_graphs, logup_soundness)?;
     let artifact = api::compile_bytecode_artifact(
         &mut driver,
         CodeGenOptions {
@@ -203,7 +216,8 @@ pub fn run_compile(
 /// The main execution of the CLI utility (full pipeline). Should be called directly from the
 /// `main` function of the application.
 pub fn run(args: &ProgramOptions) -> Result<ExitCode, Error> {
-    let (mut driver, r1cs) = compile_to_r1cs(args.root.clone(), args.draw_graphs)?;
+    let (mut driver, r1cs) =
+        compile_to_r1cs(args.root.clone(), args.draw_graphs, args.logup_soundness)?;
     let codegen_options = CodeGenOptions {
         include_debug_info: args.include_debug_info,
         ..CodeGenOptions::default()
@@ -416,5 +430,22 @@ mod tests {
             ProgramOptions::try_parse_from(["mavros", "compile", ".", "--include-debug-info"])
                 .unwrap();
         assert!(compile.include_debug_info);
+    }
+
+    #[test]
+    fn logup_soundness_defaults_to_128_and_is_overridable() {
+        let default = ProgramOptions::try_parse_from(["mavros"]).unwrap();
+        assert_eq!(default.logup_soundness, DEFAULT_LOGUP_SOUNDNESS_BITS);
+        assert_eq!(default.logup_soundness, 128);
+
+        let overridden =
+            ProgramOptions::try_parse_from(["mavros", "--logup-soundness", "96"]).unwrap();
+        assert_eq!(overridden.logup_soundness, 96);
+
+        // `global = true`, so it is also accepted after the `compile` subcommand.
+        let on_subcommand =
+            ProgramOptions::try_parse_from(["mavros", "compile", ".", "--logup-soundness", "80"])
+                .unwrap();
+        assert_eq!(on_subcommand.logup_soundness, 80);
     }
 }

--- a/compiler/src/compiler/codegen/hlssa_to_r1cs.rs
+++ b/compiler/src/compiler/codegen/hlssa_to_r1cs.rs
@@ -943,6 +943,13 @@ impl R1CGen {
         self.next_witness
     }
 
+    /// Number of lookup query sites — one term per site on the lookup side of the LogUp
+    /// identity. Together with the table-entry count this is the argument's soundness degree
+    /// `D`. Must be read before [`R1CGen::seal`] consumes `self`.
+    pub fn num_lookups(&self) -> usize {
+        self.lookups.len()
+    }
+
     fn next_witness(&mut self) -> usize {
         let result = self.next_witness;
         self.next_witness += 1;
@@ -1020,6 +1027,10 @@ impl R1CGen {
         }
 
         // challenges init
+        // FIELD-ASSUMPTION: L4-logup-challenges
+        // One `alpha` (+ an optional column-folding `beta`) gives ~log2(p) bits of LogUp
+        // soundness — sound on bn254, but only ~log2(p)/1 on a small field. A goldilocks
+        // target needs K independent (alpha, beta) pairs here (see docs/field-agnosticism.md).
         let alpha = witness_layout.challenges_end();
         witness_layout.challenges_size += 1;
         let beta = if max_width > 1 {
@@ -1190,5 +1201,235 @@ impl R1CGen {
             constraints_layout,
             constraints: result,
         }
+    }
+}
+
+// LOG-UP SOUNDNESS REPORTING AND ESTIMATION
+// ================================================================================================
+
+/// The outcome of sizing the LogUp lookup argument for a requested bits-of-security
+/// target. See `docs/field-agnosticism.md` (`L4-logup-challenges`) for the model.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SoundnessReport {
+    /// The requested bits of security (from `--logup-soundness`).
+    pub requested_bits: u32,
+
+    /// `floor(log2 p)` for the working field — a lower bound on `log2|F|`.
+    pub field_bits: u32,
+
+    /// `D = table_entries + num_lookups`, the degree of the cleared-denominator polynomial.
+    pub soundness_degree: usize,
+
+    /// Bits of security a single challenge buys: `floor(log2 p) - ceil(log2 D)`.
+    pub per_challenge_bits: u32,
+
+    /// `K = ceil(requested_bits / per_challenge_bits)` — the minimum number of challenges.
+    pub challenges: u32,
+
+    /// `K * per_challenge_bits` — a lower bound on the security actually delivered.
+    pub achieved_bits: u32,
+
+    /// `Some((k, bits))` when the request forces a nearly-empty extra challenge: dropping to
+    /// `k = challenges - 1` challenges would still deliver `bits` bits, because the request sits in
+    /// the lower half of the final challenge's contribution.
+    pub near_optimal_alternative: Option<(u32, u32)>,
+}
+
+impl SoundnessReport {
+    /// Diagnostic emitted when `challenges > 1` but K-challenge replication is not yet
+    /// implemented, so the requested target cannot be honoured on this field.
+    pub fn unsupported_message(&self) -> String {
+        let mut msg = format!(
+            "--logup-soundness={} bits needs {} LogUp challenges on this field \
+             (~{} bits each; argument degree D = {}), but multi-challenge LogUp is not yet \
+             implemented \u{2014} a single challenge provides only ~{} bits",
+            self.requested_bits,
+            self.challenges,
+            self.per_challenge_bits,
+            self.soundness_degree,
+            self.per_challenge_bits,
+        );
+        if let Some((k, bits)) = self.near_optimal_alternative {
+            msg.push_str(&format!(
+                " (note: lowering --logup-soundness to {bits} would need only {k} challenge(s), \
+                 shedding a nearly-empty extra challenge)"
+            ));
+        }
+        msg
+    }
+}
+
+/// `ceil(log2 n)` for `n >= 1`, computed with integer bit-length arithmetic (never `f64`,
+/// so the emitted circuit stays bit-reproducible across platforms). `n <= 1` -> 0.
+fn ceil_log2(n: usize) -> u32 {
+    if n <= 1 {
+        0
+    } else {
+        usize::BITS - (n - 1).leading_zeros()
+    }
+}
+
+/// Compute the LogUp challenge count for the working field's bit size.
+///
+/// FIELD-ASSUMPTION: L4-logup-challenges
+///
+/// Reads `MODULUS_BIT_SIZE` of the concrete field to size per-challenge soundness. In P3 this
+/// should read `FieldConfig::field_bit_size()` rather than the bn254 alias.
+pub fn logup_soundness_report(
+    requested_bits: u32,
+    degree: usize,
+) -> Result<SoundnessReport, String> {
+    // floor(log2 p): p in [2^(MODULUS_BIT_SIZE-1), 2^MODULUS_BIT_SIZE), so floor(log2 p) =
+    // MODULUS_BIT_SIZE - 1. Using the floor (rather than the bit size) keeps `achieved_bits`
+    // a lower bound and never over-claims security.
+    let field_bits = <crate::compiler::Field as PrimeField>::MODULUS_BIT_SIZE - 1;
+    compute_logup_soundness(requested_bits, field_bits, degree)
+}
+
+/// Pure LogUp soundness computation (unit-tested with synthetic `field_bits`).
+///
+/// LogUp proves a log-derivative rational identity at a random challenge; clearing denominators
+/// yields a nonzero polynomial of total degree `<= D = table_entries + num_lookups`, so one
+/// challenge fails with probability `<= D/|F|` (Schwartz-Zippel). K independent challenges give
+/// `(D/|F|)^K`, i.e. `K * (log2|F| - log2 D)` bits. All rounding is toward *under*-estimating
+/// security (floor `log2 p`, ceil `log2 D`), so we never report more bits than are actually
+/// delivered.
+fn compute_logup_soundness(
+    requested_bits: u32,
+    field_bits: u32,
+    degree: usize,
+) -> Result<SoundnessReport, String> {
+    let d_bits = ceil_log2(degree);
+    if field_bits <= d_bits {
+        return Err(format!(
+            "LogUp soundness: field is too small \u{2014} floor(log2 p) = {field_bits} bits is not \
+             larger than ceil(log2 D) = {d_bits} bits for a lookup argument of degree D = {degree}; \
+             a single challenge distinguishes < 1 bit, so no number of challenges recovers soundness"
+        ));
+    }
+    let per_challenge_bits = field_bits - d_bits;
+    let challenges = requested_bits.div_ceil(per_challenge_bits).max(1);
+    let achieved_bits = challenges * per_challenge_bits;
+
+    // Near-optimal: the request lands in the lower half of the final challenge's
+    // contribution, so it buys a whole extra challenge for less than half its worth.
+    let near_optimal_alternative = if challenges >= 2 {
+        let prev = (challenges - 1) * per_challenge_bits;
+        let gap = requested_bits.saturating_sub(prev);
+        if gap > 0 && gap <= per_challenge_bits / 2 {
+            Some((challenges - 1, prev))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    Ok(SoundnessReport {
+        requested_bits,
+        field_bits,
+        soundness_degree: degree,
+        per_challenge_bits,
+        challenges,
+        achieved_bits,
+        near_optimal_alternative,
+    })
+}
+
+#[cfg(test)]
+mod logup_soundness_tests {
+    use super::{compute_logup_soundness, logup_soundness_report};
+
+    #[test]
+    fn bn254_needs_a_single_challenge_for_realistic_targets() {
+        // bn254: floor(log2 p) = 253. A large circuit (D = 2^24 -> ceil(log2 D) = 24)
+        // still buys 229 bits/challenge, so every sane request is a single challenge.
+        let field_bits = 253;
+        let degree = 1 << 24;
+        for requested in [1, 80, 128, 223, 229] {
+            let r = compute_logup_soundness(requested, field_bits, degree).unwrap();
+            assert_eq!(
+                r.challenges, 1,
+                "requested {requested} should need 1 challenge"
+            );
+            assert_eq!(r.per_challenge_bits, 229);
+            assert!(r.near_optimal_alternative.is_none());
+        }
+    }
+
+    #[test]
+    fn live_bn254_alias_yields_a_single_challenge_at_the_default() {
+        // The real field alias (bn254) at the 128-bit default must be a genuine no-op.
+        let r = logup_soundness_report(128, 1 << 20).unwrap();
+        assert_eq!(r.field_bits, 253);
+        assert_eq!(r.challenges, 1);
+    }
+
+    #[test]
+    fn goldilocks_scales_challenges_with_the_target() {
+        // Synthetic goldilocks: floor(log2 p) = 63, D ~= 2^22 -> ceil(log2 D) = 22, so
+        // per-challenge = 41 bits (the sound floor of the informal ~42-bit estimate).
+        let field_bits = 63;
+        let degree = 1 << 22;
+        let pc = 41;
+        assert_eq!(
+            compute_logup_soundness(pc, field_bits, degree)
+                .unwrap()
+                .per_challenge_bits,
+            pc
+        );
+        // K = ceil(requested / 41).
+        assert_eq!(
+            compute_logup_soundness(41, field_bits, degree)
+                .unwrap()
+                .challenges,
+            1
+        );
+        assert_eq!(
+            compute_logup_soundness(42, field_bits, degree)
+                .unwrap()
+                .challenges,
+            2
+        );
+        assert_eq!(
+            compute_logup_soundness(123, field_bits, degree)
+                .unwrap()
+                .challenges,
+            3
+        );
+        assert_eq!(
+            compute_logup_soundness(124, field_bits, degree)
+                .unwrap()
+                .challenges,
+            4
+        );
+        let r128 = compute_logup_soundness(128, field_bits, degree).unwrap();
+        assert_eq!(r128.challenges, 4);
+        assert_eq!(r128.achieved_bits, 164);
+    }
+
+    #[test]
+    fn near_optimal_fires_just_above_a_challenge_boundary() {
+        let field_bits = 63;
+        let degree = 1 << 22; // per-challenge = 41
+        // 128 is 5 above the 3-challenge mark (123); 5 <= 41/2, so warn and suggest 123/K=3.
+        let r = compute_logup_soundness(128, field_bits, degree).unwrap();
+        assert_eq!(r.near_optimal_alternative, Some((3, 123)));
+        // 145 is 22 above the 3-challenge mark; 22 > 41/2 = 20, so no suggestion.
+        let r = compute_logup_soundness(145, field_bits, degree).unwrap();
+        assert_eq!(r.challenges, 4);
+        assert!(r.near_optimal_alternative.is_none());
+        // Exactly on a boundary (123 = 3*41) is a single-challenge overshoot of 0 -> K=3, none.
+        let r = compute_logup_soundness(123, field_bits, degree).unwrap();
+        assert!(r.near_optimal_alternative.is_none());
+    }
+
+    #[test]
+    fn degenerate_when_degree_exceeds_the_field() {
+        // D >= |F|: a single evaluation point can't distinguish the instance; hard error.
+        assert!(compute_logup_soundness(128, 20, 1 << 22).is_err());
+        // Boundary: field_bits == d_bits is still an error (per-challenge would be 0 bits).
+        assert!(compute_logup_soundness(128, 22, 1 << 22).is_err());
+        assert!(compute_logup_soundness(128, 23, 1 << 22).is_ok());
     }
 }

--- a/compiler/src/compiler/passes/instruction_lowering/witness_bitwise.rs
+++ b/compiler/src/compiler/passes/instruction_lowering/witness_bitwise.rs
@@ -219,6 +219,9 @@ impl LowerWitnessBitwiseOps {
         });
     }
 
+    // FIELD-ASSUMPTION: L6-int-op-strategy
+    // `not = (2^bits - 1) - value`. The all-ones mask `2^bits - 1` exceeds p at bits=64 on a
+    // small field, so u64/u128 `not` must be done per-limb.
     fn lower_not(
         &self,
         b: &mut HLBlockEmitter<'_>,
@@ -238,6 +241,9 @@ impl LowerWitnessBitwiseOps {
         });
     }
 
+    // FIELD-ASSUMPTION: L6-int-op-strategy
+    // Sign-extends via `value + sign * (two_pow(to_bits) - two_pow(from_bits))`. The
+    // `two_pow(to_bits)` shift wraps mod p once `to_bits` reaches the field width.
     fn lower_integer_sext(
         &self,
         b: &mut HLBlockEmitter<'_>,
@@ -422,6 +428,10 @@ fn spread_as_field(b: &mut impl HLEmitter, value: ValueId, bits: u8) -> ValueId 
     b.cast_to_field(spread)
 }
 
+// FIELD-ASSUMPTION: L6-int-op-strategy
+// Bitwise via spread-then-add: the spread of a `bits`-wide value occupies ~2*bits bits (cast
+// to `U(bits*2)`), so on a ~64-bit field even a 32-bit spread nearly saturates p. Small fields
+// need narrower spread limbs (why u64/u128 are already split into 32-bit limbs).
 fn lower_word_bitwise(
     b: &mut impl HLEmitter,
     kind: BinaryArithOpKind,
@@ -455,6 +465,10 @@ fn lower_u64_limb_bitwise(
     }
 }
 
+// FIELD-ASSUMPTION: L6-int-representation (combine_u32_limbs + combine_u64_fields)
+// These recombine limbs into a single field cell (`lo + hi * 2^32` / `lo + hi * 2^64`). The
+// 2^64 recombination exceeds p on a ~64-bit field, so wide results cannot live in one cell and
+// must stay multi-cell; the shift width must derive from the field size.
 fn combine_u32_limbs(b: &mut impl HLEmitter, limbs: U64Limbs) -> ValueId {
     let lo = b.cast_to_field(limbs.lo);
     let hi = b.cast_to_field(limbs.hi);

--- a/compiler/src/compiler/passes/instruction_lowering/witness_integer_arith.rs
+++ b/compiler/src/compiler/passes/instruction_lowering/witness_integer_arith.rs
@@ -110,6 +110,9 @@ impl LowerWitnessIntegerArithOps {
             && integer_bits_and_signedness(lhs_ty).is_some()
     }
 
+    // FIELD-ASSUMPTION: L6-int-op-strategy
+    // The sum/difference is computed in one field element. Sound while `2^(bits+1) < p`; a
+    // u64 sum (65 bits) overflows a ~64-bit field and needs a carry-chain lowering.
     fn lower_unsigned_addsub(
         &self,
         b: &mut HLBlockEmitter<'_>,
@@ -145,6 +148,12 @@ impl LowerWitnessIntegerArithOps {
         });
     }
 
+    // FIELD-ASSUMPTION: L6-int-op-strategy
+    // The full product is computed in one field element (guarded by
+    // `range_fits_field_injectively`). The only non-single-field path is the u128 fallback
+    // below, and it still packs `lo + cross*2^64` (~2^193) into one cell — so it assumes ~193
+    // bits of headroom. On a small field u32/u64 mul need a schoolbook multi-limb lowering
+    // with per-limb range checks and carries (see docs/field-agnosticism.md, Layer 6).
     fn lower_unsigned_mul(
         &self,
         b: &mut HLBlockEmitter<'_>,
@@ -209,6 +218,10 @@ impl LowerWitnessIntegerArithOps {
     }
 
     #[allow(clippy::too_many_arguments)]
+    // FIELD-ASSUMPTION: L6-int-op-strategy
+    // Operands are decoded to signed field values and added/subtracted in one field element,
+    // asserting the result range fits injectively. i64 breaks on a ~64-bit field because the
+    // `sign * 2^bits` re-encoding offset alone exceeds p (see `encode_signed_value`).
     fn lower_signed_addsub(
         &self,
         b: &mut HLBlockEmitter<'_>,
@@ -288,6 +301,10 @@ impl LowerWitnessIntegerArithOps {
         });
     }
 
+    // FIELD-ASSUMPTION: L6-int-op-strategy
+    // Single field mul with no multi-limb fallback at all (unlike unsigned u128). Sound only
+    // while the signed product range fits the field; i32/i64 mul need a schoolbook lowering
+    // on a small field.
     fn lower_signed_mul(
         &self,
         b: &mut HLBlockEmitter<'_>,
@@ -652,6 +669,10 @@ fn narrow_rangecheck_width(range: &IntInterval, default_bits: usize) -> usize {
 }
 
 // FIELD-ASSUMPTION: L4-modulus-query
+// This gate already reads the real modulus and flips correctly on a small field (it returns
+// false for u64xu64, and even for the fragile u32xu32 edge). The debt is not the predicate —
+// it is the missing FALSE-case codegen (only unsigned u128 mul has a fallback). See Layer 6
+// (`L6-int-op-strategy`) in docs/field-agnosticism.md.
 fn range_fits_field_injectively(range: &IntInterval) -> bool {
     let Some(lo) = range.lo() else {
         return false;
@@ -667,6 +688,10 @@ fn range_fits_field_injectively(range: &IntInterval) -> bool {
     hi - lo < p
 }
 
+// FIELD-ASSUMPTION: L6-int-op-strategy (signed encode/decode pair)
+// `signed_value_from_encoded`/`encode_signed_value` pack the sign with `two_pow(bits)` /
+// `two_pow(bits-1)` place-value shifts. These packings wrap mod p once the shift reaches the
+// field width, so i64 sign encoding is unsound on a small field.
 fn signed_value_from_encoded(
     b: &mut HLBlockEmitter<'_>,
     encoded_field: ValueId,
@@ -744,6 +769,9 @@ struct U128Limbs {
     hi: ValueId,
 }
 
+// FIELD-ASSUMPTION: L6-int-representation
+// A fixed 2x64-bit split of a u128. On a small field the limb width must derive from the
+// field size (h ~= field_bits/2), and wide integers become multi-cell values end-to-end.
 fn split_u128_value(b: &mut impl HLEmitter, value: ValueId) -> U128Limbs {
     let value = b.cast_to(CastTarget::U(128), value);
     U128Limbs {
@@ -757,6 +785,10 @@ fn split_u128_limb(b: &mut impl HLEmitter, value: ValueId, offset: usize) -> Val
     b.cast_to(CastTarget::U(64), limb)
 }
 
+// FIELD-ASSUMPTION: L6-int-op-strategy
+// Reconstructs `dividend = q * divisor + r` in one field element; the u128 path recurses into
+// the u128 mul fallback. The reconstruction overflows a small field, and even the fragile
+// u32/u64 `+` fused into `q*divisor + r` can tip past p (needs the multi-limb mul engine).
 #[allow(clippy::too_many_arguments)]
 fn lower_unsigned_divmod(
     b: &mut HLBlockEmitter<'_>,

--- a/compiler/src/compiler/ssa/hlssa/type_system.rs
+++ b/compiler/src/compiler/ssa/hlssa/type_system.rs
@@ -2,6 +2,12 @@ use std::fmt::{Debug, Display, Formatter};
 
 use crate::compiler::ssa::SSAType;
 
+// FIELD-ASSUMPTION: L6-int-representation
+//
+// These bound the integer *type system* (the widest int a Noir program may use); they are
+// field-independent and stay fixed regardless of field size. Integers wider than can fit into the
+// field natively must still be supported. A value whose type range is >= p cannot be held
+// natively in one field cell, so must be carried as multi-cell (limb-based) values end-to-end.
 pub const MAX_SUPPORTED_UNSIGNED_BITS: usize = 128;
 pub const MAX_SUPPORTED_SIGNED_BITS: usize = 64;
 

--- a/compiler/src/compiler/ssa/hlssa_to_llssa.rs
+++ b/compiler/src/compiler/ssa/hlssa_to_llssa.rs
@@ -3890,6 +3890,9 @@ fn emit_key_value_ad_lookup_call_body(
     let x_coeff = ad_read_coeff_at_dyn(e, x_cnst_idx);
     let y_coeff = ad_read_coeff_at_dyn(e, y_cnst_idx);
 
+    // FIELD-ASSUMPTION: L4-logup-challenges (4 sites)
+    // The LLSSA AD emitters bind the single challenge at `challenges_start()` (alpha) and
+    // `+1` (beta). K-challenge replication loops these as `challenges_start() + 2k`/`+ 2k + 1`.
     let logup_alpha_i32 = e.emit_int_const(32, witness_layout.challenges_start() as u64);
     let logup_beta_i32 = e.emit_int_const(32, witness_layout.challenges_start() as u64 + 1);
 

--- a/compiler/src/driver.rs
+++ b/compiler/src/driver.rs
@@ -25,7 +25,7 @@ use crate::{
         codegen::{
             CodeGenOptions,
             bytecode::CodeGen,
-            hlssa_to_r1cs::{R1CGen, R1CS},
+            hlssa_to_r1cs::{R1CGen, R1CS, logup_soundness_report},
             llssa_to_llvm::WasmCompileOpts,
         },
         pass_manager::PassManager,
@@ -75,6 +75,11 @@ pub struct BytecodeArtifact {
     pub debug_info: Option<DebugInfo>,
 }
 
+/// Default LogUp bits-of-security target when `--logup-soundness` is not given. On bn254 a
+/// single challenge already exceeds this, so the default is a byte-identical no-op; it becomes
+/// the forward tripwire once a small field (goldilocks) needs more than one challenge.
+pub const DEFAULT_LOGUP_SOUNDNESS_BITS: u32 = 128;
+
 pub struct Driver {
     project: Project,
     initial_ssa: Option<HLSSA>,
@@ -89,6 +94,8 @@ pub struct Driver {
     abi: Option<noirc_abi::Abi>,
     draw_cfg: bool,
     main_is_unconstrained: bool,
+    /// Requested LogUp bits-of-security (from `--logup-soundness`); sizes the challenge count.
+    logup_soundness: u32,
 }
 
 #[derive(Debug)]
@@ -98,6 +105,10 @@ pub enum Error {
     /// satisfied, discovered while symbolically executing the program to generate R1CS. Such a
     /// program will never execute, so it is rejected rather than compiled into constraints.
     UnsatisfiableProgram(String),
+    /// The requested `--logup-soundness` target needs more than one LogUp challenge on this
+    /// field, but multi-challenge LogUp is not yet implemented (see `docs/field-agnosticism.md`,
+    /// `L4-logup-challenges`). Rejected rather than silently emitting an under-provisioned circuit.
+    LogupSoundnessUnsupported(String),
 }
 
 impl std::fmt::Display for Error {
@@ -109,6 +120,7 @@ impl std::fmt::Display for Error {
             Error::UnsatisfiableProgram(message) => {
                 write!(f, "program will never execute: {message}")
             }
+            Error::LogupSoundnessUnsupported(message) => write!(f, "{message}"),
         }
     }
 }
@@ -133,7 +145,15 @@ impl Driver {
             abi: None,
             draw_cfg,
             main_is_unconstrained: false,
+            logup_soundness: DEFAULT_LOGUP_SOUNDNESS_BITS,
         }
+    }
+
+    /// Override the LogUp bits-of-security target (defaults to
+    /// [`DEFAULT_LOGUP_SOUNDNESS_BITS`]). Only the CLI sets this; library/test callers keep
+    /// the default, which is a no-op on bn254.
+    pub fn set_logup_soundness(&mut self, bits: u32) {
+        self.logup_soundness = bits;
     }
 
     pub fn get_debug_output_dir(&self) -> PathBuf {
@@ -452,6 +472,8 @@ impl Driver {
         r1cs_gen
             .run(&r1cs_ssa, &type_info)
             .map_err(|e| Error::UnsatisfiableProgram(e.message))?;
+        // Captured before `seal` consumes `r1cs_gen`; feeds the LogUp soundness degree D.
+        let num_lookups = r1cs_gen.num_lookups();
         let r1cs = r1cs_gen.seal();
         let mut num_non_zero_terms = 0;
         for r1c in r1cs.constraints.iter() {
@@ -482,6 +504,33 @@ impl Driver {
             total_witness = r1cs.witness_layout.size()
 
         );
+
+        // Report the LogUp challenge count for the requested bits-of-security, and reject targets
+        // that would need more than one challenge (K-challenge replication is not yet implemented).
+        // Only relevant when the program actually has a lookup argument, i.e. at least one
+        // challenge was allocated. On bn254 a single challenge exceeds any sane target, so K is
+        // always 1 here and the emitted circuit is unchanged.
+        if r1cs.witness_layout.challenges_size > 0 {
+            let degree = r1cs.witness_layout.multiplicities_size + num_lookups;
+            let report = logup_soundness_report(self.logup_soundness, degree)
+                .map_err(Error::LogupSoundnessUnsupported)?;
+            info!(
+                message = %"LogUp soundness",
+                requested_bits = report.requested_bits,
+                field_bits = report.field_bits,
+                table_entries = r1cs.witness_layout.multiplicities_size,
+                lookups = num_lookups,
+                soundness_degree_d = report.soundness_degree,
+                per_challenge_bits = report.per_challenge_bits,
+                challenges = report.challenges,
+                achieved_bits = report.achieved_bits,
+            );
+            if report.challenges > 1 {
+                return Err(Error::LogupSoundnessUnsupported(
+                    report.unsupported_message(),
+                ));
+            }
+        }
 
         Ok(r1cs)
     }

--- a/docs/field-agnosticism.md
+++ b/docs/field-agnosticism.md
@@ -15,7 +15,13 @@ field it is operating over (see #120). This is a multi-stage process that will o
 - [ ] **Phase 5:** Add support for goldilocks through the SSA and the VM using the field
       abstraction. This will need to use `crypto-primitives` as the runtime-switchable backing for
       the field elements. This must support true field width, and not rely on stuffing goldilocks
-      into larger limb counts.
+      into larger limb counts. Two small-field-specific workstreams surface here: multi-limb
+      **integer-arithmetic lowering** (Layer 6 — `u32×u32` barely fits, but `u64`/`u128` overflow
+      the field and need schoolbook limbs + a multi-cell representation) and **LogUp K-challenge
+      replication** (`L4-logup-challenges` — one challenge is unsound on a small field). The
+      user-facing `--logup-soundness=<bits>` flag (default 128) that computes and reports the
+      required challenge count is **already implemented** (byte-identical no-op on bn254); it
+      hard-errors until K-challenge replication lands.
 
 The current state has each site of a field assumption tagged with `// FIELD-ASSUMPTION: <tag>`
 directly in code. The `<tag>` values match the section headings below.
@@ -27,10 +33,13 @@ Repetitive clusters of the same operation get one marker per file with a count.
 
 - **`[ ]` / `[x]`** — migration status.
 - **Phase** — which roadmap phase touches it (P2 = façade/direct-refs, P3 = `FieldConfig` on SSA, P4
-  = monomorphize VM/backend, P5 = goldilocks + per-field width).
+  = monomorphize VM/backend, P5 = goldilocks + per-field width; P5-logup = the LogUp K-challenge
+  replication sub-phase).
 - **Kind** — `type-parametric` (already abstracts over the field via `Field`/`PrimeField`; follows
   the alias automatically once it's generic) vs `hardcoded` (names bn254 / a literal / a fixed width
-  and must be rewritten) vs `representation` (assumes the 4-limb/32-byte physical layout).
+  and must be rewritten) vs `representation` (assumes the 4-limb/32-byte physical layout) vs
+  `algorithmic` (the _lowering strategy_ itself only works with the field's headroom and needs a
+  different algorithm on a small field — Layer 6).
 
 Completion gate (Phase 5): `rg 'ark_bn254|into_bigint\(|\.0\.0|FELT_LIMBS|FIELD_SIZE|\b254\b'` over
 `compiler/ vm/ mavros-artifacts/ opcode-gen/ wasm-runtime/` returns only façade-internal hits.
@@ -287,6 +296,48 @@ Collapse onto one `FieldConfig::two_pow(exp)`:
 - [ ] `compiler/src/compiler/passes/lookup_spilling.rs:690` (returns `Field`; also `two_pow_u128` at
       `:694`).
 
+### `L4-logup-challenges` — Single LogUp Challenge Assumes a Large Field (Hardcoded count, P5-logup)
+
+The LogUp lookup argument proves the log-derivative identity `Σᵢ mᵢ/(α − tᵢ) = Σⱼ flagⱼ/(α − keyⱼ)`
+(width-2 tables fold `(key, value)` into `key + β·value`). It draws **exactly one** challenge
+`alpha` plus an optional column-folding `beta` — sound at `~2⁻²⁵³` on bn254, but only `~log₂ p` bits
+per challenge, which is inadequate on a small field (`~2⁻⁴²` per challenge on goldilocks). Reaching
+a target bits-of-security needs **K independent challenges**.
+
+**Model (see `hlssa_to_r1cs.rs::compute_logup_soundness`).** Clearing denominators gives a nonzero
+polynomial of total degree `≤ D = table_entries + num_lookups` in the challenges, so one challenge
+fails with probability `≤ D/|F|` (Schwartz–Zippel) and K independent challenges give `(D/|F|)^K`:
+
+```
+per_challenge_bits = floor(log2 p) − ceil(log2 D)      (MODULUS_BIT_SIZE − 1 today)
+K                  = ceil(requested_bits / per_challenge_bits)
+```
+
+Computed with integer bit-length arithmetic (never `f64`) and rounded so `achieved_bits` is a
+_lower_ bound. On bn254 `per_challenge ≈ 223`, so `K = 1` for any sane request and the emitted
+circuit is unchanged (byte-identical). **`beta` must be replicated per repetition** (K independent
+`(αₖ, βₖ)` pairs): a shared `beta` leaves the folding-collision term un-amplified and caps security
+regardless of K.
+
+**Status — the `--logup-soundness=<bits>` flag is implemented** (default 128). It computes and
+reports K, and **hard-errors when `K > 1`** because K-challenge replication is not yet built — never
+silently emitting an under-provisioned circuit. K-challenge replication itself is future
+**P5-logup** work; the external Fiat-Shamir prover must be updated in lockstep to squeeze K
+_independent_ challenges (not powers `α, α², …`, which are invalid for this identity) by reading
+`challenges_size` from the serialized `WitnessLayout` (gate behind the P4 header version bump).
+
+- [x] `compiler/src/compiler/codegen/hlssa_to_r1cs.rs` —
+      `compute_logup_soundness`/`logup_soundness_report` + `SoundnessReport` (the formula,
+      unit-tested); `driver.rs::generate_r1cs` reports + guards.
+- [ ] `hlssa_to_r1cs.rs` challenge allocation (`// challenges init`) — allocate K `(αₖ, βₖ)`
+      (`WitnessLayout::next_challenge` is already K-ready); replicate table inverse columns + sum
+      constraints and lookup inverse witnesses ×K.
+- [ ] `vm/src/interpreter.rs:~416` (5 sites) — phase-2 reads `alpha`/`beta` at hardcoded
+      post-commitment indices `[0]`/`[1]`; loop the batch inversion + fills over K
+      (`[2k]`/`[2k+1]`).
+- [ ] `vm/src/bytecode.rs:~694` (~9 sites) and `hlssa_to_llssa.rs:~3893` (4 sites) — AD emitters
+      bind `logup_wit_challenge_off` `{+0,+1}`; loop as `+2k`/`+2k+1`.
+
 ---
 
 ## Layer 5 — Dependency, Header & Field Selection
@@ -305,6 +356,81 @@ Collapse onto one `FieldConfig::two_pow(exp)`:
       `__field_*` symbol names, linker-bound). `wasm-runtime/src/lib.rs` gains a second field impl.
 - [ ] **JS host** — `wasm-runner/src/field.ts` hardcodes bn254 modulus/R/R_INV; needs a goldilocks
       path (Phase 5; out of scope for Rust corpus validation).
+
+---
+
+## Layer 6 — Integer-Arithmetic Lowering Strategy (Algorithmic, P5)
+
+Integer ops currently **spill into the field**: an n-bit integer (and usually the full product/sum
+of two) is computed in **one** `Field` element and range-checked back to width, with place-value
+packing via `two_pow(k)`. This holds only because bn254 (~254 bits) has headroom for every supported
+integer and product. On a small field it breaks at **two** levels, which the constant-swap tags
+(`L4-two-pow`, `L4-modulus-query`, `L3-width254`) understate — these need a genuinely different
+lowering _strategy_, not a different constant.
+
+Let `B = floor(log2 p)` (bn254: 253; goldilocks: 63). For standard widths on goldilocks the break is
+**mostly representational**:
+
+- `u8/u16` and their products (≤ 32 bits): fit — single cell, any field.
+- `u32`: operands fit; `u32 × u32` (max `= p − 2³²`) _fits_ with zero headroom (matches "u32 can
+  technically be made to fit"); bitwise natural-spread (≤ 32 bits) and shl fit. All **fragile** —
+  correct standalone, but a fused `q·divisor + r` reconstruction can tip over.
+- `u64 / u128 / i64`: a bare value's range `≥ p` (`2⁶⁴ − 1 > p`) ⇒ it **cannot be held injectively
+  in one cell**; every recombination into one cell (`combine_u64_fields`, `lower_not`'s `2⁶⁴ − 1`,
+  signed `sign·2⁶⁴` packing) wraps.
+
+So on goldilocks standard widths collapse to **{single-field for n ≤ 32, multi-cell for n ≥ 64}**;
+the "operation-strategy-only" band is empty for standard widths. `range_fits_field_injectively`
+(`witness_integer_arith.rs`) already flips correctly on a small field — **the debt is the missing
+FALSE-case codegen**, not the predicate. Today the only FALSE-case path is unsigned u128 mul, and it
+still packs `lo + cross·2⁶⁴ ≈ 2¹⁹³` into one cell (assumes ~193-bit headroom); everything else
+`assert!`/`panic!`s.
+
+**P5 target — integers wider than the field must be _supported_, not rejected.** The end state is a
+**multi-cell representation** (Option A): an integer whose type range is `≥ p` (`n > B`) is carried
+as `⌈n/h⌉` field cells end-to-end (witness layout, `Cast`, VM frame, opcode stride, serde). The
+integer type-system caps (`MAX_SUPPORTED_*_BITS` = 128/64) stay **field-independent** — a goldilocks
+`u128` is just a wider cell vector, exactly as bn254 already carries a u128 value in one cell but
+its 256-bit _product_ across two. Paired with a **schoolbook engine** for the FALSE branch (split
+operands into `h`-bit limbs with `h ≈ (field_bits − guard)/2`, byte-aligned — bn254 `h = 64` keeps
+today byte-identical, goldilocks `h = 16`; in-field partial products `< 2^{2h} < p`;
+column-accumulate with a witnessed, range-checked carry chain; keep the low result limbs). Sequence
+within P5: multi-cell representation → mul engine → add/sub-carry → divmod → bitwise → signed.
+**Near-term (P3), transitional only:** converge the scattered FALSE-case `assert!`/`panic!`s onto
+one `unimplemented!("multi-limb — P5")` funnel (byte-identical on bn254; on a small field it fails
+loudly until the multi-cell path lands, rather than silently miscompiling). This is a scaffold,
+**not** a width cap — we are not restricting the supported integer widths on any field. **Dominant
+risk:** every witnessed limb/carry must be range-checked or a malicious prover forges the result.
+
+Two tags, distinct from the constant-swap tags:
+
+### `L6-int-op-strategy` — Single-Field Op Assumes the Result Span `< p` (Algorithmic, P5)
+
+A single-field arithmetic op assumes its exact result span fits one cell (one `b.mul`/`b.add`, or a
+`two_pow`-based packing). Fix = multi-limb schoolbook / carry-chain lowering in the FALSE branch.
+
+- [ ] `witness_integer_arith.rs` — `lower_unsigned_mul` (single-field product + the ~193-bit u128
+      fallback), `lower_signed_mul` (no fallback), `lower_unsigned_addsub`, `lower_signed_addsub`,
+      `signed_value_from_encoded`/`encode_signed_value` (sign packing), `lower_unsigned_divmod`.
+- [ ] `witness_bitwise.rs` — `lower_not`, `lower_integer_sext`, `lower_word_bitwise` (spread width).
+
+### `L6-int-representation` — Value Range `≥ p` Assumed to Fit One Cell (Representation, P5 multi-cell)
+
+A value whose type range is `≥ p` (`n > B`), or a fixed limb layout, assumed to fit / recombine into
+one cell. Fix = a **multi-cell (per-limb) representation** carrying the integer across `⌈n/h⌉` field
+cells (the largest P5 sub-piece; touches witness layout, `Cast`, the VM frame, opcode stride,
+serde). Wide integers are supported, not capped away.
+
+- [ ] `compiler/src/compiler/ssa/hlssa/type_system.rs:5-6` — `MAX_SUPPORTED_UNSIGNED_BITS` /
+      `MAX_SUPPORTED_SIGNED_BITS` stay field-independent (the int-type caps); the multi-cell
+      representation carries any width `> B` on a small field.
+- [ ] `witness_integer_arith.rs` — `split_u128_value` (fixed 2×64 layout; limb width becomes `h`).
+- [ ] `witness_bitwise.rs` — `combine_u32_limbs` / `combine_u64_fields` (recombine into one cell;
+      `extract_u128_limbs`/`decompose_u64_input` limb widths must derive from the field size).
+
+The `value_range_analysis.rs` interval domain is over `BigInt` and stays correct on any field — it
+already produces the exact spans the FALSE-case codegen consumes (no new marker; only `field_top` /
+`bn254_modulus` remain `L4-modulus-query`).
 
 ---
 

--- a/vm/src/bytecode.rs
+++ b/vm/src/bytecode.rs
@@ -691,6 +691,10 @@ impl VM {
                     out_dc,
                     ad_coeffs,
                     current_wit_off: 0,
+                    // FIELD-ASSUMPTION: L4-logup-challenges (~9 sites)
+                    // The AD pass reads the single challenge at `logup_wit_challenge_off`
+                    // (alpha) and `+1` (beta). For K challenges these become
+                    // `off + 2k`/`off + 2k + 1`, looped over the K inverse-witness copies.
                     logup_wit_challenge_off: witness_layout.challenges_start(),
                     current_wit_multiplicities_off: witness_layout.multiplicities_start(),
                     current_wit_tables_off: witness_layout.tables_data_start(),

--- a/vm/src/interpreter.rs
+++ b/vm/src/interpreter.rs
@@ -411,6 +411,10 @@ pub fn run_phase2(
         phase1.out_wit_post_comm[i] = *challenge;
     }
 
+    // FIELD-ASSUMPTION: L4-logup-challenges (5 sites)
+    // Phase 2 reads the single LogUp challenge at the hardcoded post-commitment indices
+    // [0] (alpha) and [1] (beta) throughout this function. A small field needs K challenges;
+    // these reads become [2k]/[2k+1] inside a `for k in 0..K` loop (see docs/field-agnosticism.md).
     let mut running_prod = Field::from(1);
     for tbl in phase1.tables.iter() {
         let alpha = phase1.out_wit_post_comm[0];


### PR DESCRIPTION
This is in preparation for a world where the number of LogUp challenges performed depends on the desired level of security/soundness error of the protocol. Defaulting to 128 bits, this new parameter sets `b` such that the LogUp portion of the protocol exhibits `1/2^b` soundness error.

It also documents some additional spots where the integer operations were not yet accounted, for, and enhances the plan in this regard.