### PR TITLE
Bump Noir to beta 21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,8 @@ version = 4
 
 [[package]]
 name = "acir"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acir_field",
  "base64 0.22.1",
@@ -25,8 +25,8 @@ dependencies = [
 
 [[package]]
 name = "acir_field"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -38,8 +38,8 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -54,8 +54,8 @@ dependencies = [
 
 [[package]]
 name = "acvm_blackbox_solver"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acir",
  "aes",
@@ -87,13 +87,13 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -205,9 +205,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "ark-bn254"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "ark-ec"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
 dependencies = [
  "ahash",
  "ark-ff",
@@ -227,8 +227,8 @@ dependencies = [
  "ark-std",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
- "itertools 0.13.0",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -237,29 +237,26 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
  "ark-std",
- "arrayvec",
  "digest 0.10.7",
  "educe",
- "itertools 0.13.0",
  "num-bigint",
  "num-traits",
- "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -267,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-macros"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -280,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "ark-grumpkin"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef677b59f5aff4123207c4dceb1c0ec8fdde2d4af7886f48be42ad864bfa0352"
+checksum = "c2c969a12ceed8881e5c66277dabd3e7a5aa2c72c9370f3f42eca3f2dd33a21a"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -292,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "ark-poly"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
 dependencies = [
  "ahash",
  "ark-ff",
@@ -302,27 +299,26 @@ dependencies = [
  "ark-std",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
 name = "ark-serialize"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "arrayvec",
  "digest 0.10.7",
  "num-bigint",
 ]
 
 [[package]]
 name = "ark-serialize-derive"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -331,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "ark-std"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -413,7 +409,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -421,6 +417,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -486,17 +491,17 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "bn254_blackbox_solver"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -520,8 +525,8 @@ dependencies = [
 
 [[package]]
 name = "brillig"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acir_field",
  "itertools 0.14.0",
@@ -530,8 +535,8 @@ dependencies = [
 
 [[package]]
 name = "brillig_vm"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -598,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.3.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
 dependencies = [
  "serde",
  "serde_core",
@@ -622,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
 dependencies = [
  "cipher",
 ]
@@ -680,11 +685,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common 0.2.1",
  "inout",
 ]
 
@@ -749,18 +754,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583f52b0658b321b25fd6b209b6c76cf058f433071297de64e5980c3d9aad937"
 dependencies = [
- "codespan-reporting 0.13.1",
+ "codespan-reporting",
  "serde",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -771,7 +766,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1425,10 +1420,10 @@ checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "fm"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
- "codespan-reporting 0.11.1",
+ "codespan-reporting",
  "iter-extended",
  "itertools 0.14.0",
  "serde",
@@ -1661,7 +1656,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
  "foldhash",
  "serde",
 ]
@@ -1671,6 +1665,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1931,12 +1928,12 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "block-padding",
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1947,23 +1944,14 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "iter-extended"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 
 [[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2308,8 +2296,8 @@ dependencies = [
 
 [[package]]
 name = "nargo"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acvm",
  "brillig",
@@ -2329,13 +2317,14 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
+ "url",
  "walkdir",
 ]
 
 [[package]]
 name = "nargo_toml"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "dirs",
  "fm",
@@ -2353,8 +2342,8 @@ dependencies = [
 
 [[package]]
 name = "noir_greybox_fuzzer"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acvm",
  "build-data",
@@ -2374,8 +2363,8 @@ dependencies = [
 
 [[package]]
 name = "noirc_abi"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acvm",
  "iter-extended",
@@ -2391,18 +2380,18 @@ dependencies = [
 
 [[package]]
 name = "noirc_arena"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 
 [[package]]
 name = "noirc_artifacts"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acir",
  "acvm",
  "base64 0.22.1",
- "codespan-reporting 0.11.1",
+ "codespan-reporting",
  "flate2",
  "fm",
  "noirc_abi",
@@ -2416,8 +2405,8 @@ dependencies = [
 
 [[package]]
 name = "noirc_driver"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acvm",
  "build-data",
@@ -2436,10 +2425,10 @@ dependencies = [
 
 [[package]]
 name = "noirc_errors"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
- "codespan-reporting 0.11.1",
+ "codespan-reporting",
  "fm",
  "noirc_span",
  "rangemap",
@@ -2449,10 +2438,11 @@ dependencies = [
 
 [[package]]
 name = "noirc_evaluator"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acvm",
+ "bit-vec 0.9.1",
  "bn254_blackbox_solver",
  "cfg-if",
  "chrono",
@@ -2482,8 +2472,8 @@ dependencies = [
 
 [[package]]
 name = "noirc_frontend"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acvm",
  "bn254_blackbox_solver",
@@ -2513,8 +2503,8 @@ dependencies = [
 
 [[package]]
 name = "noirc_printable_type"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "acvm",
  "iter-extended",
@@ -2525,8 +2515,8 @@ dependencies = [
 
 [[package]]
 name = "noirc_span"
-version = "1.0.0-beta.20"
-source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.20#b4236c1957d0c26cb65d82adc9e5447b6ff1d629"
+version = "1.0.0-beta.21"
+source = "git+https://github.com/noir-lang/noir.git?tag=v1.0.0-beta.21#89a0f0faf3a5f1273c8ac4843b7877882437e277"
 dependencies = [
  "codespan",
  "serde",
@@ -2906,7 +2896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags 2.11.1",
  "num-traits",
  "rand 0.9.4",
@@ -3651,9 +3641,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"
@@ -4048,12 +4038,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -4545,7 +4529,7 @@ dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
- "unicode-width 0.2.2",
+ "unicode-width",
  "wasm-encoder 0.248.0",
 ]
 
@@ -4989,20 +4973,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
  "serde_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ mavros-wasm-runtime = { path = "./wasm-runtime/" }
 
 # The rest of the shared dependencies (or ones that are fussy about versions)
 anyhow = { version = "1.0.87" }
-ark-bn254 = { version = "0.5.0" }
-ark-ff = { version = "0.5.0" }
-ark-std = { version = "0.5.0" }
+ark-bn254 = { version = "0.6.0" }
+ark-ff = { version = "0.6.0" }
+ark-std = { version = "0.6.0" }
 num-traits = { version = "0.2.19" }
 serde = { version = "1.0.204", features = ["derive"] }
 tempfile = { version = "3.19.1" }

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -10,14 +10,14 @@ mavros-vm.workspace = true
 mavros-wasm-layout.workspace = true
 
 # The Noir crates that the compiler depends on
-acvm = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.20", package = "acvm" }
-fm = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.20", package = "fm" }
-nargo = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.20", package = "nargo" }
-nargo_toml = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.20", package = "nargo_toml" }
-noirc_abi = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.20", package = "noirc_abi" }
-noirc_driver = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.20", package = "noirc_driver" }
-noirc_errors = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.20", package = "noirc_errors" }
-noirc_frontend = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.20", package = "noirc_frontend" }
+acvm = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.21", package = "acvm" }
+fm = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.21", package = "fm" }
+nargo = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.21", package = "nargo" }
+nargo_toml = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.21", package = "nargo_toml" }
+noirc_abi = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.21", package = "noirc_abi" }
+noirc_driver = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.21", package = "noirc_driver" }
+noirc_errors = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.21", package = "noirc_errors" }
+noirc_frontend = { git = "https://github.com/noir-lang/noir.git", tag = "v1.0.0-beta.21", package = "noirc_frontend" }
 
 # The rest of the dependencies
 ark-bn254.workspace = true

--- a/compiler/src/compiler/lowering/expression_converter.rs
+++ b/compiler/src/compiler/lowering/expression_converter.rs
@@ -1196,7 +1196,7 @@ impl<'a> ExpressionConverter<'a> {
             Literal::Str(s) => {
                 // str<N>: array of u8 (UTF-8 bytes)
                 let elem_type = Type::u(8);
-                let elems = s.bytes().map(|byte| Constant::U(8, byte as u128)).collect();
+                let elems = s.iter().map(|byte| Constant::U(8, *byte as u128)).collect();
                 let blob = b.emit_const(Constant::Blob(Blob::new(elem_type.clone(), elems)));
                 let location = self.current_source_location.clone();
                 let arr = self


### PR DESCRIPTION
- Bump Noir deps to v1.0.0-beta.21
- arkworks 0.5 → 0.6 to match upstream
- String literals now byte slices; adapted lowering